### PR TITLE
chore: add native dependency psutil to deps bundle

### DIFF
--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
 import re
@@ -11,7 +12,7 @@ from typing import Any
 
 SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
 SUPPORTED_PLATFORMS = ["win_amd64"]
-NATIVE_DEPENDENCIES = ["xxhash"]
+NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
 
 
 def _get_project_dict() -> dict[str, Any]:

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -94,6 +94,7 @@ def _validate_files(installation_path: Path) -> None:
     assert "deadline" in module_dir
     assert "qtpy" in module_dir
     assert "xxhash" in module_dir
+    assert "psutil" in module_dir
 
     # Check the 3ds Max module is here and there's a version file
     max_submitter_dir = [f.name for f in (python_dir / "deadline" / "max_submitter").iterdir()]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We added a new dependency psutil to deadine-cloud https://github.com/aws-deadline/deadline-cloud/blob/e5176598cc859584217eaea00d5e6a14a40070d5/pyproject.toml#L47 for a new feature in experimental. This dependency has native components and needs to be added to deps bundle for every installer

### What was the solution? (How)
Added psutil to native dependencies for the feature to be supported.

### What is the impact of this change?
Bundling required dependencies for every submitter installer

### How was this change tested?
Built the installer manually and installed the submitter for windows.
```
hatch run installer:build-installer --local-dev --install-builder-path "C:\\Program Files\\InstallBuilder Enterprise 25.6.0\\" --output-dir .
cwd: C:\Users\sakshie\workplace\deadline-cloud-for-3ds-max
working directory: C:\Users\sakshie\AppData\Local\Temp\tmpf5k7fzsz
Collecting deadline==0.50.*
  Using cached deadline-0.50.1-py3-none-any.whl.metadata (13 kB)
Collecting boto3>=1.36.8 (from deadline==0.50.*)
  Using cached boto3-1.39.5-py3-none-any.whl.metadata (6.6 kB)
Collecting click>=8.1.7 (from deadline==0.50.*)
  Using cached click-8.2.1-py3-none-any.whl.metadata (2.5 kB)
Collecting jsonschema<5.0,>=4.17 (from deadline==0.50.*)
  Using cached jsonschema-4.24.0-py3-none-any.whl.metadata (7.8 kB)
Collecting psutil>=7.0.0 (from deadline==0.50.*)
  Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl.metadata (23 kB)
Collecting pywin32<311,>=307 (from deadline==0.50.*)
  Using cached pywin32-310-cp312-cp312-win_amd64.whl.metadata (9.4 kB)
Collecting pyyaml>=6.0 (from deadline==0.50.*)
  Using cached PyYAML-6.0.2-cp312-cp312-win_amd64.whl.metadata (2.1 kB)
Collecting qtpy==2.4.* (from deadline==0.50.*)
  Using cached QtPy-2.4.3-py3-none-any.whl.metadata (12 kB)
Collecting typing-extensions>=4.8 (from deadline==0.50.*)
  Using cached typing_extensions-4.14.1-py3-none-any.whl.metadata (3.0 kB)
Collecting xxhash<3.6,>=3.4 (from deadline==0.50.*)
  Using cached xxhash-3.5.0-cp312-cp312-win_amd64.whl.metadata (13 kB)
Collecting attrs>=22.2.0 (from jsonschema<5.0,>=4.17->deadline==0.50.*)
  Using cached attrs-25.3.0-py3-none-any.whl.metadata (10 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema<5.0,>=4.17->deadline==0.50.*)
  Using cached jsonschema_specifications-2025.4.1-py3-none-any.whl.metadata (2.9 kB)
Collecting referencing>=0.28.4 (from jsonschema<5.0,>=4.17->deadline==0.50.*)
  Using cached referencing-0.36.2-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.7.1 (from jsonschema<5.0,>=4.17->deadline==0.50.*)
  Using cached rpds_py-0.26.0-cp312-cp312-win_amd64.whl.metadata (4.3 kB)
Collecting packaging (from qtpy==2.4.*->deadline==0.50.*)
  Using cached packaging-25.0-py3-none-any.whl.metadata (3.3 kB)
Collecting botocore<1.40.0,>=1.39.5 (from boto3>=1.36.8->deadline==0.50.*)
  Using cached botocore-1.39.5-py3-none-any.whl.metadata (5.7 kB)
Collecting jmespath<2.0.0,>=0.7.1 (from boto3>=1.36.8->deadline==0.50.*)
  Using cached jmespath-1.0.1-py3-none-any.whl.metadata (7.6 kB)
Collecting s3transfer<0.14.0,>=0.13.0 (from boto3>=1.36.8->deadline==0.50.*)
  Using cached s3transfer-0.13.0-py3-none-any.whl.metadata (1.7 kB)
Collecting python-dateutil<3.0.0,>=2.1 (from botocore<1.40.0,>=1.39.5->boto3>=1.36.8->deadline==0.50.*)
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting urllib3!=2.2.0,<3,>=1.25.4 (from botocore<1.40.0,>=1.39.5->boto3>=1.36.8->deadline==0.50.*)
  Using cached urllib3-2.5.0-py3-none-any.whl.metadata (6.5 kB)
Collecting six>=1.5 (from python-dateutil<3.0.0,>=2.1->botocore<1.40.0,>=1.39.5->boto3>=1.36.8->deadline==0.50.*)
  Using cached six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Collecting colorama (from click>=8.1.7->deadline==0.50.*)
  Using cached colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
Using cached deadline-0.50.1-py3-none-any.whl (278 kB)
Using cached jsonschema-4.24.0-py3-none-any.whl (88 kB)
Using cached pywin32-310-cp312-cp312-win_amd64.whl (9.5 MB)
Using cached QtPy-2.4.3-py3-none-any.whl (95 kB)
Using cached xxhash-3.5.0-cp312-cp312-win_amd64.whl (30 kB)
Using cached attrs-25.3.0-py3-none-any.whl (63 kB)
Using cached boto3-1.39.5-py3-none-any.whl (139 kB)
Using cached botocore-1.39.5-py3-none-any.whl (13.8 MB)
Using cached jmespath-1.0.1-py3-none-any.whl (20 kB)
Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Using cached s3transfer-0.13.0-py3-none-any.whl (85 kB)
Using cached urllib3-2.5.0-py3-none-any.whl (129 kB)
Using cached click-8.2.1-py3-none-any.whl (102 kB)
Using cached jsonschema_specifications-2025.4.1-py3-none-any.whl (18 kB)
Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl (244 kB)
Using cached PyYAML-6.0.2-cp312-cp312-win_amd64.whl (156 kB)
Using cached referencing-0.36.2-py3-none-any.whl (26 kB)
Using cached rpds_py-0.26.0-cp312-cp312-win_amd64.whl (234 kB)
Using cached six-1.17.0-py2.py3-none-any.whl (11 kB)
Using cached typing_extensions-4.14.1-py3-none-any.whl (43 kB)
Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Using cached packaging-25.0-py3-none-any.whl (66 kB)
Installing collected packages: pywin32, xxhash, urllib3, typing-extensions, six, rpds-py, pyyaml, psutil, packaging, jmespath, colorama, attrs, referencing, qtpy, python-dateutil, click, jsonschema-specifications, botocore, s3transfer, jsonschema, boto3, deadline
Successfully installed attrs-25.3.0 boto3-1.39.5 botocore-1.39.5 click-8.2.1 colorama-0.4.6 deadline-0.50.1 jmespath-1.0.1 jsonschema-4.24.0 jsonschema-specifications-2025.4.1 packaging-25.0 psutil-7.0.0 python-dateutil-2.9.0.post0 pywin32-310 pyyaml-6.0.2 qtpy-2.4.3 referencing-0.36.2 rpds-py-0.26.0 s3transfer-0.13.0 six-1.17.0 typing-extensions-4.14.1 urllib3-2.5.0 xxhash-3.5.0
Collecting xxhash==3.5.0
  Using cached xxhash-3.5.0-cp39-cp39-win_amd64.whl.metadata (13 kB)
Collecting psutil==7.0.0
  Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl.metadata (23 kB)
Using cached xxhash-3.5.0-cp39-cp39-win_amd64.whl (30 kB)
Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl (244 kB)
Installing collected packages: xxhash, psutil
Successfully installed psutil-7.0.0 xxhash-3.5.0
Collecting xxhash==3.5.0
  Using cached xxhash-3.5.0-cp310-cp310-win_amd64.whl.metadata (13 kB)
Collecting psutil==7.0.0
  Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl.metadata (23 kB)
Using cached xxhash-3.5.0-cp310-cp310-win_amd64.whl (30 kB)
Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl (244 kB)
Installing collected packages: xxhash, psutil
Successfully installed psutil-7.0.0 xxhash-3.5.0
Collecting xxhash==3.5.0
  Using cached xxhash-3.5.0-cp311-cp311-win_amd64.whl.metadata (13 kB)
Collecting psutil==7.0.0
  Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl.metadata (23 kB)
Using cached xxhash-3.5.0-cp311-cp311-win_amd64.whl (30 kB)
Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl (244 kB)
Installing collected packages: xxhash, psutil
Successfully installed psutil-7.0.0 xxhash-3.5.0
Collecting xxhash==3.5.0
  Using cached xxhash-3.5.0-cp312-cp312-win_amd64.whl.metadata (13 kB)
Collecting psutil==7.0.0
  Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl.metadata (23 kB)
Using cached xxhash-3.5.0-cp312-cp312-win_amd64.whl (30 kB)
Using cached psutil-7.0.0-cp37-abi3-win_amd64.whl (244 kB)
Installing collected packages: xxhash, psutil
Successfully installed psutil-7.0.0 xxhash-3.5.0
[WindowsPath('C:/Users/sakshie/AppData/Local/Temp/tmp_w__rxkw/base_env'), WindowsPath('C:/Users/sakshie/AppData/Local/Temp/tmp_w__rxkw/deadline_cloud_for_3ds_max_submitter-deps.zip'), WindowsPath('C:/Users/sakshie/AppData/Local/Temp/tmp_w__rxkw/native')]
Running cmd: [WindowsPath('C:/Program Files/InstallBuilder Enterprise 25.6.0/bin/builder'), 'build', 'C:\\Users\\sakshie\\workplace\\deadline-cloud-for-3ds-max\\installer\\DeadlineCloudFor3dsMaxSubmitter.xml', 'windows-x64', '--setvars', 'project.outputDirectory=C:\\Users\\sakshie\\AppData\\Local\\Temp\\tmpf5k7fzsz\\out', 'project.version=00000000-2025-07-15']
------------------------------
Begin Install Builder Output
------------------------------
 Building AWS Deadline Cloud for 3ds Max Submitter windows-x64
 0% ______________ 50% ______________ 100%
 #########################################
Built with an evaluation version of InstallBuilder
------------------------------
End Install Builder Output
------------------------------
```
Also run the unit tests:
```
=================================================================================== slowest 5 durations ====================================================================================
0.13s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_max_init_timeout
0.04s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_run_data_wrong_schema
0.04s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_no_error
0.03s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_on_run
0.02s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_populate_action_queue_required_keys
==================================================================================== 61 passed in 6.02s ====================================================================================
```

### Was this change documented?
Not required, I've followed the same process as ``xxhash``

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*