### PR TITLE
chore(deps): update deadline-cloud and openjd-adaptor-runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ requires-python = ">=3.9"
 # 2024 - 3.9: https://help.autodesk.com/view/MAXDEV/2024/ENU/?guid=MAXDEV_Python_about_the_3ds_max_python_api_html
 
 dependencies = [
-    "deadline == 0.38.*", 
-    "openjd-adaptor-runtime == 0.5.*",
+    "deadline == 0.45.*", 
+    "openjd-adaptor-runtime == 0.6.*",
 ]
 
 [project.scripts]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
update deadline-cloud and openjd-adaptor-runtime deps

### What was the solution? (How)
update deadline-cloud to 0.45.* and openjd-adaptor-runtime to 0.6.*
### What is the impact of this change?

### How was this change tested?
`hatch run test`

### Was this change documented?
no

### Is this a breaking change?
no