### PR TITLE
Allow an environment override for locating 3dsMax.exe

### DIFF
--- a/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
+++ b/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
@@ -241,7 +241,7 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
 
         :raises: FileNotFoundError: If the max_client.py file could not be found.
         """
-        max_exe = "3dsmax"
+        max_exe = os.environ.get("3DSMAX_ADAPTOR_3DSMAX_EXECUTABLE", "3dsmax")
         regexhandler = RegexHandler(self._get_regex_callbacks())
 
         # Add the openjd namespace directory to PYTHONPATH, so that adaptor_runtime_client will be available


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*