### PR TITLE
Add Constants to support VRay7 GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ AWS Deadline Cloud officially supports rendering 3ds Max jobs using the followin
 * Autodesk Raytracer (ART) 
 * Chaos Corona 
 * Chaos V-Ray 6 (CPU & GPU)
-* Chaos V-Ray 7 (CPU)
+* Chaos V-Ray 7 (CPU & GPU)
 * Maxon Redshift
 ## Getting Started
 

--- a/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
@@ -37,7 +37,7 @@
             "oneOf": [
                 {
                     "type": "string",
-                    "pattern": "^V_Ray_([1-9]|GPU_[1-9]).*$"
+                    "pattern": "^V_Ray.*$"
                 },
                 {
                     "enum": [

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
@@ -23,11 +23,9 @@ def get_render_handler(renderer: str = "Default_Scanline_Renderer") -> DefaultMa
         return ArtHandler()
     elif renderer == "Corona":
         return CoronaHandler()
-    elif renderer.startswith("V_Ray_6"):
-        return VrayHandler(gpu=False)
-    elif renderer.startswith("V_Ray_GPU_6"):
+    elif renderer.startswith("V_Ray_GPU_"):
         return VrayHandler(gpu=True)
-    elif renderer.startswith("V_Ray_7"):
+    elif renderer.startswith("V_Ray_"):
         return VrayHandler(gpu=False)
     elif renderer == "Redshift_Renderer":
         return RedshiftHandler()

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -27,6 +27,7 @@ ALLOWED_RENDERERS = [
     "V_Ray_6",
     "V_Ray_GPU_6",
     "V_Ray_7",
+    "V_Ray_GPU_7",
     "Redshift_Renderer",
 ]
 

--- a/src/deadline/max_submitter/sanity_checks.py
+++ b/src/deadline/max_submitter/sanity_checks.py
@@ -177,10 +177,16 @@ def check_sanity_specific_state_set(settings: RenderSubmitterUISettings, state_s
             f"The state set name {state_set} is too long. The max length allowed is {STEP_NAME_MAX_STRING_LENGTH}."
         )
 
-    if str(rt.renderers.current).split(":")[0].split("__")[0] not in ALLOWED_RENDERERS:
+    renderer_name = str(rt.renderers.current).split(":")[0]
+    renderer_split_underscore = renderer_name.split("__")[0]
+    renderer_split_single_underscore = "_".join(renderer_name.split("_")[:4])
+
+    if (
+        renderer_split_underscore not in ALLOWED_RENDERERS
+        and renderer_split_single_underscore not in ALLOWED_RENDERERS
+    ):
         raise Exception(
-            f"{state_set} has an unsupported renderer set. Renderer: "
-            f"{str(rt.renderers.current).split(':')[0]}"
+            f"{state_set} has an unsupported renderer set. Renderer: " f"{renderer_name}"
         )
 
     if not settings.override_frame_range:

--- a/test/unit/deadline_submitter_for_3ds_max/test_sanity_checks.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_sanity_checks.py
@@ -7,6 +7,7 @@ from pytest import fixture, raises
 
 from deadline.max_submitter.sanity_checks import (
     check_sanity,
+    check_sanity_specific_state_set,
     JOB_PARAMETER_MAX_STRING_LENGTH,
     STEP_NAME_MAX_STRING_LENGTH,
     ALL_CAMERAS_STR,
@@ -37,6 +38,11 @@ def mock_max_utils():
 def mock_pymx_runtime():
     with patch("deadline.max_submitter.sanity_checks.rt") as mock_pymx_runtime:
         mock_pymx_runtime.renderers.current = ALLOWED_RENDERERS[0]
+        mock_pymx_runtime.maxFileName = "test_scene.max"
+        mock_pymx_runtime.rendOutputFilename = "test_output.png"
+        mock_pymx_runtime.rendTimeType = 1  # Single frame
+        mock_pymx_runtime.checkForSave.return_value = None
+        mock_pymx_runtime.execute.return_value = None
         yield mock_pymx_runtime
 
 
@@ -149,3 +155,39 @@ class TestSanityChecks:
 
         with raises(Exception):
             check_sanity(default_settings)
+
+    def test_check_sanity_specific_state_set_vray_6_update_renderer(
+        self,
+        mock_pymx_runtime: Mock,
+        default_settings: RenderSubmitterUISettings,
+    ) -> None:
+        """Test that V_Ray_6__update_2_1 renderer is accepted (splits by __ to V_Ray_6)"""
+        mock_pymx_runtime.renderers.current = "V_Ray_6__update_2_1:V-Ray 6, update 2.1"
+        mock_pymx_runtime.rendOutputFilename = ""
+
+        # Should not raise an exception
+        check_sanity_specific_state_set(default_settings, "test_state_set")
+
+    def test_check_sanity_specific_state_set_vray_gpu_7_hotfix_renderer(
+        self,
+        mock_pymx_runtime: Mock,
+        default_settings: RenderSubmitterUISettings,
+    ) -> None:
+        """Test that V_Ray_GPU_7_Hotfix_2 renderer is accepted (splits by _ to V_Ray_GPU_7)"""
+        mock_pymx_runtime.renderers.current = "V_Ray_GPU_7_Hotfix_2:V-Ray GPU 7, Hotfix 2"
+        mock_pymx_runtime.rendOutputFilename = ""
+
+        # Should not raise an exception
+        check_sanity_specific_state_set(default_settings, "test_state_set")
+
+    def test_check_sanity_specific_state_set_unsupported_renderer(
+        self,
+        mock_pymx_runtime: Mock,
+        default_settings: RenderSubmitterUISettings,
+    ) -> None:
+        """Test that an unsupported renderer raises an exception"""
+        mock_pymx_runtime.renderers.current = "Unsupported_Renderer:Some Unsupported Renderer"
+        mock_pymx_runtime.rendOutputFilename = ""
+
+        with raises(Exception, match="has an unsupported renderer set"):
+            check_sanity_specific_state_set(default_settings, "test_state_set")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Users are requesting support of 3dsmax with VRay 7 GPU render. This case was not supported before.
- From max script, I listed the VRay7 render, the name for hot fix 2 were:
```
for r in rendererClass.classes do (
    format "Renderer: %\n" r
)
```
```
...
Renderer: V_Ray_GPU_7_Hotfix_2
Renderer: V_Ray_7_Hotfix_2
...
```

- Revisions:
 - Simplified the if-else VRayHandler logic. Did more testing.

### What was the solution? (How)
- Lets add the missing constant, and set up the usage of the constant.

### What is the impact of this change?
- 3dsmax with VRay 7 GPU support

### How was this change tested?

- Built my own custom submitter, adapter.
- Created a job bundle, checked the bundle has the right renderer
- Used 3dsmax adapter via CLI and rendererd with VRay 7 GPU - https://github.com/leongdl/deadline-cloud-for-3ds-max/blob/testscript/test-3dsmax-openjd.ps1 
  - I made a prototype test script to convert the job bundle to openjd runner. This lets me test bundles as actual openjd 3dsmax adaptor commands.

### Was this change documented?
- Not Applicable.

### Is this a breaking change?
- No
- 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*