### PR TITLE
feat: Added Support for V-Ray 6 and V-Ray GPU 6 Renderers

### DIFF
--- a/depsBundle.py
+++ b/depsBundle.py
@@ -4,7 +4,6 @@ import re
 import shutil
 import subprocess
 import sys
-
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any

--- a/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
+++ b/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
@@ -15,20 +15,17 @@ import time
 from typing import Callable
 
 from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators, SemanticVersion
-from openjd.adaptor_runtime_client import Action
 from openjd.adaptor_runtime.adaptors.configuration import AdaptorConfiguration
-from openjd.adaptor_runtime.process import LoggingSubprocess
 from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
-from openjd.adaptor_runtime.application_ipc import ActionsQueue
-from openjd.adaptor_runtime.application_ipc import AdaptorServer
+from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
+from openjd.adaptor_runtime.process import LoggingSubprocess
+from openjd.adaptor_runtime_client import Action
 
 _logger = logging.getLogger(__name__)
 
 
 class MaxNotRunningError(Exception):
     """Error that is raised when attempting to use Max while it is not running"""
-
-    pass
 
 
 # Renderer needs extra steps
@@ -249,8 +246,8 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
 
         # Add the openjd namespace directory to PYTHONPATH, so that adaptor_runtime_client will be available
         # directly to the adaptor client.
-        import openjd.adaptor_runtime_client
         import deadline.max_adaptor
+        import openjd.adaptor_runtime_client
 
         openjd_namespace_dir = os.path.dirname(
             os.path.dirname(openjd.adaptor_runtime_client.__file__)

--- a/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
@@ -2,9 +2,15 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "camera": { "type": "string" },
-        "output_file_path": { "type": "string" },
-        "output_file_name": { "type": "string" },
+        "camera": {
+            "type": "string"
+        },
+        "output_file_path": {
+            "type": "string"
+        },
+        "output_file_name": {
+            "type": "string"
+        },
         "output_file_format": {
             "enum": [
                 ".avi",
@@ -24,18 +30,30 @@
                 ".vrimg"
             ]
         },
-        "state_set": { "type": "string" },
+        "state_set": {
+            "type": "string"
+        },
         "renderer": {
-            "enum": [
-                "Default_Scanline_Renderer",
-                "ART_Renderer",
-                "Corona",
-                "V_Ray_6",
-                "V_Ray_GPU_6"
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^V_Ray_[1-9](_GPU)?.*$"
+                },
+                {
+                    "enum": [
+                        "Default_Scanline_Renderer",
+                        "ART_Renderer",
+                        "Corona"
+                    ]
+                }
             ]
         },
-        "scene_file": { "type": "string" },
-        "strict_error_checking": { "type": "boolean" }
+        "scene_file": {
+            "type": "string"
+        },
+        "strict_error_checking": {
+            "type": "boolean"
+        }
     },
     "required": [
         "renderer",

--- a/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
@@ -20,7 +20,8 @@
                 ".tga",
                 ".tif",
                 ".dds",
-                ".cxr"
+                ".cxr",
+                ".vrimg"
             ]
         },
         "state_set": { "type": "string" },
@@ -28,7 +29,9 @@
             "enum": [
                 "Default_Scanline_Renderer",
                 "ART_Renderer",
-                "Corona"
+                "Corona",
+                "V_Ray_6",
+                "V_Ray_GPU_6"
             ]
         },
         "scene_file": { "type": "string" },

--- a/src/deadline/max_adaptor/MaxClient/max_client.py
+++ b/src/deadline/max_adaptor/MaxClient/max_client.py
@@ -6,8 +6,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from __future__ import annotations
 
-import os
 import logging
+import os
 import sys
 from types import FrameType
 from typing import Optional
@@ -19,15 +19,16 @@ from pymxs import runtime as rt
 # adaptor_runtime_client should work.
 try:
     from adaptor_runtime_client import ClientInterface  # type: ignore[import]
+
     from max_adaptor.MaxClient.render_handlers import (  # type: ignore[import]
         get_render_handler,
     )
 
 except (ImportError, ModuleNotFoundError):
-    from openjd.adaptor_runtime_client import ClientInterface  # type: ignore[import]
     from deadline.max_adaptor.MaxClient.render_handlers import (  # type: ignore[import]
         get_render_handler,
     )
+    from openjd.adaptor_runtime_client import ClientInterface  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
 

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
@@ -3,6 +3,7 @@
 from .default_max_handler import DefaultMaxHandler
 from .art_handler import ArtHandler
 from .corona_handler import CoronaHandler
+from .vray_handler import VrayHandler
 
 __all__ = ["DefaultMaxHandler", "get_render_handler"]
 
@@ -21,5 +22,9 @@ def get_render_handler(renderer: str = "Default_Scanline_Renderer") -> DefaultMa
         return ArtHandler()
     elif renderer == "Corona":
         return CoronaHandler()
+    elif renderer == "V_Ray_6":
+        return VrayHandler(GPU=False)
+    elif renderer == "V_Ray_GPU_6":
+        return VrayHandler(GPU=True)
     else:
         return DefaultMaxHandler()

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
@@ -1,8 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from .default_max_handler import DefaultMaxHandler
 from .art_handler import ArtHandler
 from .corona_handler import CoronaHandler
+from .default_max_handler import DefaultMaxHandler
 from .vray_handler import VrayHandler
 
 __all__ = ["DefaultMaxHandler", "get_render_handler"]

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
@@ -22,9 +22,9 @@ def get_render_handler(renderer: str = "Default_Scanline_Renderer") -> DefaultMa
         return ArtHandler()
     elif renderer == "Corona":
         return CoronaHandler()
-    elif renderer == "V_Ray_6":
-        return VrayHandler(GPU=False)
-    elif renderer == "V_Ray_GPU_6":
-        return VrayHandler(GPU=True)
+    elif renderer.startswith("V_Ray_6"):
+        return VrayHandler(gpu=False)
+    elif renderer.startswith("V_Ray_GPU_6"):
+        return VrayHandler(gpu=True)
     else:
         return DefaultMaxHandler()

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
@@ -6,9 +6,9 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
-import logging
 
 import pymxs  # noqa
 from pymxs import runtime as rt

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -1,0 +1,47 @@
+"""
+3ds Max Deadline Cloud Adaptor - V-Ray specific actions
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+
+import sys
+
+import pymxs  # noqa
+from pymxs import runtime as rt
+
+from .default_max_handler import DefaultMaxHandler
+
+# Re-assign sys stdout and stderr to print in the console instead of the Max Listener
+sys.stdout = sys.__stdout__
+sys.stderr = sys.__stderr__
+
+
+class VrayHandler(DefaultMaxHandler):
+    """Render Handler for V-Ray"""
+
+    def __init__(self, GPU):
+        """
+        Initializes the V-Ray and V-Ray Handler
+        """
+        super().__init__()
+        self.GPU: bool = GPU
+
+    def check_renderer(self) -> None:
+        """
+        Checks if the active renderer is set to V-Ray. If it is not, set it to the latest version V-Ray.
+        Gets the latest versions of V-Ray and V-Ray GPU from rt.rendererclass.classes.
+        """
+        current_renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
+
+        # The V-Ray renderer class name is "V_Ray_6__update_#_#" and "V_Ray_GPU_6__update_#_#"
+        vray = [i for i in list(rt.rendererclass.classes) if "V_Ray" in str(i) and "GPU" not in str(i)][-1]
+        vray_gpu = [i for i in list(rt.rendererclass.classes) if "V_Ray" in str(i) and "GPU" in str(i)][-1]
+
+        if self.GPU:
+            if "V_Ray_GPU" not in current_renderer:
+                # Set to most recent version of V-Ray GPU
+                rt.renderers.current = vray_gpu()
+        else:
+            if "V_Ray" not in current_renderer or "V_Ray_GPU" in current_renderer:
+                # Set to most recent version of V-Ray
+                rt.renderers.current = vray()

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -34,8 +34,12 @@ class VrayHandler(DefaultMaxHandler):
         current_renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
 
         # The V-Ray renderer class name is "V_Ray_6__update_#_#" and "V_Ray_GPU_6__update_#_#"
-        vray = [i for i in list(rt.rendererclass.classes) if "V_Ray" in str(i) and "GPU" not in str(i)][-1]
-        vray_gpu = [i for i in list(rt.rendererclass.classes) if "V_Ray" in str(i) and "GPU" in str(i)][-1]
+        vray = [
+            i for i in list(rt.rendererclass.classes) if "V_Ray" in str(i) and "GPU" not in str(i)
+        ][-1]
+        vray_gpu = [
+            i for i in list(rt.rendererclass.classes) if "V_Ray" in str(i) and "GPU" in str(i)
+        ][-1]
 
         if self.GPU:
             if "V_Ray_GPU" not in current_renderer:

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -31,21 +31,34 @@ class VrayHandler(DefaultMaxHandler):
         Checks if the active renderer is set to V-Ray. If it is not, set it to the latest version V-Ray.
         Gets the latest versions of V-Ray and V-Ray GPU from rt.rendererclass.classes.
         """
-        current_renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
+        current_renderer = str(rt.renderers.current).split(":")[0]
 
         # The V-Ray renderer class name is "V_Ray_6__update_#_#" and "V_Ray_GPU_6__update_#_#"
-        vray = [
-            i for i in list(rt.rendererclass.classes) if "V_Ray" in str(i) and "GPU" not in str(i)
-        ][-1]
-        vray_gpu = [
-            i for i in list(rt.rendererclass.classes) if "V_Ray" in str(i) and "GPU" in str(i)
-        ][-1]
-
         if self.GPU:
+            try:
+                vray_gpu = [
+                    i
+                    for i in list(rt.rendererclass.classes)
+                    if "V_Ray" in str(i) and "GPU" in str(i)
+                ][-1]
+            except Exception:
+                print("Error: unable to find V-Ray GPU plugin")
+                raise RuntimeError("Error: unable to find V-Ray GPU plugin")
+
             if "V_Ray_GPU" not in current_renderer:
                 # Set to most recent version of V-Ray GPU
                 rt.renderers.current = vray_gpu()
         else:
+            try:
+                vray = [
+                    i
+                    for i in list(rt.rendererclass.classes)
+                    if "V_Ray" in str(i) and "GPU" not in str(i)
+                ][-1]
+            except Exception:
+                print("Error: unable to find V-Ray plugin")
+                raise RuntimeError("Error: unable to find V-Ray plugin")
+
             if "V_Ray" not in current_renderer or "V_Ray_GPU" in current_renderer:
                 # Set to most recent version of V-Ray
                 rt.renderers.current = vray()

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -6,7 +6,6 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import sys
 
-import pymxs  # noqa
 from pymxs import runtime as rt
 
 from .default_max_handler import DefaultMaxHandler
@@ -19,12 +18,12 @@ sys.stderr = sys.__stderr__
 class VrayHandler(DefaultMaxHandler):
     """Render Handler for V-Ray"""
 
-    def __init__(self, GPU):
+    def __init__(self, gpu):
         """
         Initializes the V-Ray and V-Ray Handler
         """
         super().__init__()
-        self.GPU: bool = GPU
+        self.gpu: bool = gpu
 
     def check_renderer(self) -> None:
         """
@@ -34,7 +33,7 @@ class VrayHandler(DefaultMaxHandler):
         current_renderer = str(rt.renderers.current).split(":")[0]
 
         # The V-Ray renderer class name is "V_Ray_6__update_#_#" and "V_Ray_GPU_6__update_#_#"
-        if self.GPU:
+        if self.gpu:
             try:
                 vray_gpu = [
                     i

--- a/src/deadline/max_submitter/create_job_bundle.py
+++ b/src/deadline/max_submitter/create_job_bundle.py
@@ -4,17 +4,16 @@
 3ds Max Deadline Cloud Submitter - Functions for generating the job template and parameter values files
 """
 
-from copy import deepcopy
-from typing import Any
 import os
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
+
 import yaml
-
-from deadline.client.exceptions import DeadlineOperationError
-
-from utilities import max_utils
 from data_classes import RenderSubmitterUISettings, StateSetData
-from data_const import ALL_CAMERAS_STR, ALL_STEREO_CAMERAS_STR, ALL_STATE_SETS_STR
+from data_const import ALL_CAMERAS_STR, ALL_STATE_SETS_STR, ALL_STEREO_CAMERAS_STR
+from deadline.client.exceptions import DeadlineOperationError
+from utilities import max_utils
 
 
 def get_job_template(

--- a/src/deadline/max_submitter/data_classes.py
+++ b/src/deadline/max_submitter/data_classes.py
@@ -5,15 +5,14 @@
 """
 
 import dataclasses
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
-import json
 from typing import Optional
 
 import pymxs  # noqa
-from pymxs import runtime as rt
-
 from data_const import ALL_CAMERAS_STR, RENDER_SUBMITTER_SETTINGS_FILE_EXT
+from pymxs import runtime as rt
 
 
 @dataclass
@@ -113,7 +112,6 @@ class RenderSubmitterUISettings:
                     f"WARNING: Failed to load sticky settings file {sticky_settings_filename}, reverting to the "
                     "default settings."
                 )
-                pass
 
     def save_sticky_settings(self):
         """

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -19,7 +19,13 @@ RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
 TEMP_BACKUP_FILENAME = "max_backup_file.mx"
 
 # Renderers currently supported by Deadline Cloud
-ALLOWED_RENDERERS = ["Default_Scanline_Renderer", "ART_Renderer", "Corona", "V_Ray_6", "V_Ray_GPU_6"]
+ALLOWED_RENDERERS = [
+    "Default_Scanline_Renderer",
+    "ART_Renderer",
+    "Corona",
+    "V_Ray_6",
+    "V_Ray_GPU_6",
+]
 
 # Possible output extensions
 ALLOWED_EXTENSIONS = [

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -43,7 +43,7 @@ ALLOWED_EXTENSIONS = [
     ["TIF Image File (*.tif)", ".tif"],
     ["DDS Image File (*.dds)", ".dds"],
     ["Corona EXR Image Format (*.cxr)", ".cxr"],
-    ["V-Ray image formamt (*.vrimg)", ".vrimg"],
+    ["V-Ray Image Format (*.vrimg)", ".vrimg"],
 ]
 
 # Materials allowed for custom override on submit

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -19,7 +19,7 @@ RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
 TEMP_BACKUP_FILENAME = "max_backup_file.mx"
 
 # Renderers currently supported by Deadline Cloud
-ALLOWED_RENDERERS = ["Default_Scanline_Renderer", "ART_Renderer", "Corona"]
+ALLOWED_RENDERERS = ["Default_Scanline_Renderer", "ART_Renderer", "Corona", "V_Ray_6", "V_Ray_GPU_6"]
 
 # Possible output extensions
 ALLOWED_EXTENSIONS = [
@@ -37,6 +37,7 @@ ALLOWED_EXTENSIONS = [
     ["TIF Image File (*.tif)", ".tif"],
     ["DDS Image File (*.dds)", ".dds"],
     ["Corona EXR Image Format (*.cxr)", ".cxr"],
+    ["V-Ray image formamt (*.vrimg)", ".vrimg"],
 ]
 
 # Materials allowed for custom override on submit

--- a/src/deadline/max_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/max_submitter/job_bundle_output_test_runner.py
@@ -3,29 +3,28 @@
 """
 Defines the Render submitter command which is registered in 3ds Max.
 """
-import os
-import tempfile
-from unittest import mock
-import shutil
-import filecmp
 import difflib
-from typing import Any
-from pathlib import Path
+import filecmp
+import os
+import shutil
+import tempfile
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest import mock
 
 import pymxs  # noqa
-from pymxs import runtime as rt
 import qtmax
+from deadline.client.exceptions import DeadlineOperationError
+from deadline.client.ui import gui_error_handler
+from deadline.client.ui.dialogs import submit_job_to_deadline_dialog
+from max_render_submitter import show_job_bundle_submitter
+from pymxs import runtime as rt
 from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QApplication,
     QFileDialog,
     QMessageBox,
 )
-
-from deadline.client.ui import gui_error_handler
-from deadline.client.exceptions import DeadlineOperationError
-from deadline.client.ui.dialogs import submit_job_to_deadline_dialog
-from max_render_submitter import show_job_bundle_submitter
 
 
 # The following functions expose a DCC interface to the job bundle output test logic.

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -11,30 +11,27 @@ from os.path import abspath, join, normpath
 from pathlib import Path
 from typing import Any, Optional
 
-import yaml
-
-import qtmax
 import pymxs  # noqa
-from pymxs import runtime as rt
-
-from PySide2.QtCore import Qt
-
-from deadline.client.job_bundle.submission import AssetReferences
-from deadline.client.job_bundle._yaml import deadline_yaml_dump
-from deadline.client.ui.dialogs._types import JobBundlePurpose
-
-from ui.submit_dialog import SubmitMaxJobToDeadlineDialog
-from ui.scene_settings_tab import SceneSettingsWidget
-from data_classes import RenderSubmitterUISettings, StateSetData
-from sanity_checks import check_sanity
+import qtmax
+import yaml
 from create_job_bundle import get_job_template, get_parameters_values
-from utilities import max_utils, submission_utils
+from data_classes import RenderSubmitterUISettings, StateSetData
 from data_const import (
-    ALL_STEREO_CAMERAS_STR,
     ALL_STATE_SETS_STR,
-    UI_GROUP_LABEL,
+    ALL_STEREO_CAMERAS_STR,
     TEMP_BACKUP_FILENAME,
+    UI_GROUP_LABEL,
 )
+from deadline.client.job_bundle._yaml import deadline_yaml_dump
+from deadline.client.job_bundle.submission import AssetReferences
+from deadline.client.ui.dialogs._types import JobBundlePurpose
+from pymxs import runtime as rt
+from PySide2.QtCore import Qt
+from sanity_checks import check_sanity
+from ui.scene_settings_tab import SceneSettingsWidget
+from ui.submit_dialog import SubmitMaxJobToDeadlineDialog
+from utilities import max_utils, submission_utils
+
 from _version import version_tuple as adaptor_version_tuple
 
 _logger = logging.getLogger(__name__)

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -61,7 +61,7 @@ def show_job_bundle_submitter():
     render_settings.output_path = max_utils.get_scene_dir()
     render_settings.output_name = max_utils.get_scene_name() + "_###"
     render_settings.backup_file = rt.execute("GetDir #temp") + "\\" + TEMP_BACKUP_FILENAME
-    render_settings.renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
+    render_settings.renderer = str(rt.renderers.current).split(":")[0]
 
     render_settings.load_sticky_settings()
 
@@ -151,7 +151,7 @@ def show_job_bundle_submitter():
                 state_sets_to_submit.append(
                     StateSetData(
                         state_set=state_set[0],
-                        renderer=str(rt.renderers.current).split(":")[0].split("__")[0],
+                        renderer=str(rt.renderers.current).split(":")[0],
                         frame_range=max_utils.get_frames(),
                         output_directories=output_directories,
                         output_file_dir=output_dir,
@@ -190,7 +190,7 @@ def show_job_bundle_submitter():
             state_sets_to_submit.append(
                 StateSetData(
                     state_set=settings.state_set,
-                    renderer=str(rt.renderers.current).split(":")[0].split("__")[0],
+                    renderer=str(rt.renderers.current).split(":")[0],
                     frame_range=max_utils.get_frames(),
                     output_directories=output_directories,
                     output_file_dir=output_dir,

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -61,7 +61,7 @@ def show_job_bundle_submitter():
     render_settings.output_path = max_utils.get_scene_dir()
     render_settings.output_name = max_utils.get_scene_name() + "_###"
     render_settings.backup_file = rt.execute("GetDir #temp") + "\\" + TEMP_BACKUP_FILENAME
-    render_settings.renderer = str(rt.renderers.current).split(":")[0]
+    render_settings.renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
 
     render_settings.load_sticky_settings()
 
@@ -151,7 +151,7 @@ def show_job_bundle_submitter():
                 state_sets_to_submit.append(
                     StateSetData(
                         state_set=state_set[0],
-                        renderer=str(rt.renderers.current).split(":")[0],
+                        renderer=str(rt.renderers.current).split(":")[0].split("__")[0],
                         frame_range=max_utils.get_frames(),
                         output_directories=output_directories,
                         output_file_dir=output_dir,
@@ -190,7 +190,7 @@ def show_job_bundle_submitter():
             state_sets_to_submit.append(
                 StateSetData(
                     state_set=settings.state_set,
-                    renderer=str(rt.renderers.current).split(":")[0],
+                    renderer=str(rt.renderers.current).split(":")[0].split("__")[0],
                     frame_range=max_utils.get_frames(),
                     output_directories=output_directories,
                     output_file_dir=output_dir,

--- a/src/deadline/max_submitter/run_ui.py
+++ b/src/deadline/max_submitter/run_ui.py
@@ -6,14 +6,11 @@
 
 from logging import root
 
-from pymxs import runtime as rt
-
-from PySide2.QtWidgets import QMessageBox
-
 from deadline.client.config import config_file
-
-from utilities.log_utils import configure_logging
 from max_render_submitter import show_job_bundle_submitter
+from pymxs import runtime as rt
+from PySide2.QtWidgets import QMessageBox
+from utilities.log_utils import configure_logging
 
 
 def show_ui():

--- a/src/deadline/max_submitter/sanity_checks.py
+++ b/src/deadline/max_submitter/sanity_checks.py
@@ -132,7 +132,7 @@ def check_sanity_specific_state_set(settings: RenderSubmitterUISettings, state_s
     :param settings: a RenderSubmitterUISettings object containing the latest UI settings
     :param state_set: the name of the active state set
     """
-    if str(rt.renderers.current).split(":")[0] not in ALLOWED_RENDERERS:
+    if str(rt.renderers.current).split(":")[0].split("__")[0] not in ALLOWED_RENDERERS:
         raise Exception(
             f"{state_set} has an unsupported renderer set. Renderer: "
             f"{str(rt.renderers.current).split(':')[0]}"

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -4,41 +4,38 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
-import os
 import logging
+import os
 
 import pymxs  # noqa
+from data_const import (
+    ALL_STATE_SETS_STR,
+    ALLOWED_EXTENSIONS,
+    ALLOWED_RENDERERS,
+    SCENE_TWEAKS_MATS,
+    STEREO_CAMERA_OPTIONS,
+)
+from deadline.client.ui import block_signals
 from pymxs import runtime as rt
-
+from PySide2.QtCore import QRegularExpression, QSize, Qt  # type: ignore
 from PySide2.QtGui import QRegularExpressionValidator
-from PySide2.QtCore import QSize, Qt, QRegularExpression  # type: ignore
 from PySide2.QtWidgets import (  # type: ignore
+    QApplication,
     QCheckBox,
     QComboBox,
     QFileDialog,
     QGridLayout,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QMessageBox,
     QPushButton,
     QSizePolicy,
     QSpacerItem,
     QWidget,
-    QGroupBox,
-    QMessageBox,
-    QApplication,
 )
-
-from deadline.client.ui import block_signals
-
 from utilities import max_utils
-from data_const import (
-    ALLOWED_RENDERERS,
-    ALLOWED_EXTENSIONS,
-    SCENE_TWEAKS_MATS,
-    STEREO_CAMERA_OPTIONS,
-    ALL_STATE_SETS_STR,
-)
 
 _logger = logging.getLogger(__name__)
 

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -175,9 +175,8 @@ class SceneSettingsWidget(QWidget):
         )
         self.renderers_box.addItem("Current Renderer not supported by Submitter")
         for renderer in self.renderers:
-            # Adding this to the below if statement doesn't work.
-            renderer = renderer.split("__")[0]
-            if renderer in ALLOWED_RENDERERS:
+
+            if str(renderer).split("__")[0] in ALLOWED_RENDERERS:
                 self.renderers_box.addItem(renderer.replace("_", " "), renderer)
         lyt.addWidget(QLabel("Renderer"), 5, 0)
         lyt.addWidget(self.renderers_box, 5, 1)
@@ -451,7 +450,7 @@ class SceneSettingsWidget(QWidget):
         """
         Set the initial status of the ui fields
         """
-        settings.renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
+        settings.renderer = str(rt.renderers.current).split(":")[0]
         self.proj_path_txt.setText(settings.project_path)
         self.output_path_txt.setText(settings.output_path)
         self.output_name_txt.setText(settings.output_name)
@@ -543,7 +542,7 @@ class SceneSettingsWidget(QWidget):
         Gets the current renderer from the render settings and set it in the UI
         """
         _logger.debug("Renderer updated in Render Settings")
-        renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
+        renderer = str(rt.renderers.current).split(":")[0]
         index = self.renderers_box.findData(renderer)
         if index >= 0:
             self.renderers_box.setCurrentIndex(index)

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -175,6 +175,8 @@ class SceneSettingsWidget(QWidget):
         )
         self.renderers_box.addItem("Current Renderer not supported by Submitter")
         for renderer in self.renderers:
+            # Adding this to the below if statement doesn't work.
+            renderer = renderer.split("__")[0]
             if renderer in ALLOWED_RENDERERS:
                 self.renderers_box.addItem(renderer.replace("_", " "), renderer)
         lyt.addWidget(QLabel("Renderer"), 5, 0)
@@ -449,7 +451,7 @@ class SceneSettingsWidget(QWidget):
         """
         Set the initial status of the ui fields
         """
-        settings.renderer = str(rt.renderers.current).split(":")[0]
+        settings.renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
         self.proj_path_txt.setText(settings.project_path)
         self.output_path_txt.setText(settings.output_path)
         self.output_name_txt.setText(settings.output_name)
@@ -541,7 +543,7 @@ class SceneSettingsWidget(QWidget):
         Gets the current renderer from the render settings and set it in the UI
         """
         _logger.debug("Renderer updated in Render Settings")
-        renderer = str(rt.renderers.current).split(":")[0]
+        renderer = str(rt.renderers.current).split(":")[0].split("__")[0]
         index = self.renderers_box.findData(renderer)
         if index >= 0:
             self.renderers_box.setCurrentIndex(index)

--- a/src/deadline/max_submitter/ui/submit_dialog.py
+++ b/src/deadline/max_submitter/ui/submit_dialog.py
@@ -7,7 +7,6 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import logging
 
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
-
 from utilities import submission_utils
 
 _logger = logging.getLogger(__name__)

--- a/src/deadline/max_submitter/utilities/log_utils.py
+++ b/src/deadline/max_submitter/utilities/log_utils.py
@@ -5,8 +5,8 @@
 """
 
 import logging
-from logging.handlers import RotatingFileHandler
 import os
+from logging.handlers import RotatingFileHandler
 
 LOGGING_FORMAT_FILE = (
     "%(asctime)s %(levelname)8s {%(threadName)-10s}:  %(module)s %(funcName)s: %(message)s"

--- a/src/deadline/max_submitter/utilities/max_utils.py
+++ b/src/deadline/max_submitter/utilities/max_utils.py
@@ -4,9 +4,9 @@
 3ds Max Deadline Cloud Submitter - Deadline Cloud 3ds Max utilities
 """
 
-from pathlib import Path
 import logging
 import os
+from pathlib import Path
 
 import pymxs  # separate import to initialize
 from pymxs import runtime as rt

--- a/src/deadline/max_submitter/utilities/submission_utils.py
+++ b/src/deadline/max_submitter/utilities/submission_utils.py
@@ -8,12 +8,10 @@ import logging
 import os
 
 import pymxs  # separate import to initialize
-from pymxs import runtime as rt
-
-from deadline.client.job_bundle.submission import AssetReferences
-
 from data_classes import RenderSubmitterUISettings
 from data_const import SCENE_TWEAKS_MATS
+from deadline.client.job_bundle.submission import AssetReferences
+from pymxs import runtime as rt
 from utilities import max_utils
 
 _logger = logging.getLogger(__name__)
@@ -289,7 +287,7 @@ def clear_material_editor() -> list:
         _logger.info("Closed the Material Editor")
     material_storage = []
     # Note: meditMaterials is a system global containing 24 sample slots in the Material Editor
-    for i in range(0, 24):
+    for i in range(24):
         material_storage.append(rt.meditMaterials[i])
         rt.meditMaterials[i] = rt.standard()
     _logger.info("Cleared the Material Editor")
@@ -304,7 +302,7 @@ def restore_material_editor(materials: list):
     :param materials: the previously saved materials we want to restore
     """
     # Note: meditMaterials is a system global containing 24 sample slots in the Material Editor
-    for i in range(0, 24):
+    for i in range(24):
         rt.meditMaterials[i] = materials[i]
     _logger.info("Restored the Material Editor")
 
@@ -404,7 +402,7 @@ def make_paths_absolute():
         ) else false
     )
     """
-    rt.execute("closeError={}".format(close_error_mxs_function))
+    rt.execute(f"closeError={close_error_mxs_function}")
 
     # Check for deep references
     scene = max_utils.get_scene_path()

--- a/test/deadline_adaptor_for_3ds_max/unit/MaxAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_3ds_max/unit/MaxAdaptor/test_adaptor.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import re
 from unittest.mock import Mock, PropertyMock, patch
 
-import pytest
 import jsonschema  # type: ignore
-
+import pytest
 from deadline.max_adaptor.MaxAdaptor import MaxAdaptor
 from deadline.max_adaptor.MaxAdaptor.adaptor import _FIRST_MAX_ACTIONS, MaxNotRunningError
 
 
-@pytest.fixture()
+@pytest.fixture
 def init_data() -> dict:
     """
     Pytest Fixture to return an init_data dictionary that passes validation
@@ -33,7 +32,7 @@ def init_data() -> dict:
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def run_data() -> dict:
     """
     Pytest Fixture to return a run_data dictionary that passes validation

--- a/test/deadline_adaptor_for_3ds_max/unit/MaxClient/render_handlers/test_max_handler_base.py
+++ b/test/deadline_adaptor_for_3ds_max/unit/MaxClient/render_handlers/test_max_handler_base.py
@@ -2,11 +2,10 @@
 from __future__ import annotations
 
 import pytest
-
 from deadline.max_adaptor.MaxClient.render_handlers import DefaultMaxHandler
 
 
-@pytest.fixture()
+@pytest.fixture
 def maxhandlerbase():
     return DefaultMaxHandler()
 

--- a/test/deadline_adaptor_for_3ds_max/unit/MaxClient/test_client.py
+++ b/test/deadline_adaptor_for_3ds_max/unit/MaxClient/test_client.py
@@ -4,7 +4,6 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
-
 from deadline.max_adaptor.MaxClient.max_client import MaxClient, main
 
 

--- a/test/test_copyright_headers.py
+++ b/test/test_copyright_headers.py
@@ -31,13 +31,12 @@ def _check_file(filename: Path) -> None:
                     " Please add one.",
                     Path(filename),
                 )
-        else:
-            # __init__.py files are usually empty, this is to catch that.
-            raise FileMissingCopyRight(
-                f"Could not find a valid Amazon.com copyright header in the top of {filename}."
-                " Please add one.",
-                Path(filename),
-            )
+        # __init__.py files are usually empty, this is to catch that.
+        raise FileMissingCopyRight(
+            f"Could not find a valid Amazon.com copyright header in the top of {filename}."
+            " Please add one.",
+            Path(filename),
+        )
 
 
 def _is_version_file(filename: Path) -> bool:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
V-Ray and V-Ray GPU renderers didn't have render handlers and failed sanity checks. #33 
### What was the solution? (How)
Created a render handler for V-Ray that can be switched to V-Ray GPU with a boolean when initializing it. Currently only supports V-Ray 6 major version as any earlier versions don't support 3dsMax 2024, can be re-evaluated when V-Ray 7 is released.
### What is the impact of this change?
Several places I added a `.Split("__")` to the renderer class names to split off the minor version. `V_Ray_6__update_2_1 `is split into `V_Ray_6`. This shouldn't have any effect on other render engines as they don't have a double underscore in the name, but allows all V-Ray 6 minor versions to be supported without having to define every version in the `ALLOWED_RENDERERS` constant. If it's preferred to do it that way though - I'm happy to update.
### How was this change tested?
Was able to successfully submit, initialize, and run a job locally using 3dsMax 2024. Submitter and Adaptor worked as expected with the new handlers. Ran hatch formatting, linting, and tests locally.
### Was this change documented?
Inline Comments
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*