### PR TITLE
docs: update readme and comments to reflect support for 3dsmax 2025 and 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AWS Deadline Cloud for 3ds Max is a python package that allows users to create [
 
 This library requires:
 
-1. 3ds Max 2024.
+1. 3ds Max 2024, 2025, 2026.
 1. Python 3.10 or higher.
 1. Windows operating system.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,10 @@ classifiers = [
   "Intended Audience :: End Users/Desktop",
 ]
 # Python versions:
-# 2023 - 3.9: https://help.autodesk.com/view/MAXDEV/2023/ENU/?guid=MAXDEV_Python_about_the_3ds_max_python_api_html
-# 2024 - 3.9: https://help.autodesk.com/view/MAXDEV/2024/ENU/?guid=MAXDEV_Python_about_the_3ds_max_python_api_html
+# 2023 - 3.9: https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=MAXDEV_Python_what_s_new_in_3ds_max_python_api_html
+# 2024 - 3.10: https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=MAXDEV_Python_what_s_new_in_3ds_max_python_api_html
+# 2025 - 3.11: https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=MAXDEV_Python_what_s_new_in_3ds_max_python_api_html
+# 2026 - 3.11: https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=MAXDEV_Python_what_s_new_in_3ds_max_python_api_html
 
 dependencies = [
     "deadline == 0.50.*",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- We have updated 3dsmax components to work with 3dsmax 2025 and 2026. However our docs do not state that we support 2025 and 2026.

### What was the solution? (How)
- Update some docs!

### What is the impact of this change?
- Better documentation

### How was this change tested?
- NA, docs only

### Was this change documented?
- Yes, this is a docs change.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*