### PR TITLE
feat(render elements) Add Submitter UI to support Render Elements

### DIFF
--- a/src/deadline/max_submitter/create_job_bundle.py
+++ b/src/deadline/max_submitter/create_job_bundle.py
@@ -4,16 +4,25 @@
 3ds Max Deadline Cloud Submitter - Functions for generating the job template and parameter values files
 """
 
+import logging
 import os
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 import yaml
-from data_classes import RenderSubmitterUISettings, StateSetData
+from data_classes import (
+    RENDER_ELEMENT_PARAMS,
+    RENDER_ELEMENT_PARAM_MAPPING,
+    RenderSubmitterUISettings,
+    StateSetData,
+)
 from data_const import ALL_CAMERAS_STR, ALL_STATE_SETS_STR, ALL_STEREO_CAMERAS_STR
 from deadline.client.exceptions import DeadlineOperationError
 from utilities import max_utils
+from deadline.max_shared.utilities.max_utils import get_render_elements
+
+_logger = logging.getLogger(__name__)
 
 
 def get_job_template(
@@ -48,6 +57,180 @@ def get_job_template(
         job_template["jobEnvironments"].append(override_environment["environment"])
 
     return job_template
+
+
+def _create_job_bundle_render_element_props(
+    job_template: dict[str, Any], settings: RenderSubmitterUISettings
+) -> None:
+    """
+    Creates render element parameter definitions and adds them to the job template.
+
+    :param job_template: the job template to modify
+    :param settings: a RenderSubmitterUISettings object containing the latest UI settings
+    """
+    render_elements = get_render_elements()
+    if render_elements:
+        # Enabled to modify RenderElement settings at render time.
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "RenderElementsModified",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Modify Render Elements",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Enable or disable modification of render elements settings.",
+                "default": "true" if settings.enabled_modify_render_elements else "false",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # RenderElements parameter - whether to output render elements
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "RenderElements",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Output Render Elements",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Enable or disable render elements output.",
+                "default": "true",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # RenderElementsUpdatePaths parameter - whether to update render element paths
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "RenderElementsUpdatePaths",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Update Render Element Paths",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Automatically update render element output paths based on naming settings.",
+                "default": "true",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # RenderElementsIncludeNameInPath parameter - include element name in path
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "RenderElementsIncludeNameInPath",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Include Render Element Name in Path",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Add render element name as subdirectory in output path.",
+                "default": "true",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # RenderElementsIncludeTypeInPath parameter - include element type in path
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "RenderElementsIncludeTypeInPath",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Include Render Element Type in Path",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Add render element type as subdirectory in output path.",
+                "default": "false",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # RenderElementsIncludeNameInFilename parameter - include element name in filename
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "RenderElementsIncludeNameInFilename",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Include Render Element Name in Filename",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Add render element name to output filename.",
+                "default": "true",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # RenderElementsIncludeTypeInFilename parameter - include element type in filename
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "RenderElementsIncludeTypeInFilename",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Include Render Element Type in Filename",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Add render element type to output filename.",
+                "default": "false",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # VRayRenderElementsVFBControl parameter - V-Ray VFB control
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "VRayRenderElementsVFBControl",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "V-Ray Render Elements VFB Control",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Automatically control V-Ray VFB settings for render elements during rendering.",
+                "default": "true",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # VRaySplitBufferSupport parameter - V-Ray split buffer support
+        job_template["parameterDefinitions"].append(
+            {
+                "name": "VRaySplitBufferSupport",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "V-Ray Split Buffer Support",
+                    "groupLabel": "Render Elements",
+                },
+                "description": "Enable V-Ray split buffer support for render elements.",
+                "default": "true",
+                "allowedValues": ["true", "false"],
+            }
+        )
+
+        # IgnoreRenderElementsByName parameter - list of render element names to ignore
+        if any(elem.name for elem in render_elements):
+            element_names = [""] + [elem.name for elem in render_elements if elem.name]
+            job_template["parameterDefinitions"].append(
+                {
+                    "name": "IgnoreRenderElementsByName",
+                    "type": "STRING",
+                    "userInterface": {
+                        "control": "DROPDOWN_LIST",
+                        "label": "Ignore Render Elements by Name",
+                        "groupLabel": "Render Elements",
+                    },
+                    "description": "List of render element names to ignore during rendering.",
+                    "default": "",
+                    "allowedValues": element_names,
+                }
+            )
 
 
 def _create_param_definitions(
@@ -106,6 +289,9 @@ def _create_param_definitions(
                 "allowedValues": cameras_in_scene,
             }
         )
+
+    # Add render elements parameters if render elements are present in the scene
+    _create_job_bundle_render_element_props(job_template, settings)
 
     return job_template
 
@@ -216,6 +402,13 @@ def _create_step_definitions(
         ):
             init_data["data"] += "camera: '{{Param.Camera}}'\n"
 
+        # Add render element parameters to init data
+        for param in RENDER_ELEMENT_PARAMS:
+            # Convert parameter name to snake_case for init data with proper mapping
+
+            init_data_key = RENDER_ELEMENT_PARAM_MAPPING.get(param, param.lower())
+            init_data["data"] += f"{init_data_key}: '{{{{Param.{param}}}}}'\n"
+
     return job_template
 
 
@@ -275,6 +468,9 @@ def get_parameters_values(
     :param state_sets: a list of StateSetData for the submitted state sets
     :param queue_parameters: the settings from the shared job settings tab
     """
+    # Validate render elements parameter consistency
+    _validate_render_elements_parameters(settings)
+
     parameter_values = _get_job_parameters(settings, state_sets)
     queue_parameters = _get_queue_parameters_for_bundle(
         settings, parameter_values, queue_parameters
@@ -358,6 +554,91 @@ def _get_job_parameters(
     ):
         parameter_values.append({"name": "Camera", "value": settings.camera_selection})
 
+    # Add render elements parameters if render elements are present in the scene
+    render_elements = get_render_elements()
+    if render_elements:
+        # Enabled to modify RenderElement settings at render time.
+        parameter_values.append(
+            {
+                "name": "RenderElementsModified",
+                "value": "true" if settings.enabled_modify_render_elements else "false",
+            }
+        )
+
+        # RenderElements parameter
+        parameter_values.append(
+            {"name": "RenderElements", "value": "true" if settings.render_elements else "false"}
+        )
+
+        # Enhanced Render Elements Parameter Values (Authentic Deadline 10 features)
+
+        # RenderElementsUpdatePaths parameter
+        parameter_values.append(
+            {
+                "name": "RenderElementsUpdatePaths",
+                "value": "true" if settings.render_elements_update_paths else "false",
+            }
+        )
+
+        # RenderElementsIncludeNameInPath parameter
+        parameter_values.append(
+            {
+                "name": "RenderElementsIncludeNameInPath",
+                "value": "true" if settings.render_elements_include_name_in_path else "false",
+            }
+        )
+
+        # RenderElementsIncludeTypeInPath parameter
+        parameter_values.append(
+            {
+                "name": "RenderElementsIncludeTypeInPath",
+                "value": "true" if settings.render_elements_include_type_in_path else "false",
+            }
+        )
+
+        # RenderElementsIncludeNameInFilename parameter
+        parameter_values.append(
+            {
+                "name": "RenderElementsIncludeNameInFilename",
+                "value": "true" if settings.render_elements_include_name_in_filename else "false",
+            }
+        )
+
+        # RenderElementsIncludeTypeInFilename parameter
+        parameter_values.append(
+            {
+                "name": "RenderElementsIncludeTypeInFilename",
+                "value": "true" if settings.render_elements_include_type_in_filename else "false",
+            }
+        )
+
+        # VRayRenderElementsVFBControl parameter
+        parameter_values.append(
+            {
+                "name": "VRayRenderElementsVFBControl",
+                "value": "true" if settings.vray_render_elements_vfb_control else "false",
+            }
+        )
+
+        # VRaySplitBufferSupport parameter
+        parameter_values.append(
+            {
+                "name": "VRaySplitBufferSupport",
+                "value": "true" if settings.vray_split_buffer_support else "false",
+            }
+        )
+
+        # IgnoreRenderElementsByName parameter
+        if settings.ignore_render_elements_by_name:
+            # Convert list to comma-separated string for OpenJD
+            ignore_names_str = ",".join(settings.ignore_render_elements_by_name)
+            parameter_values.append(
+                {"name": "IgnoreRenderElementsByName", "value": ignore_names_str}
+            )
+        elif any(elem.name for elem in render_elements):
+            # Add empty parameter if render elements exist but none are ignored
+            parameter_values.append({"name": "IgnoreRenderElementsByName", "value": ""})
+
     return parameter_values
 
 
@@ -401,6 +682,40 @@ def _get_queue_parameters_for_bundle(
             )
 
     return queue_parameters
+
+
+def _validate_render_elements_parameters(settings: RenderSubmitterUISettings) -> None:
+    """
+    Validates render elements parameter consistency to ensure settings are coherent.
+
+    :param settings: a RenderSubmitterUISettings object containing the latest UI settings
+    :raises DeadlineOperationError: if render elements parameters are inconsistent
+    """
+    # If render elements are disabled, ignore other settings
+    if not settings.render_elements:
+        return
+
+    # Validate that ignored render element names exist in the scene
+    if settings.ignore_render_elements_by_name:
+        try:
+            # Get current render elements from scene to validate ignore list
+            render_elements = get_render_elements()
+            scene_element_names = {elem.name for elem in render_elements if elem.name}
+
+            invalid_names = [
+                name
+                for name in settings.ignore_render_elements_by_name
+                if name not in scene_element_names
+            ]
+
+            if invalid_names:
+                raise DeadlineOperationError(
+                    f"The following render element names to ignore do not exist in the scene: "
+                    f"{', '.join(invalid_names)}"
+                )
+        except Exception as e:
+            # If validation fails, log warning but don't fail submission
+            _logger.warning(f"Could not validate render element names: {e}")
 
 
 def _check_multiples(state_sets: list[StateSetData], type_: str) -> bool:

--- a/src/deadline/max_submitter/data_classes.py
+++ b/src/deadline/max_submitter/data_classes.py
@@ -8,11 +8,39 @@ import dataclasses
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 import pymxs  # noqa
 from deadline.max_submitter.data_const import ALL_CAMERAS_STR, RENDER_SUBMITTER_SETTINGS_FILE_EXT
 from pymxs import runtime as rt
+
+
+# Constants for render element parameter processing
+RENDER_ELEMENT_PARAMS: List[str] = [
+    "RenderElementsModified",
+    "RenderElements",
+    "RenderElementsUpdatePaths",
+    "RenderElementsIncludeNameInPath",
+    "RenderElementsIncludeTypeInPath",
+    "RenderElementsIncludeNameInFilename",
+    "RenderElementsIncludeTypeInFilename",
+    "VRayRenderElementsVFBControl",
+    "VRaySplitBufferSupport",
+    "IgnoreRenderElementsByName",
+]
+
+RENDER_ELEMENT_PARAM_MAPPING: Dict[str, str] = {
+    "RenderElementsModified": "enabled_modify_render_elements",
+    "RenderElements": "render_elements",
+    "RenderElementsUpdatePaths": "render_elements_update_paths",
+    "RenderElementsIncludeNameInPath": "render_elements_include_name_in_path",
+    "RenderElementsIncludeTypeInPath": "render_elements_include_type_in_path",
+    "RenderElementsIncludeNameInFilename": "render_elements_include_name_in_filename",
+    "RenderElementsIncludeTypeInFilename": "render_elements_include_type_in_filename",
+    "VRayRenderElementsVFBControl": "vray_render_elements_vfb_control",
+    "VRaySplitBufferSupport": "vray_split_buffer_support",
+    "IgnoreRenderElementsByName": "ignore_render_elements_by_name",
+}
 
 
 @dataclass
@@ -78,6 +106,41 @@ class RenderSubmitterUISettings:
     all_cameras: list[str] = field(default_factory=list)
     all_stereo_cameras: list[str] = field(default_factory=list)
 
+    # Render Elements (Basic Support - already implemented)
+    # Master control for render elements modification
+    enabled_modify_render_elements: bool = field(default=False, metadata={"sticky": True})
+    # Enable/disable render elements output
+    render_elements: bool = field(default=True, metadata={"sticky": True})
+
+    # List of specific render element names to ignore
+    ignore_render_elements_by_name: list[str] = field(
+        default_factory=list, metadata={"sticky": True}
+    )
+    # Output paths for each render element
+    render_element_output_filenames: list[str] = field(default_factory=list)
+
+    # Enhanced Render Elements (building on existing basic support - Deadline 10 feature parity)
+    # Automatically update render element output paths during submission
+    render_elements_update_paths: bool = field(default=True, metadata={"sticky": True})
+
+    # Include render element name in the output directory path
+    render_elements_include_name_in_path: bool = field(default=True, metadata={"sticky": True})
+    # Include render element type (class name) in the output directory path
+    render_elements_include_type_in_path: bool = field(default=False, metadata={"sticky": True})
+    # Include render element name in the output filename
+    render_elements_include_name_in_filename: bool = field(default=True, metadata={"sticky": True})
+    # Include render element type (class name) in the output filename
+    render_elements_include_type_in_filename: bool = field(default=False, metadata={"sticky": True})
+
+    # Store original render element names for restoration after submission
+    original_render_element_names: list[str] = field(default_factory=list)
+
+    # V-Ray Render Element Integration (V-Ray specific features from Deadline 10)
+    # Control V-Ray VFB settings for render elements during rendering
+    vray_render_elements_vfb_control: bool = field(default=True, metadata={"sticky": True})
+    # Enable V-Ray split buffer functionality for render elements
+    vray_split_buffer_support: bool = field(default=True, metadata={"sticky": True})
+
     # Developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 
@@ -126,3 +189,128 @@ class RenderSubmitterUISettings:
                 if field.metadata.get("sticky")
             }
             json.dump(obj, fh, indent=1)
+
+    def validate_render_element_names(self) -> list[str]:
+        """
+        Validate render element names to ensure they exist in the scene.
+
+        :returns: list of invalid render element names
+        :return_type: list[str]
+        """
+        invalid_names: list[str] = []
+        if not self.ignore_render_elements_by_name:
+            return invalid_names
+
+        try:
+            # Get render element manager
+            re_manager = rt.maxOps.GetCurRenderElementMgr()
+            if not re_manager:
+                return self.ignore_render_elements_by_name  # All names are invalid if no manager
+
+            # Get all render element names in the scene
+            scene_element_names = []
+            for i in range(re_manager.NumRenderElements()):
+                element = re_manager.GetRenderElement(i)
+                if element:
+                    scene_element_names.append(str(element.elementName))
+
+            # Check which names in ignore list don't exist in scene
+            for name in self.ignore_render_elements_by_name:
+                if name not in scene_element_names:
+                    invalid_names.append(name)
+
+        except Exception:
+            # If we can't access render elements, consider all names invalid
+            invalid_names = self.ignore_render_elements_by_name.copy()
+
+        return invalid_names
+
+    def validate_render_element_paths(self) -> list[str]:
+        """
+        Validate render element output paths to ensure they are accessible.
+
+        :returns: list of invalid or inaccessible paths
+        :return_type: list[str]
+        """
+        # No validation needed for render element output filenames currently
+        return []
+
+    def validate_render_element_configuration(self) -> list[str]:
+        """
+        Validate render element configuration consistency for enhanced features.
+
+        :returns: list of configuration warnings or issues
+        :return_type: list[str]
+        """
+        warnings = []
+
+        # Basic validation - check if ignore list has invalid names
+        invalid_names = self.validate_render_element_names()
+        if invalid_names:
+            warnings.append(
+                f"Ignored render element names not found in scene: {', '.join(invalid_names)}"
+            )
+
+        # Check V-Ray specific settings consistency
+        if self.vray_split_buffer_support and not self.vray_render_elements_vfb_control:
+            warnings.append(
+                "V-Ray split buffer support is enabled but V-Ray VFB control is disabled - this may not work as expected"
+            )
+
+        return warnings
+
+    def store_original_render_element_state(self) -> None:
+        """
+        Store original render element names and settings for restoration after submission.
+        This should be called before making any permanent changes to render elements.
+        """
+        try:
+            # Get render element manager
+            re_manager = rt.maxOps.GetCurRenderElementMgr()
+            if not re_manager:
+                return
+
+            # Store original element names
+            original_names = []
+            for i in range(re_manager.NumRenderElements()):
+                element = re_manager.GetRenderElement(i)
+                if element and hasattr(element, "elementName"):
+                    original_names.append(str(element.elementName))
+                else:
+                    original_names.append(f"Element_{i}")
+
+            self.original_render_element_names = original_names
+
+        except Exception:
+            # If we can't access render elements, clear the original names list
+            self.original_render_element_names = []
+
+    def restore_original_render_element_state(self) -> bool:
+        """
+        Restore original render element names and settings after submission.
+
+        :returns: True if restoration was successful, False otherwise
+        :return_type: bool
+        """
+        if not self.original_render_element_names:
+            return False
+
+        try:
+            # Get render element manager
+            re_manager = rt.maxOps.GetCurRenderElementMgr()
+            if not re_manager:
+                return False
+
+            # Restore original element names
+            count = min(len(self.original_render_element_names), re_manager.NumRenderElements())
+            for i in range(count):
+                element = re_manager.GetRenderElement(i)
+                if element and hasattr(element, "elementName"):
+                    element.elementName = self.original_render_element_names[i]
+
+            # Clear the stored names after restoration
+            self.original_render_element_names = []
+            return True
+
+        except Exception:
+            return False

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -31,6 +31,7 @@ from sanity_checks import check_sanity
 from ui.scene_settings_tab import SceneSettingsWidget
 from ui.submit_dialog import SubmitMaxJobToDeadlineDialog
 from utilities import max_utils, submission_utils
+from deadline.max_shared.utilities.max_utils import get_render_elements_output_directories
 
 from _version import version_tuple as adaptor_version_tuple
 
@@ -163,6 +164,20 @@ def on_create_job_bundle_callback(
         for state_set in state_sets_to_submit:
             state_set.frame_range = settings.frame_list
 
+    # Add render element output directories to output_directories set
+    if settings.render_elements and not settings.ignore_render_elements_by_name:
+        try:
+            render_element_dirs = get_render_elements_output_directories()
+            output_directories.update(render_element_dirs)
+            _logger.debug(f"Added render element output directories: {render_element_dirs}")
+
+            # Update state sets with render element directories
+            for state_set in state_sets_to_submit:
+                state_set.output_directories.update(render_element_dirs)
+
+        except Exception as e:
+            _logger.warning(f"Failed to get render element output directories: {e}")
+
     # Only do these actions when we want to submit a scene
     if purpose == JobBundlePurpose.SUBMISSION:
         # Make a backup of the current state of the scene
@@ -274,6 +289,18 @@ def show_job_bundle_submitter():
             output = os.path.split(rt.rendOutputFilename)
             output_directories.update([output[0]])
     output_directories.update([render_settings.output_path])
+
+    # Add render element output directories if render elements are enabled
+    try:
+        render_element_dirs = get_render_elements_output_directories()
+        if render_element_dirs:
+            output_directories.update(render_element_dirs)
+            _logger.debug(
+                f"Added render element output directories to initial setup: {render_element_dirs}"
+            )
+    except Exception as e:
+        _logger.debug(f"Could not get render element output directories during initialization: {e}")
+
     render_settings.output_directories = output_directories
 
     # Fill in the auto-detected input files

--- a/src/deadline/max_submitter/sanity_checks.py
+++ b/src/deadline/max_submitter/sanity_checks.py
@@ -187,7 +187,6 @@ def check_sanity_specific_state_set(settings: RenderSubmitterUISettings, state_s
             if renderer_name.startswith(allowed_renderer):
                 renderer_supported = True
                 break
-
     if not renderer_supported:
         raise Exception(
             f"{state_set} has an unsupported renderer set. Renderer: " f"{renderer_name}"

--- a/src/deadline/max_submitter/ui/render_elements_widget.py
+++ b/src/deadline/max_submitter/ui/render_elements_widget.py
@@ -1,0 +1,531 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Deadline 10 lookalike Render Elements Widget for 3ds Max Deadline Cloud Submitter.
+
+This widget provides render elements controls matching the exact Deadline 10 interface
+with a single unified group box and only authentic UI elements.
+"""
+
+import logging
+
+from qtpy.QtCore import Qt, Signal  # type: ignore
+from qtpy.QtWidgets import (  # type: ignore
+    QCheckBox,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from deadline.max_shared.utilities.max_utils import (
+    get_render_elements,
+    validate_render_element_paths,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class RenderElementsWidget(QWidget):
+    """
+    Deadline 10 lookalike render elements widget with exact UI fidelity.
+
+    This widget matches the original Deadline 10 render elements interface exactly,
+    using a single unified group box with only authentic controls.
+    """
+
+    # Signals for communicating changes to parent
+    settings_changed = Signal()
+    validation_changed = Signal(list)  # Emits list of validation warnings
+
+    def __init__(self, initial_settings, parent=None):
+        super().__init__(parent=parent)
+        self.settings = initial_settings
+        self._build_render_elements_ui()
+        self._connect_signals()
+        self._refresh_ui_state()  # Ensure UI matches the default state
+        self._refresh_detected_elements()
+
+    def _remove_emojis(self, text):
+        """
+        Remove status emoji characters from render element text to prevent Unicode encoding issues.
+
+        Specifically removes the status indicator emojis used in the render elements widget:
+        - 🟢 (Green circle) = Enabled with output path
+        - 🟡 (Yellow circle) = Enabled without output path
+        - 🔴 (Red circle) = Disabled
+        - ❌ (Cross mark) = Error indicator
+
+        Args:
+            text (str): Text that may contain status emoji characters
+
+        Returns:
+            str: Text with status emojis removed and whitespace cleaned up
+        """
+        # Remove specific status emojis used in this widget
+        clean_text = text.replace("🟢", "").replace("🟡", "").replace("🔴", "").replace("❌", "")
+        # Clean up extra whitespace
+        return " ".join(clean_text.split())
+
+    def _build_render_elements_ui(self):
+        """
+        Build the authentic Deadline 10 render elements UI with single unified group box.
+        """
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Single unified group box matching Deadline 10
+        render_elements_group = QGroupBox("Render Elements")
+        layout = QGridLayout(render_elements_group)
+        main_layout.addWidget(render_elements_group)
+
+        # Row 0: Modify Render Elements checkbox (main control)
+        self.modify_render_elements_checkbox = QCheckBox("Modify Render Elements")
+        self.modify_render_elements_checkbox.setChecked(False)  # Default unchecked
+        self.modify_render_elements_checkbox.setToolTip(
+            "Enable or disable modification of render elements settings. "
+            "When unchecked, all render elements setting changes on the worker will be disabled."
+        )
+        layout.addWidget(self.modify_render_elements_checkbox, 0, 0, 1, 2)
+
+        # Row 1: Output Render Elements checkbox
+        self.render_elements_checkbox = QCheckBox("Output Render Elements")
+        self.render_elements_checkbox.setToolTip(
+            "Enable or disable render elements output during rendering"
+        )
+        layout.addWidget(self.render_elements_checkbox, 1, 0, 1, 2)
+
+        # Row 2: Update Render Element Paths checkbox
+        self.update_paths_checkbox = QCheckBox("Update Render Element Paths")
+        self.update_paths_checkbox.setToolTip(
+            "Automatically update render element output paths based on naming settings"
+        )
+        layout.addWidget(self.update_paths_checkbox, 2, 0, 1, 2)
+
+        # Row 3: Path naming options
+        self.include_name_in_path_checkbox = QCheckBox("Include Render Element Name in Path")
+        self.include_name_in_path_checkbox.setToolTip(
+            "Add render element name as subdirectory in output path"
+        )
+        layout.addWidget(self.include_name_in_path_checkbox, 3, 0)
+
+        self.include_type_in_path_checkbox = QCheckBox("Include Render Element Type in Path")
+        self.include_type_in_path_checkbox.setToolTip(
+            "Add render element type as subdirectory in output path"
+        )
+        layout.addWidget(self.include_type_in_path_checkbox, 3, 1)
+
+        # Row 4: Filename naming options
+        self.include_name_in_filename_checkbox = QCheckBox(
+            "Include Render Element Name in Filename"
+        )
+        self.include_name_in_filename_checkbox.setToolTip(
+            "Add render element name to output filename"
+        )
+        layout.addWidget(self.include_name_in_filename_checkbox, 4, 0)
+
+        self.include_type_in_filename_checkbox = QCheckBox(
+            "Include Render Element Type in Filename"
+        )
+        self.include_type_in_filename_checkbox.setToolTip(
+            "Add render element type to output filename"
+        )
+        layout.addWidget(self.include_type_in_filename_checkbox, 4, 1)
+
+        # Row 5: V-Ray specific options
+        self.vray_vfb_control_checkbox = QCheckBox("V-Ray Render Elements VFB Control")
+        self.vray_vfb_control_checkbox.setToolTip(
+            "Automatically control V-Ray VFB settings for render elements during rendering"
+        )
+        layout.addWidget(self.vray_vfb_control_checkbox, 5, 0)
+
+        self.vray_split_buffer_checkbox = QCheckBox("V-Ray Split Buffer Support")
+        self.vray_split_buffer_checkbox.setToolTip(
+            "Enable V-Ray split buffer support for render elements"
+        )
+        layout.addWidget(self.vray_split_buffer_checkbox, 5, 1)
+
+        # Row 6: Ignore by Name section
+        ignore_label = QLabel("Ignore Render Elements by Name:")
+        layout.addWidget(ignore_label, 6, 0, 1, 2)
+
+        # Row 7: Ignore elements list
+        self.ignore_elements_list = QListWidget()
+        self.ignore_elements_list.setMaximumHeight(80)
+        self.ignore_elements_list.setToolTip(
+            "List of render element names to ignore during rendering"
+        )
+        layout.addWidget(self.ignore_elements_list, 7, 0, 1, 2)
+
+        # Row 8: Ignore list management buttons
+        ignore_buttons_layout = QHBoxLayout()
+        self.add_ignore_btn = QPushButton("Add Element")
+        self.add_ignore_btn.setToolTip("Add selected detected element to ignore list")
+        self.remove_ignore_btn = QPushButton("Remove Selected")
+        self.remove_ignore_btn.setToolTip("Remove selected element from ignore list")
+
+        ignore_buttons_layout.addWidget(self.add_ignore_btn)
+        ignore_buttons_layout.addWidget(self.remove_ignore_btn)
+        ignore_buttons_layout.addStretch()
+
+        ignore_buttons_widget = QWidget()
+        ignore_buttons_widget.setLayout(ignore_buttons_layout)
+        layout.addWidget(ignore_buttons_widget, 8, 0, 1, 2)
+
+        # Row 9: Detected elements list
+        detected_label = QLabel("Detected Render Elements:")
+        layout.addWidget(detected_label, 9, 0, 1, 2)
+
+        self.detected_elements_list = QListWidget()
+        self.detected_elements_list.setMaximumHeight(120)
+        self.detected_elements_list.setToolTip(
+            "List of render elements detected in the current scene"
+        )
+        layout.addWidget(self.detected_elements_list, 10, 0, 1, 2)
+
+        # Row 11: Refresh button
+        self.refresh_elements_btn = QPushButton("Refresh Detected Elements")
+        self.refresh_elements_btn.setToolTip("Refresh the list of detected render elements")
+        layout.addWidget(self.refresh_elements_btn, 11, 0, 1, 2)
+
+        # Row 12: Validation feedback
+        self.validation_feedback_label = QLabel("")
+        self.validation_feedback_label.setStyleSheet("color: red;")
+        self.validation_feedback_label.setWordWrap(True)
+        self.validation_feedback_label.setMinimumHeight(40)
+        layout.addWidget(self.validation_feedback_label, 12, 0, 1, 2)
+
+        # Store all controllable widgets for easy enable/disable
+        self._controllable_widgets = [
+            self.render_elements_checkbox,
+            self.update_paths_checkbox,
+            self.include_name_in_path_checkbox,
+            self.include_type_in_path_checkbox,
+            self.include_name_in_filename_checkbox,
+            self.include_type_in_filename_checkbox,
+            self.vray_vfb_control_checkbox,
+            self.vray_split_buffer_checkbox,
+            ignore_label,
+            self.ignore_elements_list,
+            self.add_ignore_btn,
+            self.remove_ignore_btn,
+            detected_label,
+            self.detected_elements_list,
+            self.refresh_elements_btn,
+            self.validation_feedback_label,
+        ]
+
+    def _connect_signals(self):
+        """
+        Connect all widget signals to their respective handlers.
+        """
+        # main control
+        self.modify_render_elements_checkbox.stateChanged.connect(
+            self._on_modify_render_elements_changed
+        )
+
+        # Main controls
+        self.render_elements_checkbox.stateChanged.connect(self._on_render_elements_changed)
+        self.update_paths_checkbox.stateChanged.connect(self._on_settings_changed)
+        self.include_name_in_path_checkbox.stateChanged.connect(self._on_settings_changed)
+        self.include_type_in_path_checkbox.stateChanged.connect(self._on_settings_changed)
+        self.include_name_in_filename_checkbox.stateChanged.connect(self._on_settings_changed)
+        self.include_type_in_filename_checkbox.stateChanged.connect(self._on_settings_changed)
+        self.vray_vfb_control_checkbox.stateChanged.connect(self._on_settings_changed)
+        self.vray_split_buffer_checkbox.stateChanged.connect(self._on_settings_changed)
+
+        # Ignore list management
+        self.add_ignore_btn.clicked.connect(self._add_ignore_element)
+        self.remove_ignore_btn.clicked.connect(self._remove_ignore_element)
+
+        # Detection and validation
+        self.refresh_elements_btn.clicked.connect(self._refresh_detected_elements)
+
+    def _refresh_ui_state(self):
+        """
+        Refresh the UI state to match the current checkbox values.
+        This ensures all controls are properly enabled/disabled on initialization.
+        """
+        # Trigger the main control handler to set initial state
+        self._on_modify_render_elements_changed(self.modify_render_elements_checkbox.checkState())
+
+    def _on_modify_render_elements_changed(self, state):
+        """
+        Handle changes to the main modify render elements checkbox.
+        When unchecked, disables all other render elements controls.
+        When checked, enables all other render elements controls.
+        """
+        enabled = Qt.CheckState(state) == Qt.Checked
+
+        # Enable/disable all controllable widgets
+        for widget in self._controllable_widgets:
+            widget.setEnabled(enabled)
+
+        # If we're enabling, also respect the render elements checkbox state
+        if enabled:
+            self._on_render_elements_changed(self.render_elements_checkbox.checkState())
+
+        self._on_settings_changed()
+
+    def _on_render_elements_changed(self, state):
+        """
+        Handle changes to the main render elements checkbox.
+        Only affects controls if the main modify checkbox is enabled.
+        """
+        # Only enable/disable controls if the main modify checkbox is checked
+        if not self.modify_render_elements_checkbox.isChecked():
+            return
+
+        enabled = Qt.CheckState(state) == Qt.Checked
+
+        # Enable/disable only the controls that are dependent on render elements output
+        self.update_paths_checkbox.setEnabled(enabled)
+        self.include_name_in_path_checkbox.setEnabled(enabled)
+        self.include_type_in_path_checkbox.setEnabled(enabled)
+        self.include_name_in_filename_checkbox.setEnabled(enabled)
+        self.include_type_in_filename_checkbox.setEnabled(enabled)
+        self.vray_vfb_control_checkbox.setEnabled(enabled)
+        self.vray_split_buffer_checkbox.setEnabled(enabled)
+
+        self._on_settings_changed()
+
+    def _on_settings_changed(self):
+        """
+        Handle any settings change and trigger validation.
+        """
+        self._validate_render_elements()
+        self.settings_changed.emit()
+
+    def _add_ignore_element(self):
+        """
+        Add a render element name to the ignore list.
+        """
+        current_item = self.detected_elements_list.currentItem()
+        if not current_item:
+            return
+
+        # Get the actual element name from stored item data
+        element_name = current_item.data(Qt.UserRole)
+        if not element_name:
+            # Fallback: extract clean name from display text
+            element_name = self._remove_emojis(current_item.text())
+            # Further clean up if there's a " - " separator
+            if " - " in element_name:
+                element_name = element_name.split(" - ")[0].strip()
+
+        # Check if already in ignore list (compare clean names)
+        for i in range(self.ignore_elements_list.count()):
+            existing_item = self.ignore_elements_list.item(i)
+            existing_name = existing_item.data(Qt.UserRole) or self._remove_emojis(
+                existing_item.text()
+            )
+            if existing_name == element_name:
+                return  # Already in list
+
+        # Add to ignore list with clean name
+        ignore_item = QListWidgetItem(element_name)
+        ignore_item.setData(Qt.UserRole, element_name)  # Store clean name as data
+        self.ignore_elements_list.addItem(ignore_item)
+        self._on_settings_changed()
+
+    def _remove_ignore_element(self):
+        """
+        Remove selected render element name from the ignore list.
+        """
+        current_row = self.ignore_elements_list.currentRow()
+        if current_row >= 0:
+            self.ignore_elements_list.takeItem(current_row)
+            self._on_settings_changed()
+
+    def _refresh_detected_elements(self):
+        """
+        Refresh the list of detected render elements from the scene.
+        """
+        self.detected_elements_list.clear()
+
+        try:
+            # Get render elements using shared utilities
+            render_elements = get_render_elements()
+
+            if not render_elements:
+                item = QListWidgetItem("No render elements detected in scene")
+                item.setToolTip("No render elements found in the current 3ds Max scene")
+                self.detected_elements_list.addItem(item)
+                return
+
+            # Display render elements with enhanced information
+            for element in render_elements:
+                name = element.name
+                element_type = element.type
+                enabled = element.enabled
+                has_output = element.has_output_path
+                output_filename = element.output_filename
+
+                # Status indicators
+                status_parts = []
+                status_icon = "🟢"  # Default green for enabled with output
+
+                if not enabled:
+                    status_parts.append("DISABLED")
+                    status_icon = "🔴"
+                elif not has_output:
+                    status_parts.append("NO OUTPUT PATH")
+                    status_icon = "🟡"
+
+                # V-Ray specific indicator
+                if element.vray_vfb:
+                    status_parts.append("V-RAY VFB")
+
+                status_text = f" ({', '.join(status_parts)})" if status_parts else ""
+                display_text = f"{status_icon} {name} - {element_type}{status_text}"
+
+                item = QListWidgetItem(display_text)
+                # Store the actual element name as item data for easy retrieval
+                item.setData(Qt.UserRole, name)
+                tooltip = (
+                    f"Name: {name}\n"
+                    f"Type: {element_type}\n"
+                    f"Enabled: {enabled}\n"
+                    f"Output: {output_filename or 'Not set'}\n"
+                    f"Index: {element.index}"
+                )
+                item.setToolTip(tooltip)
+                self.detected_elements_list.addItem(item)
+
+        except Exception as e:
+            _logger.error(f"Error refreshing render elements: {e}")
+            item = QListWidgetItem(f"❌ Error detecting render elements: {e}")
+            self.detected_elements_list.addItem(item)
+
+        self._validate_render_elements()
+
+    def _validate_render_elements(self):
+        """
+        Validate render elements settings and show feedback.
+        """
+        feedback_messages = []
+
+        try:
+            # Get current render elements
+            render_elements = get_render_elements()
+
+            # Validate paths
+            path_warnings = validate_render_element_paths(render_elements)
+            feedback_messages.extend(path_warnings)
+
+            # Validate ignore list - use clean names without emojis
+            ignore_names = []
+            for i in range(self.ignore_elements_list.count()):
+                item = self.ignore_elements_list.item(i)
+                # Get clean name from item data, fallback to text without emojis
+                clean_name = item.data(Qt.UserRole)
+                if not clean_name:
+                    # Fallback: remove emojis from display text
+                    clean_name = self._remove_emojis(item.text())
+                ignore_names.append(clean_name)
+
+            if ignore_names:
+                scene_element_names = [elem.name for elem in render_elements]
+                invalid_names = [name for name in ignore_names if name not in scene_element_names]
+
+                for invalid_name in invalid_names:
+                    # Use clean name in feedback message to avoid Unicode issues
+                    clean_invalid_name = self._remove_emojis(invalid_name)
+                    feedback_messages.append(
+                        f"Ignored element '{clean_invalid_name}' not found in scene"
+                    )
+
+        except Exception as e:
+            _logger.error(f"Error validating render elements: {e}")
+            feedback_messages.append(f"Error validating render elements: {e}")
+
+        # Display feedback
+        if feedback_messages:
+            self.validation_feedback_label.setText("\n".join(feedback_messages))
+            self.validation_feedback_label.setStyleSheet("color: orange;")
+        else:
+            self.validation_feedback_label.setText("✓ Render elements configuration is valid")
+            self.validation_feedback_label.setStyleSheet("color: green;")
+
+        # Emit validation signal
+        self.validation_changed.emit(feedback_messages)
+
+    def get_settings_dict(self):
+        """
+        Get current widget settings as dictionary for parameter generation.
+        """
+        return {
+            "enabled_modify_render_elements": self.modify_render_elements_checkbox.isChecked(),
+            "render_elements": self.render_elements_checkbox.isChecked(),
+            "render_elements_update_paths": self.update_paths_checkbox.isChecked(),
+            "render_elements_include_name_in_path": self.include_name_in_path_checkbox.isChecked(),
+            "render_elements_include_type_in_path": self.include_type_in_path_checkbox.isChecked(),
+            "render_elements_include_name_in_filename": self.include_name_in_filename_checkbox.isChecked(),
+            "render_elements_include_type_in_filename": self.include_type_in_filename_checkbox.isChecked(),
+            "vray_render_elements_vfb_control": self.vray_vfb_control_checkbox.isChecked(),
+            "vray_split_buffer_support": self.vray_split_buffer_checkbox.isChecked(),
+            "ignore_render_elements_by_name": [
+                self.ignore_elements_list.item(i).data(Qt.UserRole)
+                or self._remove_emojis(self.ignore_elements_list.item(i).text())
+                for i in range(self.ignore_elements_list.count())
+            ],
+        }
+
+    def update_settings_from_data_class(self, settings):
+        """
+        Update widget controls from data class settings.
+        """
+        self.modify_render_elements_checkbox.setChecked(settings.enabled_modify_render_elements)
+        self.render_elements_checkbox.setChecked(settings.render_elements)
+        self.update_paths_checkbox.setChecked(settings.render_elements_update_paths)
+        self.include_name_in_path_checkbox.setChecked(settings.render_elements_include_name_in_path)
+        self.include_type_in_path_checkbox.setChecked(settings.render_elements_include_type_in_path)
+        self.include_name_in_filename_checkbox.setChecked(
+            settings.render_elements_include_name_in_filename
+        )
+        self.include_type_in_filename_checkbox.setChecked(
+            settings.render_elements_include_type_in_filename
+        )
+        self.vray_vfb_control_checkbox.setChecked(settings.vray_render_elements_vfb_control)
+        self.vray_split_buffer_checkbox.setChecked(settings.vray_split_buffer_support)
+
+        # Update ignore list with clean names
+        self.ignore_elements_list.clear()
+        for name in settings.ignore_render_elements_by_name:
+            clean_name = self._remove_emojis(name)  # Ensure name is clean
+            ignore_item = QListWidgetItem(clean_name)
+            ignore_item.setData(Qt.UserRole, clean_name)  # Store clean name as data
+            self.ignore_elements_list.addItem(ignore_item)
+
+    def update_data_class_from_settings(self, settings):
+        """
+        Update data class settings from widget controls.
+        """
+        settings.enabled_modify_render_elements = self.modify_render_elements_checkbox.isChecked()
+        settings.render_elements = self.render_elements_checkbox.isChecked()
+        settings.render_elements_update_paths = self.update_paths_checkbox.isChecked()
+        settings.render_elements_include_name_in_path = (
+            self.include_name_in_path_checkbox.isChecked()
+        )
+        settings.render_elements_include_type_in_path = (
+            self.include_type_in_path_checkbox.isChecked()
+        )
+        settings.render_elements_include_name_in_filename = (
+            self.include_name_in_filename_checkbox.isChecked()
+        )
+        settings.render_elements_include_type_in_filename = (
+            self.include_type_in_filename_checkbox.isChecked()
+        )
+        settings.vray_render_elements_vfb_control = self.vray_vfb_control_checkbox.isChecked()
+        settings.vray_split_buffer_support = self.vray_split_buffer_checkbox.isChecked()
+
+        # Update ignore list
+        settings.ignore_render_elements_by_name = [
+            self.ignore_elements_list.item(i).text()
+            for i in range(self.ignore_elements_list.count())
+        ]

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -36,6 +36,7 @@ from qtpy.QtWidgets import (  # type: ignore
     QWidget,
 )
 from deadline.max_submitter.utilities import max_utils
+from deadline.max_submitter.ui.render_elements_widget import RenderElementsWidget
 
 _logger = logging.getLogger(__name__)
 
@@ -232,13 +233,20 @@ class SceneSettingsWidget(QWidget):
         self._build_scene_tweaks_ui()
         lyt.addWidget(self.scene_tweaks_grp_box, 9, 0, 3, 5)
 
+        # Render elements widget
+        self.render_elements_widget = RenderElementsWidget(settings, self)
+        self.render_elements_widget.validation_changed.connect(
+            self._on_render_elements_validation_changed
+        )
+        lyt.addWidget(self.render_elements_widget, 12, 0, 4, 5)
+
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 12, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 16, 0)
 
-        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 13, 0)
+        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 17, 0)
 
         self._fill_cameras_box(0)
 
@@ -281,6 +289,19 @@ class SceneSettingsWidget(QWidget):
         for mat in SCENE_TWEAKS_MATS:
             self.custom_mat_box.addItem(mat, mat)
         scene_tweaks_lyt.addWidget(self.custom_mat_box, 3, 1)
+
+    def _on_render_elements_validation_changed(self, warnings):
+        """
+        Handle validation changes from the enhanced render elements widget.
+
+        :param warnings: List of validation warning messages
+        :type warnings: list[str]
+        """
+        # Log validation warnings
+        if warnings:
+            _logger.warning(f"Render elements validation warnings: {warnings}")
+        else:
+            _logger.debug("Render elements validation passed")
 
     def _update_state_set(self, _):
         """
@@ -488,6 +509,9 @@ class SceneSettingsWidget(QWidget):
         if self.developer_options:
             (self.include_adaptor_wheels.setChecked(settings.include_adaptor_wheels))
 
+        # Update render elements widget from settings
+        self.render_elements_widget.update_settings_from_data_class(settings)
+
     def update_settings(self, settings):
         """
         Update a scene settings object with the latest values.
@@ -520,6 +544,13 @@ class SceneSettingsWidget(QWidget):
             settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()
         else:
             settings.include_adaptor_wheels = False
+
+        # Update render elements settings from widget
+        self.render_elements_widget.update_data_class_from_settings(settings)
+
+        # Update render element output filenames from detected elements
+        # Keep render_element_output_filenames empty for now
+        settings.render_element_output_filenames = []
 
     def activate_frame_override_changed(self, state):
         """


### PR DESCRIPTION
### REVIEWER:
- Please read - https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/153 for a full code level walk through of this PR.
- This review is a chunked subset of changes specifically for the submitter UI. This is PR 2 of 3 for the render elements feature.

PR1 - Share utils: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/160
PR2 - Submission UI: this PR.
PR3 - Adapter integration. https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/162

### What was the problem/requirement? (What/Why)

The 3ds Max integration for Deadline Cloud lacked comprehensive support for render elements, which are essential for advanced rendering workflows in 3ds Max. Users needed the ability to configure, validate, and manage render elements (such as diffuse, reflection, shadow passes, etc.) through both the submitter UI and the adaptor during job execution. This functionality was critical for professional rendering pipelines that rely on multi-pass rendering and compositing workflows.

### What was the solution? (How)
- In this PR, I am adding the UI elements in the 3dsmax submitter dialog. 
- The dialog has an on/off toggle (default off) to allow users to modify render elements. 
  - When off, the scene renders as is, and does not modify any render element properties. When 
  - When on, the scene applies the selected render elements on / off / properties.
- When clicking export bundle or render, the corresponding job template parameters are generated for submission.

### What is the impact of this change?

This change enables professional 3ds Max users to leverage advanced multi-pass rendering workflows through Deadline Cloud, significantly expanding the integration's capabilities. Users can now:
- Configure render elements through the submitter UI
- Have render elements automatically managed during cloud rendering
- Support complex V-Ray rendering setups with VFB integration
- Maintain consistent render element behavior between local and cloud rendering

### How was this change tested?

### Specific UI testing:
<img width="549" height="743" alt="Screenshot 2025-10-20 at 4 44 37 PM" src="https://github.com/user-attachments/assets/320549f4-6a16-414c-8f31-7aebfb0915a5" />
<img width="546" height="735" alt="Screenshot 2025-10-20 at 4 44 28 PM" src="https://github.com/user-attachments/assets/7046df6d-e001-41d2-945a-07a93b3b578d" />

- Tested both positive and negative cases for all buttons. 
- When disabled, the widget greys out all options. This can be a simple toggle to turn on the feature.
- When enabled, the widget enables all options. The settings are sticky too.
- Tested Job Bundle parameters both on/off combinations to make sure bundles are generated correctly.

### Was this change documented?
- We will create a "user guide" in the future, but this is a UX change.

### Is this a breaking change?

No, this is not a breaking change. The render elements support is additive functionality that extends existing capabilities without modifying existing APIs or workflows.

----
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
