### PR TITLE
docs: Fix the submitter manual installation instructions 

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,12 +52,15 @@ WARNING: This workflow installs additional Python packages into your 3ds Max's p
 
 #### Manual installation
 
-1. Copy `STDCMenuCreator.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`)
-2. Put `AWSDeadline-SubmitToDeadlineCloud.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
-3. Create a `python` folder in your scripts directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\scripts`).
-4. Copy `max_submitter` folder into that newly created `python` folder.
-5. Install `deadline` package (from CodeArtifact) to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` using a Python 3.9 installation (for compatibility with Max)
-    - `pip install deadline -t ~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts`
+1. Build your local copy of `deadline-cloud-for-3ds-max`.
+1. To install the submitter in 3dsMax:
+    1. Copy `STDCMenuCreator.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`)
+    1. Copy `AWSDeadline-SubmitToDeadlineCloud.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
+1. The point of entry for the submitter is the `run_ui.py` file under the `max_submitter` folder. Thus, this file needs to be discoverable by 3dsMax, and `max_submitter` needs to be a discoverable package by python.
+    1. Add the path to `max_submitter` to the `ADSK_3DSMAX_SCRIPTS_ADDON_DIR` environment variable (e.g. In Powershell run `$env:ADSK_3DSMAX_SCRIPTS_ADDON_DIR += "C:\Users\<username>\workplace\deadline-cloud-for-3ds-max\src\deadline\max_submitter"`).
+    1. Add the path to `max_submitter` to the `PYTHONPATH` environment variable (e.g. In Powershell run `$env:PYTHONPATH += "C:\Users\<username>\workplace\deadline-cloud-for-3ds-max\src\deadline\max_submitter"`).
+1. Install `deadline` package to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts`, using a python version that is compatible with the version of 3dsMax that you are using (e.g. For 3dsMax 2024 run `pip install deadline --python-version 3.10 --only-binary=:all: -t $env:HOMEPATH\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` in Powershell).
+1. Run `3dsmax` from the same command-line window where the environment variables were set. To do so, `3dsmax` needs to be part of the PATH (e.g. In Powershell run `$env:PATH += ";C:\Program Files\Autodesk\<version>"`).
 
 #### Install for Development
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@
 
 ### Disclaimer
 ---
-This GitHub repository is an example integration with AWS Deadline Cloud that is intended to only be used for testing and is subject to change. This code is an alpha release. It is not a commercial release and may contain bugs, errors, defects, or harmful components. Accordingly, the code in this repository is provided as-is. Use within a production environment is at your own risk!
+This GitHub repository is an example integration with AWS Deadline Cloud that is intended to only be used for testing and is subject to change. **This code is an alpha release. It is not a commercial release and may contain bugs, errors, defects, or harmful components.** Accordingly, the code in this repository is provided as-is. Use within a production environment is at your own risk!
 
 Our focus is to explore a variety of software applications to ensure we have good coverage across common workflows. We prioritized making this example available earlier to users rather than being feature complete.
+
+There are two open issues that prevent successful installation and rendering:
+* [Bug: Opening the 3ds Max Submitter fails with “runtime error : Failed to open file run_ui.py”](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/27)
+* [Bug: Adaptor freezes on launching 3ds Max](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/39)
 
 This example has been used by at least one internal or external development team to create a series of jobs that successfully rendered. However, your mileage may vary. If you have questions or issues with this example, please start a discussion or cut an issue.
 ---


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The instructions to install the submitter manually are missing some steps. We have an [opened issue](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/27) due to this problem.

### What was the solution? (How)
Add clarity to the manual installation instructions.

### What is the impact of this change?
Remove submitter installation friction.

### How was this change tested?
Previewed as markdown.

### Was this change documented?
Yes.

### Is this a breaking change?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

<img width="1094" alt="Screenshot 2024-10-07 at 11 48 08" src="https://github.com/user-attachments/assets/a54ccc9a-c77e-403d-97fd-c5dc47a80c90">
