### PR TITLE
feat!: public release

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -41,11 +41,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    env:
-      CODEARTIFACT_REGION: "us-west-2"
-      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -88,17 +83,9 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
           pip install --upgrade hatch
           hatch -v build
 
@@ -187,9 +174,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
           pip install --upgrade hatch
           pip install --upgrade twine
 
@@ -210,7 +194,6 @@ jobs:
           export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CUSTOMER_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
           twine upload dist/*
 
-      # TODO: Uncomment this block to publish to PyPI once this package is public
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -19,10 +19,6 @@ jobs:
         os: [windows-latest]
     env:
       PYTHON: ${{ matrix.python-version }}
-      CODEARTIFACT_REGION: "us-west-2"
-      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v4
       if: ${{ !inputs.branch }}
@@ -38,19 +34,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-        aws-region: us-west-2
-        mask-aws-account-id: true
-
     - name: Install Hatch
       shell: bash
       run: |
-        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
         pip install --upgrade hatch
 
     - name: Run Linting

--- a/hatch.toml
+++ b/hatch.toml
@@ -24,14 +24,12 @@ lint = [
 python = ["3.9", "3.10", "3.11", "3.12"]
 
 [envs.default.env-vars]
-PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 
 [envs.codebuild.scripts]
 build = "hatch build"
 
 [envs.codebuild.env-vars]
-PIP_INDEX_URL=""
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 
 [envs.release]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 # 2024 - 3.9: https://help.autodesk.com/view/MAXDEV/2024/ENU/?guid=MAXDEV_Python_about_the_3ds_max_python_api_html
 
 dependencies = [
-    "deadline == 0.45.*", 
-    "openjd-adaptor-runtime == 0.6.*",
+    "deadline == 0.47.*", 
+    "openjd-adaptor-runtime == 0.7.*",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We're about to publicly release this library. We need to prep the build process for that.

### What was the solution? (How)

- Bump deadline-cloud to `0.47.0` and openjd-adaptor-runtime to `0.7.0`

- Update the build script to no longer define a PIP_INDEX_URL -- the environment variable
  that we used to interface with our internal repository during private development.

- Update the code quality check to pull deps from the public PyPI, so
  that we're testing as customers would use it.

- Use the public PyPI in the release flows since all deps are now
  available publicly. This ensures that the artifact we release can be
  built & used by anyone using PyPI.

### What is the impact of this change?

Release readiness

### How was this change tested?

Tests will not pass until dependencies are released


### Was this change documented?

No

### Is this a breaking change?

No, but it is being marked as one to force a minor version bump when we release.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*