### PR TITLE
chore(release): update semantic release template

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -8,16 +8,16 @@
         {% endfor %}
     {% endif %}
 
-    {% if "feature" in release["elements"] %}
+    {% if "features" in release["elements"] %}
 ### Features
-        {% for commit in release["elements"]["feature"] %}
+        {% for commit in release["elements"]["features"] %}
 * {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(": ")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
         {% endfor %}
     {% endif %}
 
-    {% if "fix" in release["elements"] %}
+    {% if "bug fixes" in release["elements"] %}
 ### Bug Fixes
-        {% for commit in release["elements"]["fix"] %}
+        {% for commit in release["elements"]["bug fixes"] %}
 * {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Release: bump action is failing because we recently upgraded `python-semantic-release` which has breaking changes that don't work with our template file

### What was the solution? (How)

Update template file to work on newer version

### What is the impact of this change?

Release process works again

### How was this change tested?

Tested locally by making the change then manually running `hatch env create release; hatch run release:deps; hatch run release:bump`. Resulting diff for CHANGELOG.md:

```
$ git status -vv
On branch mainline
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   CHANGELOG.md

--------------------------------------------------
Changes not staged for commit:
diff --git i/CHANGELOG.md w/CHANGELOG.md
index 32b8a29..f5df190 100644
--- i/CHANGELOG.md
+++ w/CHANGELOG.md
@@ -1,23 +1,31 @@
+## 0.1.2 (2024-12-12)
+
+
+### Features
+* Added Support for V-Ray 6 and V-Ray GPU 6 Renderers (#35) ([`8cea88e`](https://github.com/jericht/deadline-cloud-for-3ds-max/commit/8cea88ec48848c4f0324e5e63ba7d09dca5a2ac6))
+* Added Support for Corona Renderer (#34) ([`ff3c26f`](https://github.com/jericht/deadline-cloud-for-3ds-max/commit/ff3c26f52783164b63dfdb6cd74603738d765f9c))
+
+### Bug Fixes
+* Run 3dsMax in silent mode (#52) ([`59d1716`](https://github.com/jericht/deadline-cloud-for-3ds-max/commit/59d1716000dda7fbf41a3b81888ded550f04a780))
+
 ## 0.1.1 (2024-05-01)
 
-### Dependencies
-* Update deadline requirement from ==0.47.* to ==0.48.* (#23) ([`b45f444`](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/commit/b45f444c91d5655c7c5b8278973a540a349c2b5e))
+
 
 
 ## 0.1.0 (2024-04-02)
 
-### BREAKING CHANGES
-* public release (#11) ([`55d4c2f`](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/commit/55d4c2fbeeb76f036466f1754d2b0a205251d939))
 
+### Features
+* public release (#11) ([`55d4c2f`](https://github.com/jericht/deadline-cloud-for-3ds-max/commit/55d4c2fbeeb76f036466f1754d2b0a205251d939))
 
 
-## v0.0.1 (2024-03-26)
+## 0.0.1 (2024-03-26)
 
-### BREAKING CHANGES
-* initial integeration commit (#2) ([`873d2de`](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/commit/873d2ded6d1dfe1f590e9e3460bd76266954efc0))
 
+### Features
+* initial integeration commit (#2) ([`873d2de`](https://github.com/jericht/deadline-cloud-for-3ds-max/commit/873d2ded6d1dfe1f590e9e3460bd76266954efc0))
 
 ### Bug Fixes
-* added some missing install files, updated development readme, added job bundle test scaffolding (#5) ([`48a0170`](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/commit/48a0170de5b738c3abe3d8d416c23c10fa4aa618))
-
+* added some missing install files, updated development readme, added job bundle test scaffolding (#5) ([`48a0170`](https://github.com/jericht/deadline-cloud-for-3ds-max/commit/48a0170de5b738c3abe3d8d416c23c10fa4aa618))
 
no changes added to commit (use "git add" and/or "git commit -a")
```

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*