### PR TITLE
chore: update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,12 +1,31 @@
 name: "\U0001F41B Bug Report"
 description: Report a bug
-title: "Bug: TITLE"
-labels: ["bug"]
+title: "Bug: (short bug description)"
+labels: ["bug", "needs triage"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report!
+
+        ⚠️ If the bug that you are reporting is a security-related issue or security vulnerability,
+        then please do not create a report via this template. Instead please
+        notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
+        or directly via email to [AWS Security](aws-security@amazon.com).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: What is the problem? A clear and concise description of the bug.
+    validations:
+      required: true
+
   - type: textarea
     id: expected_behaviour
     attributes:
       label: Expected Behaviour
+      description: What did you expect to happen?
     validations:
       required: true
 
@@ -14,6 +33,7 @@ body:
     id: current_behaviour
     attributes:
       label: Current Behaviour
+      description: What actually happened? Please include as much detail as you can.
     validations:
       required: true
 
@@ -21,13 +41,23 @@ body:
     id: reproduction_steps
     attributes:
       label: Reproduction Steps
+      description: |
+        Please provide as much detail as you can to help us understand how we can reproduce the bug.
+        Step by step instructions and self-contained code snippets are ideal.
     validations:
       required: true
 
   - type: textarea
-    id: code_snippet
+    id: environment
     attributes:
-      label: Code Snippet
+      label: Environment
+      description: Please provide information on the environment and software versions that you are using to reproduce the bug.
+      value: |
+        At minimum:
+        1. Operating system (e.g. Windows Server 2022; Amazon Linux 2023; etc.)
+        2. Version of 3ds Max
+        3. Version of this package
+
+        Please share other details about your environment that you think might be relevant to reproducing the bug.
     validations:
       required: true
-

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,8 +1,7 @@
-
 name: "📕 Documentation Issue"
 description: Issue in the documentation
-title: "Docs: TITLE"
-labels: ["documenation"]
+title: "Docs: (short description of the issue)"
+labels: ["documentation", "needs triage"]
 body:
   - type: textarea
     id: documentation_issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,17 +1,35 @@
 name: "\U0001F680 Feature Request"
 description: Request a new feature
-title: "Feature request: TITLE"
-labels: ["feature"]
+title: "Feature request: (short description of the feature)"
+labels: ["enhancement", "needs triage"]
 body:
   - type: textarea
-    id: use_case
+    id: problem
     attributes:
-      label: Use Case
+      label: Describe the problem
+      description: |
+        Help us understand the problem that you are trying to solve, and why it is important to you.
+        Provide as much detail as you are able.
     validations:
       required: true
+
   - type: textarea
     id: proposed_solution
     attributes:
       label: Proposed Solution
+      description: |
+        Describe your proposed feature that you see solving this problem for you. If you have a
+        full or partial prototype implementation then please open a draft pull request and link to
+        it here as well.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Example Use Cases
+      description: |
+        Provide some sample code snippets or shell scripts that show how **you** would use this feature as
+        you have proposed it.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,17 +1,19 @@
 name: "🛠️ Maintenance"
 description: Some type of improvement
-title: "Maintenance: TITLE"
-labels: ["feature"]
+title: "Maintenance: (short description of the issue)"
+labels: ["needs triage"]
 body:
   - type: textarea
     id: description
     attributes:
       label: Description
+      description: Describe the improvement and why it is important to do.
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
       label: Solution
+      description: Provide any ideas you have for how the suggestion can be implemented.
     validations:
       required: true


### PR DESCRIPTION
Updating the GitHub issue templates to be consistent with other aws-deadline repos.