### PR TITLE
feat: Add support for 3dsmaxbatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ The 3ds Max Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface th
 * a standardized render application interface,
 * sticky rendering, where the application stays open between tasks,
 
-Jobs created by the submitter use this adaptor by default.
+Jobs created by the submitter use this adaptor by default, and require that both the installed adaptor
+and the 3dsMax executable be available on the PATH of the user that will be running the jobs.
+
+Alternatively, you can set the `3DSMAX_EXECUTABLE` environment variable to point to a 3dsMax executable.
+The adaptor supports both `3dsmax` and `3dsmaxbatch`.
 
 ### Getting Started
 

--- a/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
+++ b/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
@@ -16,10 +16,13 @@ from typing import Callable
 
 from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators, SemanticVersion
 from openjd.adaptor_runtime.adaptors.configuration import AdaptorConfiguration
-from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
+from openjd.adaptor_runtime.app_handlers import RegexHandler
 from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
 from openjd.adaptor_runtime.process import LoggingSubprocess
 from openjd.adaptor_runtime_client import Action
+
+from deadline.max_adaptor.executable_handler import MaxExecutableHandler
+from deadline.max_adaptor.MaxAdaptor.regex_callback_handler import MaxRegexCallback
 
 _logger = logging.getLogger(__name__)
 
@@ -58,7 +61,8 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
     _server: AdaptorServer | None = None
     _server_thread: threading.Thread | None = None
     _max_client: LoggingSubprocess | None = None
-    _action_queue = ActionsQueue()
+    _executable_handler: MaxExecutableHandler = MaxExecutableHandler()
+    _action_queue: ActionsQueue = ActionsQueue()
     _is_rendering: bool = False
 
     # If a thread raises an exception we will update this to raise in the main thread
@@ -162,22 +166,25 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
         _logger.debug("start max server thread")
         os.environ["MAX_ADAPTOR_SERVER_PATH"] = self._wait_for_socket()
 
-    def _get_regex_callbacks(self) -> list[RegexCallback]:
+    def _get_regex_callbacks(self) -> list[MaxRegexCallback]:
         """
-        Returns a list of RegexCallbacks used by the Max Adaptor
+        Returns a list of MaxRegexCallbacks used by the Max Adaptor
 
         :returns: List of Regex Callbacks to add
-        :return type: list[RegexCallback]
+        :return type: list[MaxRegexCallback]
         """
         callback_list = []
         completed_regexes = [re.compile("MaxClient: Finished Rendering Frame [0-9]+")]
-        progress_regexes = [re.compile("\\[PROGRESS\\] ([0-9]+) percent")]
+        progress_regexes = [
+            re.compile("\\[PROGRESS\\] ([0-9]+) percent"),
+            re.compile("Rendering Image Completed ([0-9]+) %"),
+        ]
         error_regexes = [re.compile(".*Exception:.*|.*Error:.*|.*Warning.*")]
 
-        callback_list.append(RegexCallback(completed_regexes, self._handle_complete))
-        callback_list.append(RegexCallback(progress_regexes, self._handle_progress))
+        callback_list.append(MaxRegexCallback(completed_regexes, self._handle_complete))
+        callback_list.append(MaxRegexCallback(progress_regexes, self._handle_progress))
         if self.init_data.get("strict_error_checking", False):
-            callback_list.append(RegexCallback(error_regexes, self._handle_error))
+            callback_list.append(MaxRegexCallback(error_regexes, self._handle_error))
 
         return callback_list
 
@@ -241,7 +248,6 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
 
         :raises: FileNotFoundError: If the max_client.py file could not be found.
         """
-        max_exe = "3dsmax"
         regexhandler = RegexHandler(self._get_regex_callbacks())
 
         # Add the openjd namespace directory to PYTHONPATH, so that adaptor_runtime_client will be available
@@ -263,7 +269,7 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
 
         # PythonHost executes 3ds Max with scripts from cli
         self._max_client = LoggingSubprocess(
-            args=[max_exe, "-U", "PythonHost", self.max_client_path, "-silent", "-dm"],
+            args=self._executable_handler.calculate_execution_parameters(self.max_client_path),
             stdout_handler=regexhandler,
             stderr_handler=regexhandler,
         )

--- a/src/deadline/max_adaptor/MaxAdaptor/regex_callback_handler.py
+++ b/src/deadline/max_adaptor/MaxAdaptor/regex_callback_handler.py
@@ -1,0 +1,25 @@
+"""
+3ds Max Deadline Cloud Adaptor - 3dsMax Regex Callback Handler
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+
+from __future__ import annotations
+import re
+from openjd.adaptor_runtime.app_handlers import RegexCallback
+
+
+class MaxRegexCallback(RegexCallback):
+
+    def __init__(
+        self, regex_list, callback, exit_if_matched=False, only_run_if_first_matched=False
+    ):
+        super().__init__(regex_list, callback, exit_if_matched, only_run_if_first_matched)
+
+    def get_match(self, msg: str) -> re.Match | None:
+        """
+        Takes care of a special case in 3dsMax, in which unexpected characters are added to executable output.
+        The rest of the functionality is the as in the parent class.
+        :param msg: The text to parse.
+        """
+        return super().get_match(msg.replace("\x00", ""))

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
@@ -13,6 +13,8 @@ import sys
 import pymxs  # noqa
 from pymxs import runtime as rt
 
+from deadline.max_adaptor.executable_handler import MaxExecutableHandler, SupportedMaxExecutable
+
 logger = logging.getLogger(__name__)
 
 # Re-assign sys stdout and stderr to print in the console instead of the Max Listener
@@ -37,6 +39,7 @@ class DefaultMaxHandler:
         self.output_dir = None
         self.output_name = None
         self.output_format = None
+        self._executable_handler: MaxExecutableHandler = MaxExecutableHandler()
 
     def start_render(self, data: dict) -> None:
         """
@@ -52,11 +55,11 @@ class DefaultMaxHandler:
         """
         frame = data.get("frame")
         if frame is None:
-            print("Error: MaxClient: start_render called without a frame number.")
+            self.log_to_console("Error: MaxClient: start_render called without a frame number.")
             raise RuntimeError("MaxClient: start_render called without a frame number.")
 
         if self.output_dir is None or self.output_name is None or self.output_format is None:
-            print(
+            self.log_to_console(
                 "Error: MaxClient: start_render called without a valid output path. Output directory, name or format "
                 "is missing."
             )
@@ -80,7 +83,7 @@ class DefaultMaxHandler:
 
         # Since camera can be set by both init and run data, this isn't a required parameter in either schema.
         if self.camera_node is None:
-            print("Error: MaxClient: start_render called without a camera.")
+            self.log_to_console("Error: MaxClient: start_render called without a camera.")
             raise RuntimeError("MaxClient: start_render called without a camera.")
 
         # Create output path to pass along with render
@@ -101,7 +104,7 @@ class DefaultMaxHandler:
 
         rt.render(camera=self.camera_node, outputFile=output_path)
 
-        print(f"MaxClient: Finished Rendering Frame {frame}\n", flush=True)
+        self.log_to_console(f"MaxClient: Finished Rendering Frame {frame}")
 
     def reformat_framenumber_padding(self, name: str, number: int) -> str:
         """
@@ -147,7 +150,7 @@ class DefaultMaxHandler:
         logger.debug("Setting camera with init data")
         camera_name = data.get("camera")
         if not camera_name:
-            print("No camera specified in init data")
+            self.log_to_console("No camera specified in init data")
             return
         camera = self.get_camera_to_render(camera_name)
         self.camera_node = rt.getNodeByName(camera)
@@ -167,7 +170,7 @@ class DefaultMaxHandler:
         camera_names = [camera.name for camera in cameras]
 
         if camera_name not in camera_names:
-            print(f"Error: The specified camera, {camera_name}, does not exist.")
+            self.log_to_console(f"Error: The specified camera, {camera_name}, does not exist.")
             raise RuntimeError(f"The specified camera, {camera_name}, does not exist.")
         return camera_name
 
@@ -247,7 +250,9 @@ class DefaultMaxHandler:
                 f"masterState.CurrentState = #(needState)"
             )
         except NameError:
-            print(f"Error: The specified state set, '{state_set_name}', does not exist.")
+            self.log_to_console(
+                f"Error: The specified state set, '{state_set_name}', does not exist."
+            )
             raise RuntimeError(f"The specified state set, '{state_set_name}', does not exist.")
 
         self.check_renderer()
@@ -264,11 +269,21 @@ class DefaultMaxHandler:
         logger.debug("opening max scene")
         file_path = data.get("scene_file", "")
         if not os.path.isfile(file_path):
-            print(f"Error: The scene file '{file_path}' does not exist")
+            self.log_to_console(f"Error: The scene file '{file_path}' does not exist")
             raise FileNotFoundError(f"Error: The scene file '{file_path}' does not exist")
         try:
             rt.SetQuietMode(True)
             rt.loadMaxFile(file_path, quiet=True)
         except Exception:
-            print(f"Error: while opening '{file_path}'")
+            self.log_to_console(f"Error: while opening '{file_path}'")
             raise RuntimeError(f"Error: while opening '{file_path}'")
+
+    def log_to_console(self, message: str) -> None:
+        """
+        Handles logging to the stdout, based on which 3dsMax executable is being used.
+        :param message: The text to log to the stdout.
+        """
+        if self._executable_handler.is_executable_type(SupportedMaxExecutable.BATCH):
+            rt.logsystem.logEntry(message, broadcast=True)
+        else:
+            print(message, flush=True)

--- a/src/deadline/max_adaptor/executable_handler.py
+++ b/src/deadline/max_adaptor/executable_handler.py
@@ -1,0 +1,81 @@
+"""
+3ds Max Deadline Cloud Adaptor - 3dsMax Executable Handler
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+
+from enum import Enum
+from os import environ
+from functools import cache
+import re
+from typing import List, Dict, Match, Optional
+from dataclasses import dataclass
+
+
+class SupportedMaxExecutable(Enum):
+    INTERACTIVE = "3dsmax"
+    BATCH = "3dsmaxbatch"
+
+
+@dataclass
+class MaxExecutable:
+    full_path: str
+    exe_type: SupportedMaxExecutable
+
+
+class MaxExecutableHandler:
+    """
+    Bussiness logic layer to take to facilitate supporting multiple 3dsMax executables.
+    """
+
+    def __init__(self):
+        # Execution configuration by executable type.
+        self._max_exe_parameters: Dict[SupportedMaxExecutable, List[str]] = {
+            SupportedMaxExecutable.INTERACTIVE: ["-silent", "-dm", "-U", "PythonHost"],
+            SupportedMaxExecutable.BATCH: ["-dm", "on", "-v", "5"],
+        }
+
+    @property
+    @cache
+    def max_executable(self) -> MaxExecutable:
+        """
+        The 3dsMax executable is determined on the fly, based on the 3DSMAX_EXECUTABLE environment variable.
+        If 3DSMAX_EXECUTABLE is not set, it defaults to '3dsmax'.
+        :returns: Data object containing the details of the 3dsMax executable.
+        :throws ValueError: If the value set in 3DSMAX_EXECUTABLE is not recognized as a valid 3dsMax executable.
+        """
+        max_exe_path: str = environ.get("3DSMAX_EXECUTABLE", "3dsmax")
+        pattern: str = r"[\\\/]?([^\\\/]+?)(\.exe)?$"
+
+        match: Optional[Match[str]] = re.search(pattern, max_exe_path)
+
+        if not match:
+            raise ValueError(f"Unable to get a 3dsMax executable from path {max_exe_path}")
+
+        max_exe: Optional[str] = match.group(1)
+        if any(max_exe == supported_max_exe.value for supported_max_exe in SupportedMaxExecutable):
+            return MaxExecutable(full_path=max_exe_path, exe_type=SupportedMaxExecutable(max_exe))
+
+        raise ValueError(
+            f"No valid 3dsMax executable was found in the provided path {max_exe_path}"
+        )
+
+    def calculate_execution_parameters(self, max_client_path: str) -> List[str]:
+        """
+        Provides the complete list of paratemers to run 3dsMax, in function of the configured executable.
+        :param max_client_path: The path of the client script to use with 3dsMax.
+        :returns: List of string tokens representing the parameters needed to run 3dsMax.
+        """
+        max_exe: MaxExecutable = self.max_executable
+        return [
+            max_exe.full_path,
+            *self._max_exe_parameters[max_exe.exe_type],
+            max_client_path,
+        ]
+
+    def is_executable_type(self, executable_type: SupportedMaxExecutable) -> bool:
+        """
+        Determines if the configured 3dsMax executable corresponds to the provided type.
+        :returns: True if the 3dsMax executable is equal to the provided executable type, False otherwise.
+        """
+        return self.max_executable.exe_type == executable_type

--- a/test/deadline_adaptor_for_3ds_max/unit/MaxAdaptor/test_regex_callback_handler.py
+++ b/test/deadline_adaptor_for_3ds_max/unit/MaxAdaptor/test_regex_callback_handler.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from deadline.max_adaptor.MaxAdaptor.regex_callback_handler import MaxRegexCallback
+from unittest.mock import patch, Mock
+
+
+class TestMaxRegexCallback:
+
+    @patch("deadline.max_adaptor.MaxAdaptor.regex_callback_handler.RegexCallback.get_match")
+    def test_get_match_removes_extra_characters(self, mock_regex_callback: Mock) -> None:
+        max_regex_callback: MaxRegexCallback = MaxRegexCallback([], None)
+
+        max_regex_callback.get_match("\x00\x00a\x00\x00\x00\x00\x00b\x00\x00\x00c\x00")
+
+        mock_regex_callback.assert_called_once_with("abc")

--- a/test/deadline_adaptor_for_3ds_max/unit/MaxClient/render_handlers/test_max_handler_base.py
+++ b/test/deadline_adaptor_for_3ds_max/unit/MaxClient/render_handlers/test_max_handler_base.py
@@ -1,8 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
+from unittest.mock import patch, Mock
 
 import pytest
 from deadline.max_adaptor.MaxClient.render_handlers import DefaultMaxHandler
+from deadline.max_adaptor.executable_handler import MaxExecutableHandler
 
 
 @pytest.fixture
@@ -37,3 +39,31 @@ class TestDefaultMaxHandler:
 
         # THEN
         assert maxhandlerbase.output_format == args["output_file_format"]
+
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt")
+    @patch.object(MaxExecutableHandler, "is_executable_type")
+    def test_log_to_console(
+        self,
+        mock_executable_handler: Mock,
+        mock_rt: Mock,
+        maxhandlerbase: DefaultMaxHandler,
+        capsys: pytest.CaptureFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_executable_handler.return_value = False
+        test_message_3dsmax: str = "3dsmax test message"
+
+        maxhandlerbase.log_to_console(test_message_3dsmax)
+
+        captured_result = capsys.readouterr()
+        assert captured_result.out == f"{test_message_3dsmax}\n"
+        assert not mock_rt.logsystem.logEntry.called
+
+        mock_executable_handler.return_value = True
+        test_message_3dsmaxbatch: str = "3dsmaxbatch test message"
+
+        maxhandlerbase.log_to_console(test_message_3dsmaxbatch)
+
+        captured_result = capsys.readouterr()
+        assert test_message_3dsmaxbatch not in captured_result.out
+        mock_rt.logsystem.logEntry.assert_called_once_with(test_message_3dsmaxbatch, broadcast=True)

--- a/test/deadline_adaptor_for_3ds_max/unit/test_executable_handler.py
+++ b/test/deadline_adaptor_for_3ds_max/unit/test_executable_handler.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from deadline.max_adaptor.executable_handler import (
+    MaxExecutableHandler,
+    SupportedMaxExecutable,
+)
+from unittest.mock import patch, Mock
+import pytest
+from typing import List
+
+
+class TestMaxExecutableHandler:
+
+    @pytest.mark.parametrize(
+        "max_exe_env_var,expected_max_exe",
+        [
+            ("3dsmax", "3dsmax"),
+            ("3dsmax.exe", "3dsmax"),
+            ("C:\\Users\\user1\\somedir\\3dsmax", "3dsmax"),
+            ("C:\\Users\\user1\somedir\\3dsmax.exe", "3dsmax"),
+            ("/users/user1/somedir/3dsmax.exe", "3dsmax"),
+            ("3dsmaxbatch", "3dsmaxbatch"),
+            ("3dsmaxbatch.exe", "3dsmaxbatch"),
+            ("C:\\Users\\user1\\somedir\\3dsmaxbatch", "3dsmaxbatch"),
+            ("C:\\Users\\user1\\somedir\\3dsmaxbatch.exe", "3dsmaxbatch"),
+            ("/users/user1/somedir/3dsmaxbatch.exe", "3dsmaxbatch"),
+        ],
+    )
+    @patch("deadline.max_adaptor.executable_handler.environ")
+    def test_executable_calculation_with_valid_exe_path(
+        self, mock_environ: Mock, max_exe_env_var: str, expected_max_exe: str
+    ) -> None:
+        mock_environ.get.return_value = max_exe_env_var
+        max_executable_handler: MaxExecutableHandler = MaxExecutableHandler()
+
+        assert max_executable_handler.max_executable.exe_type.value == expected_max_exe
+
+    @pytest.mark.parametrize(
+        "max_exe_env_var",
+        [
+            ("3dsma"),
+            ("3dsmax.ex"),
+            ("3dsmxbatch"),
+            ("3dsmxbatch.xe"),
+            (""),
+        ],
+    )
+    @patch("deadline.max_adaptor.executable_handler.environ")
+    def test_executable_calculation_with_invalid_exe_path(
+        self, mock_environ: Mock, max_exe_env_var: str
+    ) -> None:
+        mock_environ.get.return_value = max_exe_env_var
+        max_executable_handler: MaxExecutableHandler = MaxExecutableHandler()
+
+        with pytest.raises(ValueError):
+            max_executable_handler.max_executable
+
+    @pytest.mark.parametrize(
+        "max_exe",
+        [
+            ("3dsmax"),
+            ("3dsmaxbatch"),
+        ],
+    )
+    @patch("deadline.max_adaptor.executable_handler.environ")
+    def test_calculate_execution_parameters(self, mock_environ: Mock, max_exe: str) -> None:
+        mock_environ.get.return_value = max_exe
+        max_executable_handler: MaxExecutableHandler = MaxExecutableHandler()
+        expected_max_exe: SupportedMaxExecutable = SupportedMaxExecutable(max_exe)
+        max_client_path: str = "C:\\test\\max\\client\\path.py"
+
+        execution_parameters: List[str] = max_executable_handler.calculate_execution_parameters(
+            max_client_path
+        )
+
+        assert expected_max_exe.value in execution_parameters
+        assert max_client_path in execution_parameters
+        assert set(max_executable_handler._max_exe_parameters[expected_max_exe]).issubset(
+            set(execution_parameters)
+        )
+
+    @pytest.mark.parametrize(
+        "configured_max_exe, max_exe_to_check",
+        [
+            ("3dsmax", "3dsmax"),
+            ("3dsmax", "3dsmaxbatch"),
+            ("3dsmaxbatch", "3dsmax"),
+            ("3dsmaxbatch", "3dsmaxbatch"),
+        ],
+    )
+    @patch("deadline.max_adaptor.executable_handler.environ")
+    def test_is_executable_type(
+        self, mock_environ: Mock, configured_max_exe: str, max_exe_to_check: str
+    ) -> None:
+        mock_environ.get.return_value = configured_max_exe
+        max_executable_handler: MaxExecutableHandler = MaxExecutableHandler()
+        expected_result: bool = SupportedMaxExecutable(
+            configured_max_exe
+        ) == SupportedMaxExecutable(max_exe_to_check)
+
+        actual_result: bool = max_executable_handler.is_executable_type(
+            SupportedMaxExecutable(max_exe_to_check)
+        )
+
+        assert actual_result == expected_result


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want the 3dsMax adaptor to be able to use 3dsmaxbatch. However, when trying to use it, the adaptor would freeze without marking the tasks as complete.

### What was the solution? (How)
* Create MaxExecutableHandler to help support multiple 3dsMax executables.
* Create MaxRegexCallback to take care of removing unexpected characters from 3dsaxbatch.
* Update the progress regex to match the output from 3dsmaxbatch.
* Implement log_to_console() method in the DefaultMaxHandler class, to use a specific logging strategy in function of what 3dsMax executable is being used.

### What is the impact of this change?
3dsmaxbatch is supported.

### How was this change tested?
* Unit tests.
* Submitted jobs and validate they succeeded.

### Was this change documented?

### Is this a breaking change?
No
----

<img width="1651" alt="Screenshot 2025-01-23 at 10 26 32 AM" src="https://github.com/user-attachments/assets/2a8be8b2-19f4-4837-9b08-a1e9c556dae0" />

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*