### PR TITLE
fix: Run 3dsMax in silent mode

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,12 +52,15 @@ WARNING: This workflow installs additional Python packages into your 3ds Max's p
 
 #### Manual installation
 
-1. Copy `STDCMenuCreator.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`)
-2. Put `AWSDeadline-SubmitToDeadlineCloud.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
-3. Create a `python` folder in your scripts directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\scripts`).
-4. Copy `max_submitter` folder into that newly created `python` folder.
-5. Install `deadline` package (from CodeArtifact) to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` using a Python 3.9 installation (for compatibility with Max)
-    - `pip install deadline -t ~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts`
+1. Build your local copy of `deadline-cloud-for-3ds-max`.
+1. To install the submitter in 3dsMax:
+    1. Copy `STDCMenuCreator.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`)
+    1. Copy `AWSDeadline-SubmitToDeadlineCloud.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
+1. The point of entry for the submitter is the `run_ui.py` file under the `max_submitter` folder. Thus, this file needs to be discoverable by 3dsMax, and `max_submitter` needs to be a discoverable package by python.
+    1. Add the path to `max_submitter` to the `ADSK_3DSMAX_SCRIPTS_ADDON_DIR` environment variable (e.g. In Powershell run `$env:ADSK_3DSMAX_SCRIPTS_ADDON_DIR += "C:\Users\<username>\workplace\deadline-cloud-for-3ds-max\src\deadline\max_submitter"`).
+    1. Add the path to `max_submitter` to the `PYTHONPATH` environment variable (e.g. In Powershell run `$env:PYTHONPATH += "C:\Users\<username>\workplace\deadline-cloud-for-3ds-max\src\deadline\max_submitter"`).
+1. Install `deadline` package to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts`, using a python version that is compatible with the version of 3dsMax that you are using (e.g. For 3dsMax 2024 run `pip install deadline --python-version 3.10 --only-binary=:all: -t $env:HOMEPATH\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` in Powershell).
+1. Run `3dsmax` from the same command-line window where the environment variables were set. To do so, `3dsmax` needs to be part of the PATH (e.g. In Powershell run `$env:PATH += ";C:\Program Files\Autodesk\<version>"`).
 
 #### Install for Development
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,7 +69,7 @@ WARNING: This workflow installs additional Python packages into your 3ds Max's p
 3. Put `AWSDeadline-SubmitToDeadlineCloud.mcr` and `AWSDeadline-RunJobBundleTests.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
 4. Modify the path in `AWSDeadline-SubmitToDeadlineCloud.mcr` to `<reporoot>/src/deadline/max_submitter/run_ui.py`. Set the `DEBUG` variable to `true`.
 5. Modify the path in `AWSDeadline-RunJobBundleTests.mcr` to `<reporoot>/src/deadline/max_submitter/job_bundle_output_test_runner.py`. Set the `DEBUG` variable to `true`.
-6. Install `deadline` package (from CodeArtifact) to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` using a Python 3.9 installation (for compatibility with Max)
+6. Install `deadline` package (from CodeArtifact) to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` using a Python 3.10 installation (for compatibility with Max)
     - `pip install deadline -t ~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts`
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@
 
 ### Disclaimer
 ---
-This GitHub repository is an example integration with AWS Deadline Cloud that is intended to only be used for testing and is subject to change. This code is an alpha release. It is not a commercial release and may contain bugs, errors, defects, or harmful components. Accordingly, the code in this repository is provided as-is. Use within a production environment is at your own risk!
+This GitHub repository is an example integration with AWS Deadline Cloud that is intended to only be used for testing and is subject to change. **This code is an alpha release. It is not a commercial release and may contain bugs, errors, defects, or harmful components.** Accordingly, the code in this repository is provided as-is. Use within a production environment is at your own risk!
 
 Our focus is to explore a variety of software applications to ensure we have good coverage across common workflows. We prioritized making this example available earlier to users rather than being feature complete.
+
+There are two open issues that prevent successful installation and rendering:
+* [Bug: Opening the 3ds Max Submitter fails with “runtime error : Failed to open file run_ui.py”](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/27)
+* [Bug: Adaptor freezes on launching 3ds Max](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/39)
 
 This example has been used by at least one internal or external development team to create a series of jobs that successfully rendered. However, your mileage may vary. If you have questions or issues with this example, please start a discussion or cut an issue.
 ---

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ AWS Deadline Cloud for 3ds Max is a python package that allows users to create [
 This library requires:
 
 1. 3ds Max 2024,
-1. Python 3.9 or higher; and
+1. Python 3.10 or higher; and
 1. Windows operating system.
 
 ## Submitter

--- a/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
+++ b/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
@@ -263,7 +263,7 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
 
         # PythonHost executes 3ds Max with scripts from cli
         self._max_client = LoggingSubprocess(
-            args=[max_exe, "-U", "PythonHost", self.max_client_path],
+            args=[max_exe, "-U", "PythonHost", self.max_client_path, "-silent", "-dm"],
             stdout_handler=regexhandler,
             stderr_handler=regexhandler,
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/39
https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/49

### What was the solution? (How)
* Fix documentation to reference python 3.10 instead of 3.9.
* Run 3dsMax using `-silent` and `-dm`.
https://help.autodesk.com/view/3DSMAX/2024/ENU/?guid=GUID-1A97CFEC-60A3-4221-B9C3-5C808E2AED35

### What is the impact of this change?
Unblock customers from using 3dsMax on CMF.

### How was this change tested?
* `hatch run test`
* Installed changes and submitted a job.

### Was this change documented?
N/A

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

<img width="1863" alt="Screenshot 2024-11-14 at 1 38 20 PM" src="https://github.com/user-attachments/assets/be7f2a5f-5e02-403c-bf16-da08958aa0e1">
