### PR TITLE
feat: Add VRAY 7 support without gpu

### DIFF
--- a/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
@@ -27,6 +27,8 @@ def get_render_handler(renderer: str = "Default_Scanline_Renderer") -> DefaultMa
         return VrayHandler(gpu=False)
     elif renderer.startswith("V_Ray_GPU_6"):
         return VrayHandler(gpu=True)
+    elif renderer.startswith("V_Ray_7"):
+        return VrayHandler(gpu=False)
     elif renderer == "Redshift_Renderer":
         return RedshiftHandler()
     else:

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -25,6 +25,7 @@ ALLOWED_RENDERERS = [
     "Corona",
     "V_Ray_6",
     "V_Ray_GPU_6",
+    "V_Ray_7",
     "Redshift_Renderer",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Users are not able to render anything with VRAY 7 as it was not in the supported renderers. This resolves #90 

### What was the solution? (How)
Adding V_Ray_7 to the render handler and `ALLOWED_RENDERERS`

### What is the impact of this change?
This does not impact any existing functionality but adds support for customers to render using VRAY 7 

### How was this change tested?
I created a simple scene with a box, vray light, and vray camera. I submitted the job to my Customer Managed Fleet (CMF) and downloaded the completed render.
I know VRAY 7 has GPU support but I do not have a GPU to confirm the functionality works out of the box.

### Was this change documented?
This change was not documented. There is another issue asking for this documentation #101 

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*