### PR TITLE
chore: Update deadline to 0.52.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 # 2026 - 3.11: https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=MAXDEV_Python_what_s_new_in_3ds_max_python_api_html
 
 dependencies = [
-    "deadline == 0.50.*",
+    "deadline == 0.52.*",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`deadline-cloud-for-3ds-max` currently consume `deadline` 0.50.* and we want to update it to latest version

### What was the solution? (How)
Update the dependencies version anchor to 0.52

### What is the impact of this change?
`deadline-cloud-for-3ds-max` will consume the latest version of `deadline`

### How was this change tested?
#### Unit test
```
======================================================================== slowest 5 durations ========================================================================
0.13s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_max_init_timeout
0.03s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_cleanup::test_on_cleanup
0.03s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_on_run_render_fail
0.03s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_run_data_wrong_schema
0.03s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_server_init_fail
======================================================================== 64 passed in 3.71s =========================================================================
```
#### Integ test
```
================================================= test session starts =================================================
platform win32 -- Python 3.10.8, pytest-8.4.2, pluggy-1.6.0 -- C:\Users\RDP\AppData\Local\hatch\env\virtual\deadline-cloud-for-3ds-max\uwxZ9M_K\integ\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\RDP\Documents\deadline-cloud-for-3ds-max
configfile: pyproject.toml
plugins: flaky-3.8.1, cov-6.2.1, xdist-3.8.0
1 worker [2 items]
scheduling tests via LoadScheduling

test/integ/test_3dsmax_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 50%] PASSED test/integ/test_3dsmax_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_3dsmax_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [100%] PASSED test/integ/test_3dsmax_submitters.py::TestSubmitters::test_minimal_scene_submitter
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

================================================= slowest 5 durations =================================================
36.02s call     test/integ/test_3dsmax_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
27.74s call     test/integ/test_3dsmax_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s setup    test/integ/test_3dsmax_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
0.00s setup    test/integ/test_3dsmax_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s teardown test/integ/test_3dsmax_submitters.py::TestSubmitters::test_minimal_scene_submitter
============================================ 2 passed in 64.97s (0:01:04) =============================================
```
#### Manual test
- Create a custom installer that anchor to `deadline` version 0.52.*
- Install it on a windows machine with fresh 3dsMax
- Open the submitter and check to make sure:
   - Field take input correctly and save it accordingly
   - Drop down work as expected
   - Submitter UI can be close after submit a job
      - For this, I made sure the behaviour is correct by also install our currently public submitter installer and check

### Was this change documented?
No

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*