### PR TITLE
docs: Remove the alpha disclaimer from the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,6 @@
 [![python](https://img.shields.io/pypi/pyversions/deadline-cloud-for-3ds-max.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-3ds-max)
 [![license](https://img.shields.io/pypi/l/deadline-cloud-for-3ds-max.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/blob/mainline/LICENSE)
 
-### Disclaimer
----
-This GitHub repository is an example integration with AWS Deadline Cloud that is intended to only be used for testing and is subject to change. **This code is an alpha release. It is not a commercial release and may contain bugs, errors, defects, or harmful components.** Accordingly, the code in this repository is provided as-is. Use within a production environment is at your own risk!
-
-Our focus is to explore a variety of software applications to ensure we have good coverage across common workflows. We prioritized making this example available earlier to users rather than being feature complete.
-
-This example has been used by at least one internal or external development team to create a series of jobs that successfully rendered. However, your mileage may vary. If you have questions or issues with this example, please start a discussion or cut an issue.
-
----
-
 AWS Deadline Cloud for 3ds Max is a python package that allows users to create [AWS Deadline Cloud][deadline-cloud] jobs from within 3ds Max. Using the [Open Job Description (OpenJD) Adaptor Runtime][openjd-adaptor-runtime] this package also provides a command line application that adapts 3ds Max's command line interface to support the [OpenJD specification][openjd].
 
 [deadline-cloud]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html
@@ -27,8 +17,8 @@ AWS Deadline Cloud for 3ds Max is a python package that allows users to create [
 
 This library requires:
 
-1. 3ds Max 2024,
-1. Python 3.10 or higher; and
+1. 3ds Max 2024.
+1. Python 3.10 or higher.
 1. Windows operating system.
 
 ## Submitter

--- a/test/unit/deadline_submitter_for_3ds_max/test_sanity_checks.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_sanity_checks.py
@@ -16,7 +16,7 @@ from deadline.max_submitter.sanity_checks import (
 from deadline.max_submitter.data_classes import RenderSubmitterUISettings
 
 
-@fixture(scope="session", autouse=True)
+@fixture(scope="function", autouse=True)
 def mock_max_utils():
     with patch("deadline.max_submitter.sanity_checks.max_utils") as mock_max_utils:
         mock_max_utils.get_camera_names.return_value = [
@@ -33,14 +33,14 @@ def mock_max_utils():
         yield mock_max_utils
 
 
-@fixture(scope="session", autouse=True)
+@fixture(scope="function", autouse=True)
 def mock_pymx_runtime():
     with patch("deadline.max_submitter.sanity_checks.rt") as mock_pymx_runtime:
         mock_pymx_runtime.renderers.current = ALLOWED_RENDERERS[0]
         yield mock_pymx_runtime
 
 
-@fixture
+@fixture(scope="function")
 def default_settings() -> RenderSubmitterUISettings:
     settings: RenderSubmitterUISettings = RenderSubmitterUISettings()
     settings.name = "test_job_name"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`deadline-cloud-for-3ds-max` now fulfills all the requirements to stop being an alpha release.

### What was the solution? (How)
Remove the disclaimer in the README file about this repo being an alpha release.

### What is the impact of this change?
De-alpha `deadline-cloud-for-3ds-max`.

### How was this change tested?
N/A

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*