### PR TITLE
docs: update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## v0.0.1 (2024-03-26)
 
 ### BREAKING CHANGES
-* initial integeration commit (#2) ([`873d2de`](https://github.com/casillas2/deadline-cloud-for-3ds-max/commit/873d2ded6d1dfe1f590e9e3460bd76266954efc0))
+* initial integeration commit (#2) ([`873d2de`](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/commit/873d2ded6d1dfe1f590e9e3460bd76266954efc0))
 
 
 ### Bug Fixes
-* added some missing install files, updated development readme, added job bundle test scaffolding (#5) ([`48a0170`](https://github.com/casillas2/deadline-cloud-for-3ds-max/commit/48a0170de5b738c3abe3d8d416c23c10fa4aa618))
+* added some missing install files, updated development readme, added job bundle test scaffolding (#5) ([`48a0170`](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/commit/48a0170de5b738c3abe3d8d416c23c10fa4aa618))
 
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,54 @@
-## 3ds Max Submitter
+# Development documentation
+This package has two active branches:
+
+- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
+- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
+
+## Build / Test / Release
+
+### Build the package
+
+```bash
+hatch build
+```
+
+### Run tests
+
+```bash
+hatch run test
+```
+
+### Run linting
+
+```bash
+hatch run lint
+```
+
+### Run formatting
+
+```bash
+hatch run fmt
+```
+
+### Run tests for all supported Python versions
+
+```bash
+hatch run all:test
+```
+
+## Use development Submitter in 3ds Max
+
+```bash
+hatch run install
+hatch shell
+```
+Then launch 3ds Max from that terminal.
+
+A development version of deadline-cloud-for-3ds-max is then available to be loaded.
+
+## Submitter Development Workflow
+
+WARNING: This workflow installs additional Python packages into your 3ds Max's python distribution.
 
 #### Manual installation
 
@@ -22,3 +72,30 @@
 ### Usage
 
 After installation a "Deadline Cloud" menu is available the menu bar. Run "Submit to Deadline Cloud" to open the submitter.
+
+### Application Interface Adaptor Development Workflow
+
+You can work on the adaptor alongside your submitter development workflow using a Deadline Cloud
+farm that uses a service-managed fleet. You'll need to perform the following steps to substitute
+your build of the adaptor for the one in the service.
+
+1. Use the development location from the Submitter Development Workflow. Make sure you're running 3ds Max with `set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` enabled.
+2. Build wheels for `openjd_adaptor_runtime`, `deadline` and `deadline_cloud_for_3ds_max`, place them in a "wheels" folder in `deadline-cloud-for-3ds-max`. A script is provided to do this, just execute from `deadline-cloud-for-3ds-max`:
+
+   ```bash
+   # If you don't have the build package installed already
+   $ pip install build
+   ...
+   $ ./scripts/build_wheels.sh
+   ```
+
+   Wheels should have been generated in the "wheels" folder:
+
+   ```bash
+   $ ls ./wheels
+   deadline_cloud_for_3ds_max-<version>-py3-none-any.whl
+   deadline-<version>-py3-none-any.whl
+   openjd_adaptor_runtime-<version>-py3-none-any.whl
+   ```
+
+3. Open the 3ds Max integrated submitter, and in the Job-Specific Settings tab, enable the option 'Include Adaptor Wheels'. This option is only visible when the environment variable `DEADLINE_ENABLE_DEVELOPER_OPTIONS` is set to `true`. Then submit your test job.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,59 @@
+[![pypi](https://img.shields.io/pypi/v/deadline-cloud-for-3ds-max.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-3ds-max)
+[![python](https://img.shields.io/pypi/pyversions/deadline-cloud-for-3ds-max.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-3ds-max)
+[![license](https://img.shields.io/pypi/l/deadline-cloud-for-3ds-max.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/blob/mainline/LICENSE)
+
 # AWS Deadline Cloud for 3ds Max
 
+### Disclaimer
+---
 This GitHub repository is an example integration with AWS Deadline Cloud that is intended to only be used for testing and is subject to change. This code is an alpha release. It is not a commercial release and may contain bugs, errors, defects, or harmful components. Accordingly, the code in this repository is provided as-is. Use within a production environment is at your own risk!
- 
+
 Our focus is to explore a variety of software applications to ensure we have good coverage across common workflows. We prioritized making this example available earlier to users rather than being feature complete.
 
 This example has been used by at least one internal or external development team to create a series of jobs that successfully rendered. However, your mileage may vary. If you have questions or issues with this example, please start a discussion or cut an issue.
+---
 
-## Overview
+AWS Deadline Cloud for 3ds Max is a python package that allows users to create [AWS Deadline Cloud][deadline-cloud] jobs from within 3ds Max. Using the [Open Job Description (OpenJD) Adaptor Runtime][openjd-adaptor-runtime] this package also provides a command line application that adapts 3ds Max's command line interface to support the [OpenJD specification][openjd].
 
-This package has two active branches:
-
-- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
-- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
-
-The deadline.max_adaptor package is an adaptor that renders 3ds Max scenes through the 3dsmax executable. It uses the Open Job Description adaptor_runtime and supports job stickiness.
-
-## Development
-
-See [DEVELOPMENT](DEVELOPMENT.md) for more information.
-
-## Build / Test / Release
-
-### Build the package
-
-```bash
-hatch run build
-```
-
-### Run tests
-
-```bash
-hatch run test
-```
-
-### Run linting
-
-```bash
-hatch run lint
-```
-
-### Run formatting
-
-```bash
-hatch run fmt
-```
-
-### Run tests for all supported Python versions
-
-```bash
-hatch run all:test
-```
+[deadline-cloud]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html
+[deadline-cloud-client]: https://github.com/aws-deadline/deadline-cloud
+[openjd]: https://github.com/OpenJobDescription/openjd-specifications/wiki
+[openjd-adaptor-runtime]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python
+[openjd-adaptor-runtime-lifecycle]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/blob/release/README.md#adaptor-lifecycle
 
 ## Compatibility
 
 This library requires:
 
+1. 3ds Max 2024,
 1. Python 3.9 or higher; and
-2. Windows operating system.
+1. Windows operating system.
+
+## Submitter
+
+This package provides a 3ds Max plugin that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
+
+## Adaptor
+
+The 3ds Max Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch 3ds Max and feed it commands. This gives the following benefits:
+* a standardized render application interface,
+* sticky rendering, where the application stays open between tasks,
+
+Jobs created by the submitter use this adaptor by default.
+
+### Getting Started
+
+The adaptor can be installed by the standard python packaging mechanisms:
+```sh
+$ pip install deadline-cloud-for-3ds-max
+```
+
+After installation it can then be used as a command line tool:
+```sh
+$ 3dsmax-openjd --help
+```
+
+For more information on the commands the OpenJD adaptor runtime provides, see [here][openjd-adaptor-runtime-lifecycle].
 
 ## Versioning
 
@@ -68,25 +65,13 @@ versions will increment during this initial development stage, they are describe
 2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
 3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
 
-## Telemetry
-
-This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
-
-You can opt out of telemetry data collection by either:
-
-1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
-2. Setting the config file: `deadline config set telemetry.opt_out true`
-
-Note that setting the environment variable supersedes the config file setting.
-
-## Downloading
-
-You can download this package from:
-- [GitHub releases](https://github.com/casillas2/deadline-cloud-for-3ds-max/releases)
-
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/blob/release/CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## Telemetry
+
+See [telemetry](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/blob/release/docs/telemetry.md) for more information.
 
 ## License
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,10 @@
+# Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0"
 requires-python = ">=3.9"
 description = "The submitter and adaptor to enable 3ds Max support for AWS Deadline Cloud"
 # https://pypi.org/classifiers/
+authors = [
+  {name = "Amazon Web Services"},
+]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python",
@@ -31,6 +34,10 @@ dependencies = [
     "deadline == 0.45.*", 
     "openjd-adaptor-runtime == 0.6.*",
 ]
+
+[project.urls]
+Homepage = "https://github.com/aws-deadline/deadline-cloud-for-3ds-max"
+Source = "https://github.com/aws-deadline/deadline-cloud-for-3ds-max"
 
 [project.scripts]
 3dsmax-openjd = "deadline.max_adaptor.MaxAdaptor:main"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are preparing for the first public release which includes publishing our distribution artifacts to PyPI. The description of the package on PyPI will include the `README.md` contents of this repository. Any links in the `README.md` that are relative need to be made absolute since they will not resolve correctly on PyPI. When choosing the absolute link, the link must refer to the correct branch (`mainline` vs `release`) depending on the context of the link.

Additionally, once the repository becomes public, visitors will be looking for basic information about the project such as:

*   what is it?
*   what can it be used for?
*   how can it be used and operated?
*   how can people interact with the project?

### What was the solution? (How)

* Wrote it in VSCode with .md rendering
* view in Github rendering

### What is the impact of this change?

Readers landing on our published PyPI and GitHub pages will have a more clear and curated introduction to the project, emphasizing why they might find it important and providing information to help them get started using it and contributing to it.

### How was this change tested?

*   Using Visual Studio Code's markdown preview feature
*   Reviewing GitHub's markdown rendered version

### Was this change documented?

This change is documentation :)

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
