### PR TITLE
docs: Improve manual instructions to install the submitter

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,3 +1,7 @@
+[deadline-cloud-monitor-setup]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#install-deadline-cloud-monitor
+[aws-cli-credentials]: https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-authentication.html
+[3ds-max-2024-folders-documentation]: https://help.autodesk.com/view/MAXDEV/2024/ENU/?guid=GUID-F7577416-051E-478C-BB5D-81243BAAC8EC
+
 # Development documentation
 This package has two active branches:
 
@@ -36,41 +40,29 @@ hatch run fmt
 hatch run all:test
 ```
 
-## Use development Submitter in 3ds Max
-
-```bash
-hatch run install
-hatch shell
-```
-Then launch 3ds Max from that terminal.
-
-A development version of deadline-cloud-for-3ds-max is then available to be loaded.
-
 ## Submitter Development Workflow
 
 WARNING: This workflow installs additional Python packages into your 3ds Max's python distribution.
 
 #### Manual installation
 
-1. Build your local copy of `deadline-cloud-for-3ds-max`.
-1. To install the submitter in 3dsMax:
-    1. Copy `STDCMenuCreator.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`)
-    1. Copy `AWSDeadline-SubmitToDeadlineCloud.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
-1. The point of entry for the submitter is the `run_ui.py` file under the `max_submitter` folder. Thus, this file needs to be discoverable by 3dsMax, and `max_submitter` needs to be a discoverable package by python.
-    1. Add the path to `max_submitter` to the `ADSK_3DSMAX_SCRIPTS_ADDON_DIR` environment variable (e.g. In Powershell run `$env:ADSK_3DSMAX_SCRIPTS_ADDON_DIR += "C:\Users\<username>\workplace\deadline-cloud-for-3ds-max\src\deadline\max_submitter"`).
-    1. Add the path to `max_submitter` to the `PYTHONPATH` environment variable (e.g. In Powershell run `$env:PYTHONPATH += "C:\Users\<username>\workplace\deadline-cloud-for-3ds-max\src\deadline\max_submitter"`).
-1. Install `deadline` package to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts`, using a python version that is compatible with the version of 3dsMax that you are using (e.g. For 3dsMax 2024 run `pip install deadline --python-version 3.10 --only-binary=:all: -t $env:HOMEPATH\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` in Powershell).
-1. Run `3dsmax` from the same command-line window where the environment variables were set. To do so, `3dsmax` needs to be part of the PATH (e.g. In Powershell run `$env:PATH += ";C:\Program Files\Autodesk\<version>"`).
-
-#### Install for Development
-
-1. Copy `STDCMenuCreator.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`).
-2. Modify the file path in `STDCMenuCreator.ms`  to `<reporoot>/src/deadline/max_submitter`. Set the `DEBUG` variable to `true`.
-3. Put `AWSDeadline-SubmitToDeadlineCloud.mcr` and `AWSDeadline-RunJobBundleTests.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
-4. Modify the path in `AWSDeadline-SubmitToDeadlineCloud.mcr` to `<reporoot>/src/deadline/max_submitter/run_ui.py`. Set the `DEBUG` variable to `true`.
-5. Modify the path in `AWSDeadline-RunJobBundleTests.mcr` to `<reporoot>/src/deadline/max_submitter/job_bundle_output_test_runner.py`. Set the `DEBUG` variable to `true`.
-6. Install `deadline` package (from CodeArtifact) to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` using a Python 3.10 installation (for compatibility with Max)
-    - `pip install deadline -t ~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts`
+1. Clone `deadline-cloud-for-3ds-max`, and build your local copy running `hatch build`.
+1. To install the submitter in 3dsMax, you need to copy the UI components into the corresponding 3ds Max installation directories. You can find the UI component files in your local copy of `deadline-cloud-for-3ds-max`.
+    1. Copy `<LOCAL_REPO_PATH>\install_files\STDCMenuCreator.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`, more details about 3ds Max system directories can be found in the 3ds Max [documentation][3ds-max-2024-folders-documentation])
+    1. Copy `<LOCAL_REPO_PATH>\install_files\AWSDeadline-SubmitToDeadlineCloud.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
+1. The point of entry for the submitter is the `run_ui.py` file under the `max_submitter` folder. Thus, this file needs to be discoverable by 3dsMax, and `max_submitter` needs to be a discoverable package by python. In Powershell run:
+    1. `$env:ADSK_3DSMAX_SCRIPTS_ADDON_DIR += ";<LOCAL_REPO_PATH>\src\deadline\max_submitter"`.
+    1. `$env:PYTHONPATH += ";<LOCAL_REPO_PATH>\src\;<LOCAL_REPO_PATH>\src\deadline\max_submitter"`.
+1. Install `deadline` package to `~\DeadlineCloudSubmitter\Submitters\3dsMax\scripts`, using a python version that is compatible with the version of 3dsMax that you are using. In Powershell run:
+    1. `& "C:\Program Files\Autodesk\<version>\Python\python.exe" -m ensurepip`
+    1. `& "C:\Program Files\Autodesk\<version>\Python\python.exe" -m pip install deadline -t $env:HOMEPATH\DeadlineCloudSubmitter\Submitters\3dsMax\scripts` 
+1. Run `3dsmax` from the same command-line window where the environment variables were set. To do so, `3dsmax` needs to be part of the PATH. In Powershell run `$env:PATH += ";C:\Program Files\Autodesk\<version>"`.
+1. To supply AWS account credentials for the submitter to use when submitting a job you can either:
+    1. [Install and set up the Deadline Cloud Monitor][deadline-cloud-monitor-setup], and then log in to the monitor. Logging in
+       to the monitor will make AWS credentials available to the submitter, automatically.
+    1. Set up an AWS credentials profile [as you would for the AWS CLI][aws-cli-credentials], and select that profile for the submitter
+       to use.
+    1. Or default to your AWS EC2 instance profile credentials if you are running a workstation in the cloud.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,25 @@ This library requires:
 1. Python 3.10 or higher.
 1. Windows operating system.
 
+## Getting Started
+
+This 3ds Max integration for AWS Deadline Cloud has two components that you will need to install:
+
+1. The 3ds Max submitter plug-in must be installed on the workstation that you will use to submit jobs; and
+2. The 3ds Max adaptor must be installed on all of your AWS Deadline Cloud worker hosts that will be running the 3ds Max jobs that you submit.
+
+Before submitting any large, complex, or otherwise compute-heavy 3ds Max render jobs to your farm using the submitter and adaptor that you
+set up, we strongly recommend that you construct a simple test scene that can be rendered quickly and submit renders of that
+scene to your farm to ensure that your setup is correctly functioning.
+
 ## Submitter
 
-This package provides a 3ds Max plugin that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
+The 3ds Max submitter plug-in creates a shelf button in your 3ds Max UI that can be used to submit jobs to AWS Deadline Cloud. Clicking this button
+reveals a UI to create a job submission for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client].
+It automatically determines the files required based on the loaded scene, allows the user to specify render options, builds an
+[Open Job Description template][openjd] that defines the workflow, and submits the job to the farm and queue of your choosing.
+
+We are working on implementing a submitter installer for 3ds Max to automate the submitter installation. In the meantime, the submitter needs to be installed manually. To install the submitter follow the instructions [here](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/blob/mainline/DEVELOPMENT.md#manual-installation).
 
 ## Adaptor
 
@@ -36,8 +52,6 @@ and the 3dsMax executable be available on the PATH of the user that will be runn
 
 Alternatively, you can set the `3DSMAX_EXECUTABLE` environment variable to point to a 3dsMax executable.
 The adaptor supports both `3dsmax` and `3dsmaxbatch`.
-
-### Getting Started
 
 The adaptor can be installed by the standard python packaging mechanisms:
 ```sh


### PR DESCRIPTION
Solves: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/77

### What was the problem/requirement? (What/Why)
The instructions to manually install the submitter are not clear enough.

### What was the solution? (How)
* Update the submitter information in the README file.
* Add more specific information to the manual installation instructions in the DEVELOPMENT file.

### What is the impact of this change?
Better documentation to make the installer easier to install.

### How was this change tested?
N/A

### Was this change documented?
Yes.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*