### PR TITLE
chore: stale and responded workflows to not require secrets

### DIFF
--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -6,5 +6,4 @@ on:
 jobs:
   check-for-response:
     uses: aws-deadline/.github/.github/workflows/reusable_responded.yml@mainline
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -7,5 +7,3 @@ on:
 jobs:
   check-for-stales:
     uses: aws-deadline/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The passing of the GITHUB token does not work because it is a reserved name. By default the calling workflow passes the GITHUB_TOKEN, so we do not need to specify it.

### What was the solution? (How)

Remove:
```
secrets:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

### What is the impact of this change?
No secret passing are specified in the workflow.

### How was this change tested?

https://github.com/moorec-aws/openjd-specifications/actions/runs/17472318384/job/49623539652

Confirmed expected permissions:
```
GITHUB_TOKEN Permissions
  Contents: read
  Issues: write
  Metadata: read
  PullRequests: write
Secret source: Actions
```

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*