### PR TITLE
feat: Added Support for Corona Renderer

### DIFF
--- a/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
@@ -19,14 +19,16 @@
                 ".rpf",
                 ".tga",
                 ".tif",
-                ".dds"
+                ".dds",
+                ".cxr"
             ]
         },
         "state_set": { "type": "string" },
         "renderer": {
             "enum": [
                 "Default_Scanline_Renderer",
-                "ART_Renderer"
+                "ART_Renderer",
+                "Corona"
             ]
         },
         "scene_file": { "type": "string" },

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
@@ -2,6 +2,7 @@
 
 from .default_max_handler import DefaultMaxHandler
 from .art_handler import ArtHandler
+from .corona_handler import CoronaHandler
 
 __all__ = ["DefaultMaxHandler", "get_render_handler"]
 
@@ -18,5 +19,7 @@ def get_render_handler(renderer: str = "Default_Scanline_Renderer") -> DefaultMa
     """
     if renderer == "ART_Renderer":
         return ArtHandler()
+    elif renderer == "Corona":
+        return CoronaHandler()
     else:
         return DefaultMaxHandler()

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/corona_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/corona_handler.py
@@ -1,0 +1,34 @@
+"""
+3ds Max Deadline Cloud Adaptor - Corona specific actions
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+
+import sys
+
+import pymxs  # noqa
+from pymxs import runtime as rt
+
+from .default_max_handler import DefaultMaxHandler
+
+# Re-assign sys stdout and stderr to print in the console instead of the Max Listener
+sys.stdout = sys.__stdout__
+sys.stderr = sys.__stderr__
+
+
+class CoronaHandler(DefaultMaxHandler):
+    """Render Handler for Corona"""
+
+    def __init__(self):
+        """
+        Initializes the Corona and Corona Handler
+        """
+        super().__init__()
+
+    def check_renderer(self) -> None:
+        """
+        Checks if the active renderer is set to Corona. If it is not, set it to Corona.
+        """
+        current_renderer = str(rt.renderers.current).split(":")[0]
+        if current_renderer != "Corona":
+            rt.renderers.current = rt.Corona()

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -36,7 +36,7 @@ ALLOWED_EXTENSIONS = [
     ["Targa Image File (*.tga)", ".tga"],
     ["TIF Image File (*.tif)", ".tif"],
     ["DDS Image File (*.dds)", ".dds"],
-    ["Corona EXR Image Format (*.cxr)",".cxr"]
+    ["Corona EXR Image Format (*.cxr)", ".cxr"],
 ]
 
 # Materials allowed for custom override on submit

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -19,7 +19,7 @@ RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
 TEMP_BACKUP_FILENAME = "max_backup_file.mx"
 
 # Renderers currently supported by Deadline Cloud
-ALLOWED_RENDERERS = ["Default_Scanline_Renderer", "ART_Renderer"]
+ALLOWED_RENDERERS = ["Default_Scanline_Renderer", "ART_Renderer", "Corona"]
 
 # Possible output extensions
 ALLOWED_EXTENSIONS = [
@@ -36,6 +36,7 @@ ALLOWED_EXTENSIONS = [
     ["Targa Image File (*.tga)", ".tga"],
     ["TIF Image File (*.tif)", ".tif"],
     ["DDS Image File (*.dds)", ".dds"],
+    ["Corona EXR Image Format (*.cxr)",".cxr"]
 ]
 
 # Materials allowed for custom override on submit


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Only Default and ART renderers were supported, rendering a file with Corona would default to the scanline renderer.

### What was the solution? (How)

I duplicated the ART render handler and adjusted it to be a Corona Handler. I also adjusted the allowed output files to include .cxr (Corona EXR Format) and the allowed renderers to include Corona

### What is the impact of this change?

Minor impact, should just add support for Corona.

### How was this change tested?

I built the wheel and installed it and was able to run Corona jobs.

### Was this change documented?

Only through commit messages, based on the format of the surrounding code additional comments were unnecessary.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*