### PR TITLE
chore: Set timeouts for the adaptor in the job template

### DIFF
--- a/src/deadline/max_submitter/default_max_job_template.yaml
+++ b/src/deadline/max_submitter/default_max_job_template.yaml
@@ -111,12 +111,14 @@ steps:
               - '{{Env.File.runStart}}'
             cancelation:
               mode: NOTIFY_THEN_TERMINATE
+            timeout: 87000
           onExit:
             command: powershell
             args:
               - '{{Env.File.runStop}}'
             cancelation:
               mode: NOTIFY_THEN_TERMINATE
+            timeout: 600
   script:
     actions:
       onRun:

--- a/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
@@ -123,12 +123,14 @@ steps:
           - '{{Env.File.runStart}}'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: powershell
           args:
           - '{{Env.File.runStop}}'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     actions:
       onRun:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/82

### What was the solution? (How)
Set timeouts for the adaptor in the job template 

### What is the impact of this change?
Add guardrails for better performance.

### How was this change tested?
* `hatch build && hatch run test && hatch run integ:test_submitters`

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*