### PR TITLE
chore: use correct openjd-adaptor-runtime RUNTIME_INSTALLABLE in create_adaptor_packaging_artifact.sh

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -104,7 +104,7 @@ if [ $SOURCE = 1 ]; then
         $ADAPTOR_INSTALLABLE
 else
     # In PyPI mode, PyPI and/or a CodeArtifact must have these packages
-    RUNTIME_INSTALLABLE=openjd-adaptor-runtime-for-python
+    RUNTIME_INSTALLABLE=openjd-adaptor-runtime
     ADAPTOR_INSTALLABLE=$ADAPTOR_NAME
 
     pip install \


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In our `create_adaptor_packaging_artifact.py` scripts, we need to pull the `openjd-adaptor-runtime` from pip. This package incorrectly tried to pull the `openjd-adaptor-runtime-for-python`, which is different than all the [other adaptor packages](https://github.com/search?q=org%3Aaws-deadline%20RUNTIME_INSTALLABLE%3Dopenjd-adaptor-runtime&type=code)

### What was the solution? (How)
Updated the `RUNTIME_INSTALLABLE` to use the `openjd-adaptor-runtime`.

### What is the impact of this change?
`create_adaptor_packaging_artifact.sh` no longer errors during run

### How was this change tested?
Ran `./create_adaptor_packaging_artifact.sh`

Before:
```
ERROR: Could not find a version that satisfies the requirement openjd-adaptor-runtime-for-python (from versions: none)
ERROR: No matching distribution found for openjd-adaptor-runtime-for-python
```

After: 
```
Installing collected packages: openjd-adaptor-runtime
```

### Was this change documented?
No, not required

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*