### PR TITLE
fix: use correct VRay regex in adaptor init-data schema

### DIFF
--- a/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
@@ -37,7 +37,7 @@
             "oneOf": [
                 {
                     "type": "string",
-                    "pattern": "^V_Ray_[1-9](_GPU)?.*$"
+                    "pattern": "^V_Ray_([1-9]|GPU_[1-9]).*$"
                 },
                 {
                     "enum": [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
While running 3DSMax on Windows using VRay6 GPU (Service-Managed Fleet), we get this error from jobs:
```
Error encountered while starting adaptor: 'V_Ray_GPU_6__update_2_1' 
does not match '^V_Ray_[1-9](_GPU)?.*$'
```

### What was the solution? (How)

If I use PowerShell to change the regex string to `"^V_Ray_([1-9]|GPU_[1-9]).*$"`, this resolves the issue. (This is done with a host configuration script). This way it doesn't matter if its `V_Ray_GPU_6__update_2_1` or `V_Ray_6_GPU__update_2_1`, however, if you look at [this](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/blob/8cea88ec48848c4f0324e5e63ba7d09dca5a2ac6/src/deadline/max_submitter/data_const.py#L27) I believe `V_Ray_GPU_6` is the correct string.

### What is the impact of this change?
This should resolve issues with VRay6 GPU renderers on 3DSMax

### How was this change tested?
I have used PowerShell and host configuration scripts to modify the schema directly on a server before a job start which resolved this issue

### Was this change documented?

### Is this a breaking change?
Currently, yes.  But the new regex should handle both strings. (`V_Ray_GPU_6__update_2_1` or `V_Ray_6_GPU__update_2_1`)