### PR TITLE
chore: Add an easy to update script for the submitter for development

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,6 +52,9 @@ WARNING: This workflow installs additional Python packages into your 3ds Max's p
 1. Installer should be built under the `installer` sub-folder.
 1. Double click on the built installer to setup all 3dsMax versions.
 
+##### Quick Update for development.
+1. After using the Installer installation, developers can quickly iterate by using `.\scripts\update_installed_files.bat` The script will copy and update all `.py` files.
+
 #### Manual installation
 
 1. Clone `deadline-cloud-for-3ds-max`, and build your local copy running `hatch build`.

--- a/scripts/update_installed_files.bat
+++ b/scripts/update_installed_files.bat
@@ -1,0 +1,54 @@
+@echo off
+REM Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+REM Quick batch script to update installed 3ds Max submitter files
+REM This is faster than rebuilding the entire installer during development
+
+echo === 3ds Max Submitter File Updater ===
+echo.
+
+set SOURCE_ROOT=src\deadline
+set DEST_ROOT=%USERPROFILE%\DeadlineCloudFor3dsMaxSubmitter\scripts\deadline
+
+REM Check if source exists
+if not exist "%SOURCE_ROOT%" (
+    echo ERROR: Source directory not found: %SOURCE_ROOT%
+    echo Make sure you're running this from the deadline-cloud-for-3ds-max root directory
+    pause
+    exit /b 1
+)
+
+REM Check if destination exists
+if not exist "%DEST_ROOT%" (
+    echo ERROR: Destination directory not found: %DEST_ROOT%
+    echo Make sure the 3ds Max submitter is installed
+    pause
+    exit /b 1
+)
+
+echo Updating max_submitter files...
+xcopy /E /Y /I "%SOURCE_ROOT%\max_submitter" "%DEST_ROOT%\max_submitter"
+if %ERRORLEVEL% neq 0 (
+    echo ERROR: Failed to copy max_submitter files
+    pause
+    exit /b 1
+)
+echo   ✓ max_submitter updated
+
+echo Updating max_shared files...
+xcopy /E /Y /I "%SOURCE_ROOT%\max_shared" "%DEST_ROOT%\max_shared"
+if %ERRORLEVEL% neq 0 (
+    echo ERROR: Failed to copy max_shared files
+    pause
+    exit /b 1
+)
+echo   ✓ max_shared updated
+
+echo.
+echo === Update Complete ===
+echo The installed 3ds Max submitter files have been updated.
+echo.
+echo Next steps:
+echo 1. Restart 3ds Max if it's currently running
+echo 2. Test the submitter to verify your changes work
+echo.
+pause


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Iterating on submitter development was quite slow. I had to 1) build the installer, 2) click^n the installer, 3) restart 3dsmax.
- This is slow and needs >1 minute of time.

### What was the solution? (How)
- Add a simple update script that can update a submitter installation after the default installer has setup the paths. This script updates the Python files.
- Users can quickly write / generate code, run the script, reboot 3dsmax all in <1 minute.

### What is the impact of this change?
- Quicker dev cycle.

### How was this change tested?
- I've been using it to develop new features.

### Was this change documented?
- Yes, I have updated DEVELOPMENT.md

### Is this a breaking change?
Nope.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*