### PR TITLE
fix: Fix V_Ray renderer generally using "starts with"

### DIFF
--- a/src/deadline/max_submitter/sanity_checks.py
+++ b/src/deadline/max_submitter/sanity_checks.py
@@ -178,13 +178,17 @@ def check_sanity_specific_state_set(settings: RenderSubmitterUISettings, state_s
         )
 
     renderer_name = str(rt.renderers.current).split(":")[0]
-    renderer_split_underscore = renderer_name.split("__")[0]
-    renderer_split_single_underscore = "_".join(renderer_name.split("_")[:4])
 
-    if (
-        renderer_split_underscore not in ALLOWED_RENDERERS
-        and renderer_split_single_underscore not in ALLOWED_RENDERERS
-    ):
+    # Check if renderer is supported - either exact match or starts with an allowed renderer
+    renderer_supported = renderer_name in ALLOWED_RENDERERS
+    if not renderer_supported:
+        # Check if renderer starts with any allowed renderer (handles versions/hotfixes)
+        for allowed_renderer in ALLOWED_RENDERERS:
+            if renderer_name.startswith(allowed_renderer):
+                renderer_supported = True
+                break
+
+    if not renderer_supported:
         raise Exception(
             f"{state_set} has an unsupported renderer set. Renderer: " f"{renderer_name}"
         )

--- a/test/unit/deadline_submitter_for_3ds_max/test_sanity_checks.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_sanity_checks.py
@@ -161,7 +161,7 @@ class TestSanityChecks:
         mock_pymx_runtime: Mock,
         default_settings: RenderSubmitterUISettings,
     ) -> None:
-        """Test that V_Ray_6__update_2_1 renderer is accepted (splits by __ to V_Ray_6)"""
+        """Test that V_Ray_6__update_2_1 renderer is accepted (starts with V_Ray_6)"""
         mock_pymx_runtime.renderers.current = "V_Ray_6__update_2_1:V-Ray 6, update 2.1"
         mock_pymx_runtime.rendOutputFilename = ""
 
@@ -173,8 +173,20 @@ class TestSanityChecks:
         mock_pymx_runtime: Mock,
         default_settings: RenderSubmitterUISettings,
     ) -> None:
-        """Test that V_Ray_GPU_7_Hotfix_2 renderer is accepted (splits by _ to V_Ray_GPU_7)"""
+        """Test that V_Ray_GPU_7_Hotfix_2 renderer is accepted (starts with V_Ray_GPU_7)"""
         mock_pymx_runtime.renderers.current = "V_Ray_GPU_7_Hotfix_2:V-Ray GPU 7, Hotfix 2"
+        mock_pymx_runtime.rendOutputFilename = ""
+
+        # Should not raise an exception
+        check_sanity_specific_state_set(default_settings, "test_state_set")
+
+    def test_check_sanity_specific_state_set_vray_7_hotfix_renderer(
+        self,
+        mock_pymx_runtime: Mock,
+        default_settings: RenderSubmitterUISettings,
+    ) -> None:
+        """Test that V_Ray_7_Hotfix_2 renderer is accepted (starts with V_Ray_7)"""
+        mock_pymx_runtime.renderers.current = "V_Ray_7_Hotfix_2:V-Ray 7, Hotfix 2"
         mock_pymx_runtime.rendOutputFilename = ""
 
         # Should not raise an exception
@@ -191,3 +203,25 @@ class TestSanityChecks:
 
         with raises(Exception, match="has an unsupported renderer set"):
             check_sanity_specific_state_set(default_settings, "test_state_set")
+
+    def test_allowed_renderers_no_substring_conflicts(self) -> None:
+        """Test that none of the allowed renderers is a substring of another.
+
+        This prevents issues where renderer version checking might incorrectly match
+        a shorter renderer name that is a substring of a longer one.
+        For example, if 'V_Ray' and 'V_Ray_6' were both in the list,
+        'V_Ray_6_update_1' would match 'V_Ray' first instead of 'V_Ray_6'.
+        """
+        for i, renderer_a in enumerate(ALLOWED_RENDERERS):
+            for j, renderer_b in enumerate(ALLOWED_RENDERERS):
+                if i != j:  # Don't compare renderer with itself
+                    assert renderer_a not in renderer_b, (
+                        f"Renderer '{renderer_a}' is a substring of '{renderer_b}'. "
+                        f"This could cause incorrect renderer detection. "
+                        f"Consider using more specific renderer names or reordering the list."
+                    )
+                    assert renderer_b not in renderer_a, (
+                        f"Renderer '{renderer_b}' is a substring of '{renderer_a}'. "
+                        f"This could cause incorrect renderer detection. "
+                        f"Consider using more specific renderer names or reordering the list."
+                    )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- I found another path where the VRay renderer detection was problematic.
- It seems VRay is inconsistency using _ or __ and different formatting for the renderer name. This is quite troublesome.

### What was the solution? (How)
- At least the V_Ray begins with string is always consistent and more passible. 
- Use Begins with instead, and add unit test to detect the cases.

### What is the impact of this change?
- Better VRay detection in 3dsmax

### How was this change tested?
- Loaded a test scene, selected different VRay7 renderers, GPU, CPU, ART etc. Started the Deadline Cloud submitter to export a bundle. This will trigger the submitter sanity test code.
 
### Was this change documented?
- No

### Is this a breaking change?
- No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*