### PR TITLE
fix: Add sticky settings for various job settings

### DIFF
--- a/src/deadline/max_submitter/data_classes.py
+++ b/src/deadline/max_submitter/data_classes.py
@@ -72,6 +72,14 @@ class RenderSubmitterUISettings:
     name: str = field(default="", metadata={"sticky": True})
     description: str = field(default="", metadata={"sticky": True})
 
+    priority: int = field(default=50, metadata={"sticky": True})
+    initial_status: str = field(default="READY", metadata={"sticky": True})
+    max_failed_tasks_count: int = field(default=20, metadata={"sticky": True})
+    max_retries_per_task: int = field(default=5, metadata={"sticky": True})
+    max_worker_count: int = field(
+        default=-1, metadata={"sticky": True}
+    )  # -1 indicates unlimited max worker count
+
     # Job specific settings tab
     override_frame_range: bool = field(default=False, metadata={"sticky": True})
     frame_list: str = field(default="", metadata={"sticky": True})


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The 3ds Max submitter was missing sticky settings for shared job settings like priority, max_retries_per_task, and others. This made it inconvenient for users who had to re-enter these common settings for every job submission. 

- Bug fix: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/124

### What was the solution? (How)
Added five new sticky settings fields to the `RenderSubmitterUISettings` dataclass:
- `priority: int` (default: 50)
- `initial_status: str` (default: "READY")
- `max_failed_tasks_count: int` (default: 20)
- `max_retries_per_task: int` (default: 5)
- `max_worker_count: int` (default: -1 for unlimited)

All fields include `metadata={"sticky": True}` to enable automatic persistence using the existing sticky settings system.

### What is the impact of this change?
Users can now set their preferred shared job settings once, and they will be automatically saved and restored between submitter sessions. This significantly improves the user experience by reducing repetitive configuration tasks and ensuring consistent job settings across submissions.

### How was this change tested?
- Code passes all formatting checks (`hatch run fmt`)
- Code passes all linting checks (`hatch run lint`)
- Updated the submitter via scripts, edited job settings, saved the bundle, exited the dialog and re-opened the dialog. The updated settings are persisted.


### Was this change documented?
The fields are documented with inline comments explaining their purpose and default values. The sticky settings functionality leverages the existing documentation and implementation pattern.

### Is this a breaking change?
No, this is not a breaking change. All new fields have sensible defaults and are backward compatible with existing configurations.

----
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
