### PR TITLE
chore: Implement build installer workflow

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -1,0 +1,40 @@
+name: Build Installers
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        required: true
+        default: Windows
+        type: choice
+        options:
+        - Windows
+      ref_type:
+        required: true
+        default: heads
+        type: choice
+        options:
+        - tags
+        - heads
+      ref:
+        required: true
+        type: string
+        default: mainline
+      environment:
+        required: true
+        type: choice
+        options:
+        - mainline
+
+jobs:
+  BuildInstaller:
+    if: (github.repository == 'aws-deadline/deadline-cloud-for-3ds-max')
+    name: Build Installer
+    uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
+    secrets: inherit
+    with:
+      environment: ${{inputs.environment}}
+      ref_type: ${{inputs.ref_type}}
+      ref: ${{inputs.ref}}
+      oses: "['${{inputs.os}}']"
+      project_name: deadline-cloud-for-3ds-max

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -44,6 +44,18 @@ jobs:
       with:
           tag: ${{ needs.TagRelease.outputs.tag }}
 
+  BuildAndStageInstallers:
+    needs: [TagRelease, PreRelease]
+    uses: aws-deadline/.github/.github/workflows/reusable_build_and_stage_installers.yml@mainline
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      project_name: ${{ github.event.repository.name }}
+      tag: ${{ needs.TagRelease.outputs.tag }}
+      oses: "['Windows']"
+
   Release:
       needs: [TagRelease, PreRelease]
       uses: aws-deadline/.github/.github/workflows/reusable_release.yml@mainline

--- a/pipeline/build_installer.ps1
+++ b/pipeline/build_installer.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = "Stop"
+
+hatch run installer:build-installer @args

--- a/pipeline/build_installer.sh
+++ b/pipeline/build_installer.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Set the -e option
+set -e
+
+hatch run installer:build-installer $@

--- a/pipeline/test_installer.ps1
+++ b/pipeline/test_installer.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = "Stop"
+
+hatch run test-installer

--- a/pipeline/test_installer.sh
+++ b/pipeline/test_installer.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Set the -e option
+set -e
+
+hatch run test-installer


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We recently implemented the 3dsMax individual submitter installer. We need to integrate the individual installer with the Deadline Cloud shared installer.

### What was the solution? (How)
* Create a `build_installer` workflow.
* Update the release workflow to run `build_installer`. 

### What is the impact of this change?
The 3dsMax installer is now available in the shared installer.

### How was this change tested?
* Build the individual installer.
* Manually built the share installer including the 3dsMax individual installer.
* Ran the `build_installer` workflow against a build pipeline in my dev account.  

### Was this change documented?
N/A

### Is this a breaking change?
No

<img width="554" alt="Screenshot 2025-06-25 at 2 30 53 PM" src="https://github.com/user-attachments/assets/89895480-e9fc-4086-81b0-aee2b1f1cb0f" />

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*