### PR TITLE
feat: Add submitter support for 3dsMax 2025+

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,7 +48,7 @@ WARNING: This workflow installs additional Python packages into your 3ds Max's p
 
 1. Clone `deadline-cloud-for-3ds-max`, and build your local copy running `hatch build`.
 1. To install the submitter in 3dsMax, you need to copy the UI components into the corresponding 3ds Max installation directories. You can find the UI component files in your local copy of `deadline-cloud-for-3ds-max`.
-    1. Copy `<LOCAL_REPO_PATH>\install_files\STDCMenuCreator.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`, more details about 3ds Max system directories can be found in the 3ds Max [documentation][3ds-max-2024-folders-documentation])
+    1. Copy `<LOCAL_REPO_PATH>\install_files\STDCMenuCreator_v#.ms` into your 3DS Max startup scripts (e.g. `C:\Program Files\Autodesk\<version>\scripts\Startup`, more details about 3ds Max system directories can be found in the 3ds Max [documentation][3ds-max-2024-folders-documentation]). For 3ds Max 2024 use `STDCMenuCreator_v0.ms`. For 3ds Max 2025+ use `STDCMenuCreator_v1.ms`.
     1. Copy `<LOCAL_REPO_PATH>\install_files\AWSDeadline-SubmitToDeadlineCloud.mcr` in 3ds Max usermacros directory (e.g. `C:\Users\<username>\AppData\Local\Autodesk\3dsMax\<version>\ENU\usermacros`).
 1. The point of entry for the submitter is the `run_ui.py` file under the `max_submitter` folder. Thus, this file needs to be discoverable by 3dsMax, and `max_submitter` needs to be a discoverable package by python. In Powershell run:
     1. `$env:ADSK_3DSMAX_SCRIPTS_ADDON_DIR += ";<LOCAL_REPO_PATH>\src\deadline\max_submitter"`.

--- a/install_files/STDCMenuCreator_v0.ms
+++ b/install_files/STDCMenuCreator_v0.ms
@@ -1,4 +1,5 @@
 -- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+-- Compatibility: 3ds Max 2024
 (
 	-- change to true for development install
 	local DEBUG = false

--- a/install_files/STDCMenuCreator_v1.ms
+++ b/install_files/STDCMenuCreator_v1.ms
@@ -1,0 +1,55 @@
+-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+-- Compatibility: 3ds Max 2025+
+
+-- Function to create the AWS Deadline menu
+function createDeadlineCloudMenu =
+(
+    -- Get the menu manager from the callback parameter
+    local menuMgr = callbacks.notificationParam()
+    local mainMenuBar = menuMgr.mainMenuBar
+    
+    -- No need to check for existing menu - the CreateSubMenu will handle it
+    -- If a menu with the same GUID already exists, it will be replaced
+    
+    -- Create a new AWS Deadline menu with a unique GUID
+    -- Using a fixed GUID ensures consistency across sessions
+    local deadlineCloudMenuGUID = "F8FFB827-741C-4A81-8C89-BBF856DCF56D"
+    local deadlineCloudMenu = mainMenuBar.CreateSubMenu deadlineCloudMenuGUID "AWS Deadline"
+    
+    -- Define menu items with their GUIDs
+    local menuItems = #()
+    
+    -- Add the Submit to Deadline Cloud menu item
+    local submitActionGUID = "6AC5FDFE-2AF7-4069-8493-D8A1462F4E7F"
+    -- MacroScript action table ID is 647394
+    local macroScriptActionTableID = 647394
+    
+    -- Create the Submit to Deadline Cloud action
+    deadlineCloudMenu.CreateAction submitActionGUID macroScriptActionTableID "SubmitToDeadlineCloud`DeadlineCloud" title:"Submit to Deadline Cloud"
+    
+    -- Add the Test Job Bundle Output menu item if in DEBUG mode
+    local DEBUG = false
+    if DEBUG do
+    (
+        local testJobBundleGUID = "A2B3C4D5-E6F7-8901-2345-6789ABCDEF01"
+        deadlineCloudMenu.CreateAction testJobBundleGUID macroScriptActionTableID "TestJobBundleOutput`DeadlineCloud" title:"Run Job Bundle Tests"
+    )
+    
+    -- Python script to add repo path to max script locations
+    python.Execute "import sys"
+    python.Execute "import os"
+    python.Execute "sys.path.append(os.path.expanduser(r'~\\DeadlineCloudSubmitter\\Submitters\\3dsMax\\scripts'))"
+    
+    if DEBUG do
+    (
+        -- change to <reporoot>/src/deadline/max_submitter
+        -- TODO: Update to find local dev repo
+        python.Execute "sys.path.append(r'C:\\Workspace\\deadline-cloud-for-3ds-max\\src\\deadline\\max_submitter')"
+    )
+)
+
+-- Remove any existing callback with the same ID to avoid duplicates
+callbacks.removeScripts id:#deadlineCloudMenu
+
+-- Register the callback to create menus when 3ds Max loads menus
+callbacks.addScript #cuiRegisterMenus createDeadlineCloudMenu id:#deadlineCloudMenu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 # 2024 - 3.9: https://help.autodesk.com/view/MAXDEV/2024/ENU/?guid=MAXDEV_Python_about_the_3ds_max_python_api_html
 
 dependencies = [
-    "deadline == 0.49.*",
+    "deadline == 0.50.*",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 
@@ -85,8 +85,11 @@ namespace_packages = true
 explicit_package_bases = true
 mypy_path = "src"
 
-# [[tool.mypy.overrides]]
-# module = ["PySide2.*"]
+[[tool.mypy.overrides]]
+module = [
+  "pymxs.*",
+  "qtpy.*"
+]
 
 # --- RUFF / BLACK ---
 

--- a/src/deadline/max_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/max_submitter/job_bundle_output_test_runner.py
@@ -20,7 +20,7 @@ from deadline.client.ui import gui_error_handler
 from deadline.client.ui.dialogs import submit_job_to_deadline_dialog
 from max_render_submitter import show_job_bundle_submitter
 from pymxs import runtime as rt
-from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
+from qtpy.QtWidgets import (  # type: ignore
     QApplication,
     QFileDialog,
     QMessageBox,

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -26,7 +26,7 @@ from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.ui.dialogs._types import JobBundlePurpose
 from pymxs import runtime as rt
-from PySide2.QtCore import Qt
+from qtpy.QtCore import Qt  # type: ignore
 from sanity_checks import check_sanity
 from ui.scene_settings_tab import SceneSettingsWidget
 from ui.submit_dialog import SubmitMaxJobToDeadlineDialog

--- a/src/deadline/max_submitter/run_ui.py
+++ b/src/deadline/max_submitter/run_ui.py
@@ -9,7 +9,7 @@ from logging import root
 from deadline.client.config import config_file
 from max_render_submitter import show_job_bundle_submitter
 from pymxs import runtime as rt
-from PySide2.QtWidgets import QMessageBox
+from qtpy.QtWidgets import QMessageBox  # type: ignore
 from utilities.log_utils import configure_logging
 
 

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -17,9 +17,9 @@ from deadline.max_submitter.data_const import (
 )
 from deadline.client.ui import block_signals
 from pymxs import runtime as rt
-from PySide2.QtCore import QRegularExpression, QSize, Qt  # type: ignore
-from PySide2.QtGui import QRegularExpressionValidator
-from PySide2.QtWidgets import (  # type: ignore
+from qtpy.QtCore import QRegularExpression, QSize, Qt  # type: ignore
+from qtpy.QtGui import QRegularExpressionValidator  # type: ignore
+from qtpy.QtWidgets import (  # type: ignore
     QApplication,
     QCheckBox,
     QComboBox,
@@ -56,7 +56,6 @@ class FileSearchLineEdit(QWidget):
 
         lyt = QHBoxLayout(self)
         lyt.setContentsMargins(0, 0, 0, 0)
-        lyt.setMargin(0)
 
         self.edit = QLineEdit(self)
         self.btn = QPushButton("...", parent=self)
@@ -526,13 +525,13 @@ class SceneSettingsWidget(QWidget):
         """
         Set the activated/deactivated status of the Frame override text box
         """
-        self.frame_override_txt.setEnabled(state == Qt.Checked)
+        self.frame_override_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)
 
     def activate_custom_material_changed(self, state):
         """
         Set the activated/deactivated status of the Custom material combo box
         """
-        self.custom_mat_box.setEnabled(state == Qt.Checked)
+        self.custom_mat_box.setEnabled(Qt.CheckState(state) == Qt.Checked)
 
     def _update_renderer(self):
         """

--- a/test/unit/deadline_submitter_for_3ds_max/__init__.py
+++ b/test/unit/deadline_submitter_for_3ds_max/__init__.py
@@ -5,11 +5,11 @@ from unittest.mock import MagicMock
 mock_modules = [
     "deadline.client.ui.deadline_authentication_status",
     "pymxs",
-    "PySide2",
-    "PySide2.QtCore",
-    "PySide2.QtGui",
-    "PySide2.QtWidgets",
     "qtmax",
+    "qtpy",
+    "qtpy.QtCore",
+    "qtpy.QtWidgets",
+    "qtpy.QtGui",
 ]
 
 for module in mock_modules:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/102

### What was the problem/requirement? (What/Why)
3dsMax 2025 has a couple of changes that affected the submitter: 1) The Max Script mechanism to handle menus changed, 2) Upgrade from PySide2 to PySide6.

### What was the solution? (How)
* Create a new version of the menu with the new syntax.
* Remove direct references to PySide2.

### What is the impact of this change?
Submitter support for 3dsMax 2025+

### How was this change tested?
* Submitted job successfully from 3dsMax 2024 and 2025.
* Ran integ tests: `hatch run integ:test`
```
================================================= 2 passed in 56.38s ==================================================
```

### Was this change documented?
Yes

### Is this a breaking change?
No

<img width="638" alt="Screenshot 2025-06-17 at 6 11 54 PM" src="https://github.com/user-attachments/assets/edc22c14-9e0f-493b-856f-f6e89f735a9a" />

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*