### PR TITLE
feat: Add 3dsMax executable environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ The 3ds Max Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface th
 * a standardized render application interface,
 * sticky rendering, where the application stays open between tasks,
 
-Jobs created by the submitter use this adaptor by default.
+Jobs created by the submitter use this adaptor by default, and require that both the installed adaptor
+and the 3dsMax executable be available on the PATH of the user that will be running your jobs.
+
+Or you can set the `3DSMAX_EXECUTABLE` to point to the 3dsMax executable.
 
 ### Getting Started
 
@@ -62,13 +65,13 @@ For more information on the commands the OpenJD adaptor runtime provides, see [h
 
 ## Versioning
 
-This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its 
+This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its
 initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how
 versions will increment during this initial development stage, they are described below:
 
-1. The MAJOR version is currently 0, indicating initial development. 
-2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
-3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
+1. The MAJOR version is currently 0, indicating initial development.
+2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API.
+3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API.
 
 ## Security
 

--- a/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
+++ b/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
@@ -241,7 +241,7 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
 
         :raises: FileNotFoundError: If the max_client.py file could not be found.
         """
-        max_exe = "3dsmax"
+        max_exe = os.environ,get("3DSMAX_EXECUTABLE", "3dsmax")
         regexhandler = RegexHandler(self._get_regex_callbacks())
 
         # Add the openjd namespace directory to PYTHONPATH, so that adaptor_runtime_client will be available

--- a/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
+++ b/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
@@ -241,7 +241,7 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
 
         :raises: FileNotFoundError: If the max_client.py file could not be found.
         """
-        max_exe = os.environ,get("3DSMAX_EXECUTABLE", "3dsmax")
+        max_exe = os.environ.get("3DSMAX_EXECUTABLE", "3dsmax")
         regexhandler = RegexHandler(self._get_regex_callbacks())
 
         # Add the openjd namespace directory to PYTHONPATH, so that adaptor_runtime_client will be available


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The assumption that the 3dsMax executable exists on the PATH doesn't always make sense, often it is easier to specify the version of 3dsMax to use by explicit path and using an environment variable is an easy way to do this for customers.

### What was the solution? (How)
We have defined a new environment variable 3DSMAX_EXECUTABLE which follows the naming from 
[`deadline-cloud-for-cinema-4d`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py#L298) of `<EXE_NAME>_EXECUTABLE`
### What is the impact of this change?
Additional functionality, non-breaking, adds the environment variable override but falls back to existing functionality
### How was this change tested?

### Was this change documented?
Yes added in the README.md

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
