### PR TITLE
feat(render elements): VRay split frame buffer and VFB fixes to support Render Elements

### DIFF
--- a/src/deadline/max_adaptor/MaxClient/render_element_manager.py
+++ b/src/deadline/max_adaptor/MaxClient/render_element_manager.py
@@ -5,6 +5,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -17,6 +18,8 @@ from deadline.max_shared.utilities.max_utils import (
     RenderElementInfo,
     RenderElementState,
     VRayRenderElementSettings,
+    _configure_render_element_outputs_filename,
+    _is_renderer_vray,
     configure_render_element_paths,
     configure_vray_render_elements,
     get_render_elements,
@@ -67,15 +70,34 @@ class RenderElementManager:
     - Original state storage and restoration
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        output_file_path: Optional[str] = None,
+        output_file_name: Optional[str] = None,
+        output_file_format: Optional[str] = None,
+    ) -> None:
         """
         Initialize the render element manager.
+
+        If any of the output_file_* parameters are None, they will default to the current
+        settings of the render element in the scene. Note that paths may not be path mapped
+        in this case. By default, the submitter always populates these values based on the scene.
+
+        Args:
+            output_file_path: Output directory path for split buffer
+            output_file_name: Output filename for split buffer
+            output_file_format: Output file format/extension
         """
         self.logger = logging.getLogger(__name__)
         self.re_manager: Optional[Any] = None
         self.original_state: Optional[RenderElementState] = None
-        self.cached_settings = {}
+        self.cached_settings: Dict[str, Any] = {}
         self.is_configured = False
+        self.output_file_path: Optional[str] = output_file_path
+        self.output_file_name: Optional[str] = output_file_name
+        self.output_file_format: Optional[str] = output_file_format
+        self.is_vray: bool = False
+        self.current_renderer: str = ""
 
     def _print_render_element_debug_info(self, render_elements: List[RenderElementInfo]) -> None:
         """
@@ -160,6 +182,11 @@ class RenderElementManager:
             self.original_state = store_original_render_element_state(render_elements)
             self.logger.debug(f"Stored original state for {len(render_elements)} render elements")
 
+            # Parse ignore list once for all operations
+            ignore_list = self._get_ignore_list(data)
+            if ignore_list:
+                self.logger.info(f"Ignoring render elements by name: {ignore_list}")
+
             # Configure render elements active state
             elements_enabled = self._configure_render_elements_active(data)
 
@@ -174,13 +201,35 @@ class RenderElementManager:
                 return RenderElementResult(success=True, message="Render elements disabled")
 
             # Handle ignore settings
-            self._handle_ignore_settings(data, render_elements)
+            self._handle_ignore_settings(data, render_elements, ignore_list)
 
-            # Update paths and filenames if requested
-            self._update_paths_and_filenames(data, render_elements)
+            # Detect renderer type and store as attributes
+            self.is_vray, self.current_renderer = _is_renderer_vray()
+            self.logger.info(
+                f"Detected renderer: '{self.current_renderer}' (V-Ray: {self.is_vray})"
+            )
 
-            # Handle V-Ray specific settings
-            self._configure_vray_settings(data, render_elements)
+            # Configure render element outputs based on renderer type
+            if self.is_vray:
+                # Handle V-Ray specific settings
+                self._configure_vray_settings(data, render_elements, ignore_list)
+            else:
+                # Configure standard render element outputs for non-VRay renderers
+                self.logger.info(
+                    f"Configuring standard render element outputs for '{self.current_renderer}'"
+                )
+
+                # Configure standard render element outputs
+                warnings = _configure_render_element_outputs_filename(
+                    render_elements,
+                    self.output_file_path,
+                    self.output_file_name,
+                    self.output_file_format,
+                    ignore_list,
+                )
+                if warnings:
+                    for warning in warnings:
+                        self.logger.warning(f"Standard render element configuration: {warning}")
 
             # Validate final configuration
             settings = self._convert_data_to_settings(data)
@@ -249,7 +298,7 @@ class RenderElementManager:
         return elements_enabled
 
     def _handle_ignore_settings(
-        self, data: Dict[str, Any], render_elements: List[RenderElementInfo]
+        self, data: Dict[str, Any], render_elements: List[RenderElementInfo], ignore_list: List[str]
     ) -> None:
         """
         Handle render element ignore settings.
@@ -259,15 +308,11 @@ class RenderElementManager:
             render_elements: List of render elements from scene
         """
         # Handle ignore by name list
-        ignore_names_str = self._get_param_value(data, ["ignore_render_elements_by_name"], "")
-        if ignore_names_str:
-            ignore_names = [name.strip() for name in ignore_names_str.split(",") if name.strip()]
-            self.logger.info(f"Ignoring render elements by name: {ignore_names}")
-
+        if ignore_list:
             disabled_count = 0
             for element in render_elements:
                 element_name = element.name
-                if element_name in ignore_names:
+                if element_name in ignore_list:
                     try:
                         # Disable the render element using the underlying pymxs object
                         element_obj = element.element_object
@@ -326,7 +371,7 @@ class RenderElementManager:
             raise
 
     def _configure_vray_settings(
-        self, data: Dict[str, Any], render_elements: List[RenderElementInfo]
+        self, data: Dict[str, Any], render_elements: List[RenderElementInfo], ignore_list: List[str]
     ) -> None:
         """
         Configure V-Ray specific render element settings.
@@ -351,15 +396,31 @@ class RenderElementManager:
 
             if vfb_control or split_buffer:
                 self.logger.info(
-                    f"Configuring V-Ray settings - VFB Control: {vfb_control}, Split Buffer: {split_buffer}"
+                    f"Configuring V-Ray settings for '{self.current_renderer}' - VFB Control: {vfb_control}, Split Buffer: {split_buffer}"
                 )
+                if split_buffer:
+                    if self.output_file_path and self.output_file_name:
+                        self.logger.info(
+                            f"Split buffer output: {os.path.join(self.output_file_path, self.output_file_name)}"
+                        )
+                    else:
+                        self.logger.warning(
+                            f"Split buffer enabled but missing output info - path: '{self.output_file_path}', name: '{self.output_file_name}'"
+                        )
 
                 vray_settings = VRayRenderElementSettings(
                     vray_render_elements_vfb_control=vfb_control,
                     vray_split_buffer_support=split_buffer,
                 )
 
-                vray_warnings = configure_vray_render_elements(render_elements, vray_settings)
+                vray_warnings = configure_vray_render_elements(
+                    render_elements,
+                    vray_settings,
+                    output_path=self.output_file_path,
+                    output_name=self.output_file_name,
+                    output_file_format=self.output_file_format,
+                    ignore_list=ignore_list,
+                )
                 if vray_warnings:
                     for warning in vray_warnings:
                         self.logger.warning(f"V-Ray configuration: {warning}")
@@ -438,6 +499,21 @@ class RenderElementManager:
             self.logger.error(f"Failed to restore render elements: {e}")
             return RenderElementResult(success=False, error=str(e))
 
+    def _get_ignore_list(self, data: Dict[str, Any]) -> List[str]:
+        """
+        Parse ignore render elements list from configuration data.
+
+        Args:
+            data: Configuration data dictionary
+
+        Returns:
+            List of render element names to ignore
+        """
+        ignore_names_str = self._get_param_value(data, ["ignore_render_elements_by_name"], "")
+        if ignore_names_str:
+            return [name.strip() for name in ignore_names_str.split(",") if name.strip()]
+        return []
+
     def _get_param_value(
         self, data: Dict[str, Any], param_names: List[str], default: str = ""
     ) -> str:
@@ -471,12 +547,8 @@ class RenderElementManager:
         Returns:
             RenderElementConfigurationSettings object compatible with shared utilities
         """
-        # Convert ignore render elements by name
-        ignore_names_str = self._get_param_value(data, ["ignore_render_elements_by_name"], "")
-        if ignore_names_str:
-            ignore_names = [name.strip() for name in ignore_names_str.split(",") if name.strip()]
-        else:
-            ignore_names = []
+        # Use the parsed ignore list
+        ignore_names = self._get_ignore_list(data)
 
         # Convert boolean settings
         render_elements_update_paths = (

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
@@ -353,7 +353,11 @@ class DefaultMaxHandler:
                     RenderElementManager,
                 )
 
-                self.render_element_manager = RenderElementManager()
+                self.render_element_manager = RenderElementManager(
+                    output_file_path=self.output_dir,
+                    output_file_name=self.output_name,
+                    output_file_format=self.output_format,
+                )
 
             result = self.render_element_manager.configure_render_elements(data)
             if not result.success:

--- a/src/deadline/max_shared/utilities/max_utils.py
+++ b/src/deadline/max_shared/utilities/max_utils.py
@@ -10,7 +10,8 @@ and management.
 
 import logging
 import os
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional, TypedDict
 
@@ -49,7 +50,7 @@ class VRayRenderElementSettings:
     """
 
     vray_render_elements_vfb_control: bool = True
-    vray_split_buffer_support: bool = True
+    vray_split_buffer_support: bool = False
 
 
 @dataclass
@@ -61,17 +62,12 @@ class RenderElementConfigurationSettings:
     used for validation and path management.
     """
 
-    ignore_render_elements_by_name: Optional[list[str]] = None
+    ignore_render_elements_by_name: list[str] = field(default_factory=list)
     render_elements_update_paths: bool = True
     render_elements_include_name_in_path: bool = True
     render_elements_include_type_in_path: bool = False
     render_elements_include_name_in_filename: bool = True
     render_elements_include_type_in_filename: bool = False
-
-    def __post_init__(self):
-        """Initialize default values for mutable fields."""
-        if self.ignore_render_elements_by_name is None:
-            self.ignore_render_elements_by_name = []
 
 
 @dataclass
@@ -182,16 +178,10 @@ def validate_render_element_paths(render_elements: list[RenderElementInfo]) -> l
     for element in render_elements:
         element_name: str = element.name
         output_filename: str = element.output_filename
-        has_output_path: bool = element.has_output_path
         enabled: bool = element.enabled
 
         # Skip disabled render elements
         if not enabled:
-            continue
-
-        # Check for missing output paths
-        if not has_output_path or not output_filename:
-            warnings.append(f"Render element '{element_name}' has no output path specified")
             continue
 
         # Check if output directory is accessible
@@ -319,7 +309,7 @@ def validate_render_element_configuration(
         return warnings
 
     # Validate ignore by name settings
-    ignore_by_name: list[str] = settings.ignore_render_elements_by_name or []
+    ignore_by_name: list[str] = settings.ignore_render_elements_by_name
     if ignore_by_name:
         element_names: list[str] = [element.name for element in render_elements]
         for ignored_name in ignore_by_name:
@@ -396,7 +386,12 @@ def configure_render_element_paths(
 
 
 def configure_vray_render_elements(
-    render_elements: list[RenderElementInfo], settings: VRayRenderElementSettings
+    render_elements: list[RenderElementInfo],
+    settings: VRayRenderElementSettings,
+    output_path: Optional[str] = None,
+    output_name: Optional[str] = None,
+    output_file_format: Optional[str] = ".png",
+    ignore_list: list[str] = [],
 ) -> list:
     """
     Configures V-Ray specific render element settings.
@@ -408,6 +403,14 @@ def configure_vray_render_elements(
     :type render_elements: list[RenderElementInfo]
     :param settings: V-Ray render element settings
     :type settings: VRayRenderElementSettings
+    :param output_path: output directory path for split buffer files
+    :type output_path: str
+    :param output_name: base output filename for split buffer files
+    :type output_name: str
+    :param output_file_format: output file format/extension for split buffer files
+    :type output_file_format: str
+    :param ignore_list: list of render element names to ignore (disable)
+    :type ignore_list: list[str]
     :returns: list of configuration warnings
     :return_type: list[str]
     """
@@ -416,17 +419,157 @@ def configure_vray_render_elements(
     if not render_elements:
         return warnings
 
+    # Check if current renderer matches V-Ray pattern (^V_Ray.*$)
+    is_vray, current_renderer = _is_renderer_vray()
+
+    if not is_vray:
+        message = f"Skipping V-Ray render element configuration - current renderer '{current_renderer}' does not match V-Ray pattern"
+        _logger.info(message)
+        warnings.append(message)
+        return warnings
+
+    _logger.info(
+        f"V-Ray renderer detected: '{current_renderer}' - proceeding with V-Ray configuration"
+    )
+
     vfb_control: bool = settings.vray_render_elements_vfb_control
+    split_buffer: bool = settings.vray_split_buffer_support
 
     try:
+        # Configure global V-Ray VFB control if enabled
+        if vfb_control:
+            try:
+                rt.renderers.current.output_on = False
+                _logger.info(
+                    "Disabled V-Ray VFB (output_on = False) - render elements will use 3ds Max framebuffer"
+                )
+            except Exception as e:
+                warnings.append(f"Failed to configure global V-Ray VFB control: {e}")
+
+        # Configure split buffer if enabled
+        if split_buffer:
+            try:
+                rt.renderers.current.output_splitgbuffer = True
+
+                # Set the base filename for split files (critical for split buffer to work)
+                if output_path and output_name:
+                    # Prepare base filename with format extension
+                    base_name, _ = os.path.splitext(output_name)
+                    assert (
+                        output_file_format is not None
+                    )  # Should never be None due to default value
+                    extension = (
+                        output_file_format
+                        if output_file_format.startswith(".")
+                        else f".{output_file_format}"
+                    )
+                    filename_with_format = f"{base_name}{extension}"
+                    base_filepath = os.path.join(output_path, filename_with_format)
+                    rt.renderers.current.output_splitfilename = base_filepath
+                    _logger.info(f"V-Ray split buffer filename set to: {base_filepath}")
+                else:
+                    missing_params = []
+                    if not output_path:
+                        missing_params.append("output_file_path")
+                    if not output_name:
+                        missing_params.append("output_file_name (check template has this defined)")
+                    warnings.append(
+                        f"Split buffer enabled but missing: {', '.join(missing_params)} - split files may not save correctly"
+                    )
+
+                rt.renderers.current.output_splitRGB = True
+                rt.renderers.current.output_splitAlpha = True
+
+                _logger.info("V-Ray split buffer configured")
+            except Exception as e:
+                warnings.append(f"Failed to configure V-Ray split buffer: {e}")
+
+        # Configure split buffer filenames - set same base filename for all render elements
+        if split_buffer:
+            try:
+                re_manager = rt.maxOps.GetCurRenderElementMgr()
+                if re_manager and output_path and output_name:
+                    # Prepare base filename with format extension
+                    base_name, _ = os.path.splitext(output_name)
+                    assert (
+                        output_file_format is not None
+                    )  # Should never be None due to default value
+                    extension = (
+                        output_file_format
+                        if output_file_format.startswith(".")
+                        else f".{output_file_format}"
+                    )
+                    filename_with_format = f"{base_name}{extension}"
+                    base_filename = os.path.join(output_path, filename_with_format)
+
+                    # Set the SAME base filename for ALL enabled render elements
+                    # V-Ray VFB will automatically append layer names during rendering
+                    filename_set_count = 0
+                    for element in render_elements:
+                        if element.enabled and element.name not in ignore_list:
+                            try:
+                                re_manager.SetRenderElementFilename(element.index, base_filename)
+                                filename_set_count += 1
+                                _logger.debug(
+                                    f"Set V-Ray split buffer base filename for '{element.name}': {base_filename}"
+                                )
+                            except Exception as e:
+                                warnings.append(
+                                    f"Failed to set split buffer filename for '{element.name}': {e}"
+                                )
+
+                    _logger.info(
+                        f"V-Ray split buffer: Set base filename for {filename_set_count} render elements"
+                    )
+                else:
+                    if not re_manager:
+                        warnings.append(
+                            "V-Ray split buffer filename setup failed: No render element manager"
+                        )
+                    if not (output_path and output_name):
+                        warnings.append(
+                            "V-Ray split buffer filename setup skipped: Missing output path or name"
+                        )
+            except Exception as e:
+                warnings.append(f"Failed to configure V-Ray split buffer filenames: {e}")
+
+        # Configure per-element settings
+        enabled_count = 0
+        disabled_count = 0
+
         for element in render_elements:
             element_obj = element.element_object
             if not element_obj:
                 continue
 
             element_name: str = element.name
+            should_ignore = element_name in ignore_list
 
-            # Configure V-Ray VFB control
+            # Skip V-Ray VFB specific elements (matching Deadline 10 pattern)
+            element_type = str(rt.classof(element_obj))
+            if element_type in ["VRayOptionRE", "VRayAlpha"]:
+                _logger.debug(f"Skipping V-Ray VFB element: {element_name} ({element_type})")
+                continue
+
+            # Automatically enable/disable render elements based on VFB control and ignore list
+            if vfb_control:
+                try:
+                    if should_ignore:
+                        element_obj.enabled = False
+                        # Also update our wrapper to keep it in sync
+                        element.enabled = False
+                        disabled_count += 1
+                        _logger.info(f"Disabled render element (ignored): {element_name}")
+                    else:
+                        element_obj.enabled = True
+                        # Also update our wrapper to keep it in sync
+                        element.enabled = True
+                        enabled_count += 1
+                        _logger.debug(f"Enabled render element: {element_name}")
+                except Exception as e:
+                    warnings.append(f"Failed to set enabled state for '{element_name}': {e}")
+
+            # Configure V-Ray VFB control per element
             if hasattr(element_obj, "vrayVFB"):
                 try:
                     # Disable VFB for render elements when VFB control is enabled
@@ -435,8 +578,11 @@ def configure_vray_render_elements(
                 except Exception as e:
                     warnings.append(f"Failed to configure V-Ray VFB for '{element_name}': {e}")
 
-            # Additional V-Ray specific configurations can be added here
-            # based on element type and settings
+        # Log summary of enabled/disabled elements
+        if vfb_control:
+            _logger.info(
+                f"V-Ray VFB Control: Enabled {enabled_count} render elements, disabled {disabled_count}"
+            )
 
     except Exception as e:
         _logger.error(f"Error configuring V-Ray render elements: {e}")
@@ -551,6 +697,106 @@ def restore_original_render_element_state(original_state: RenderElementState) ->
         warnings.append(f"State restoration failed: {e}")
 
     return warnings
+
+
+def _configure_render_element_outputs_filename(
+    render_elements: list[RenderElementInfo],
+    output_path: Optional[str] = None,
+    output_name: Optional[str] = None,
+    output_file_format: Optional[str] = ".exr",
+    ignore_list: list[str] = [],
+) -> list[str]:
+    """
+    Configure output filenames for standard (non-VRay) render elements.
+
+    This function sets unique output filenames for each enabled render element
+    using standard 3ds Max naming conventions.
+
+    :param render_elements: list of RenderElementInfo objects
+    :param output_path: base output directory path
+    :param output_name: base output filename
+    :param output_file_format: output file format/extension
+    :param ignore_list: list of render element names to skip
+    :returns: list of configuration warnings
+    """
+    warnings: list[str] = []
+
+    if not render_elements:
+        return warnings
+
+    if not (output_path and output_name):
+        warnings.append(
+            "Standard render element filename configuration skipped: Missing output path or name"
+        )
+        return warnings
+
+    try:
+        re_manager = rt.maxOps.GetCurRenderElementMgr()
+        if not re_manager:
+            warnings.append(
+                "Standard render element filename configuration failed: No render element manager"
+            )
+            return warnings
+
+        # Prepare base filename without extension
+        base_filename, _ = os.path.splitext(output_name)
+
+        filename_set_count = 0
+        for element in render_elements:
+            if not element.enabled or element.name in ignore_list:
+                continue
+
+            try:
+                # Create unique filename: basename_elementname.ext
+                purified_element_name = purify_render_element_name(element.name)
+                assert output_file_format is not None  # Should never be None due to default value
+                extension = (
+                    output_file_format
+                    if output_file_format.startswith(".")
+                    else f".{output_file_format}"
+                )
+                unique_filename = f"{base_filename}_{purified_element_name}{extension}"
+                full_path = os.path.join(output_path, unique_filename)
+
+                # Set the render element filename
+                re_manager.SetRenderElementFilename(element.index, full_path)
+                filename_set_count += 1
+                _logger.debug(
+                    f"Set standard render element filename for '{element.name}': {full_path}"
+                )
+
+            except Exception as e:
+                warnings.append(f"Failed to set filename for render element '{element.name}': {e}")
+
+        _logger.info(
+            f"Standard render elements: Set unique filenames for {filename_set_count} render elements"
+        )
+
+    except Exception as e:
+        _logger.error(f"Error configuring standard render element filenames: {e}")
+        warnings.append(f"Standard render element filename configuration failed: {e}")
+
+    return warnings
+
+
+def _is_renderer_vray() -> tuple[bool, str]:
+    """
+    Check if the current renderer is V-Ray.
+
+    This is a private helper function that checks if the current renderer
+    matches the V-Ray pattern used throughout the Deadline integration.
+
+    :returns: tuple of (is_vray, renderer_name)
+    :return_type: tuple[bool, str]
+    """
+    try:
+        current_renderer = str(rt.renderers.current)
+        vray_pattern = r"^V_Ray.*$"
+        is_vray = bool(re.match(vray_pattern, current_renderer))
+        return is_vray, current_renderer
+    except Exception as e:
+        _logger.error(f"Failed to check current renderer: {e}")
+        return False, "Unknown"
 
 
 def _build_render_element_path(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Please read - https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/153 for a full code level walk through of this PR.
- This review is a chunked subset of changes specifically for the submitter UI. This is PR 4 of 4 for the render elements feature.

PR1 - Share utils: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/160
PR2 - Submission UI: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/161
PR3 - Adapter https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/162
PR4 - VRay render layer and VFB setup. This PR:  https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/167
- Original prototype (https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/152)

The 3ds Max adaptor needs to support Render Elements, and specifically for the VRay renderer.
- To use VRay with Render Elements, we need to turn off the VRay frame buffer and fallback to the 3dsmax frame buffer.
- Also, for general render elements, we did not set the output folder, enabled render elements only rendered to user configured locations. 

### What was the solution? (How)

Implemented comprehensive V-Ray render element support with renderer detection and split buffer functionality:

**V-Ray Split Buffer Implementation:**
- Added renderer-level split buffer configuration (`output_splitgbuffer`, `output_splitRGB`, `output_splitAlpha`)
- Implemented proper split buffer filename management with base filename setting
- Added split buffer validation and output file prediction

**Enhanced V-Ray VFB Control:**
- Added global V-Ray VFB control (`rt.renderers.current.output_on = False`)
- Implemented automatic render element enabling/disabling based on ignore lists
- Added per-element VFB control with proper `vrayVFB` property management

**Renderer Agnostic Architecture:**
- Added V-Ray detection using regex pattern (`^V_Ray.*$`)
- Implemented separate workflows for V-Ray vs standard renderers
- Added standard render element filename configuration for non-V-Ray renderers

### What is the impact of this change?
- RenderElements renders with VRay works properly even in headless mode!
- RenderElements (ART, Scanline) render elements outputs to the general job output folder.

### How was this change tested?
- Created Test Bundles, rendered both using ART and VRay with render elements. Render elements are outputed as part of the job.

### Was this change documented?
- NA
- Once this is merged, I am going to write a feature user guide doc.

### Is this a breaking change?

**No, this is not a breaking change.**

- All existing parameters and APIs remain unchanged
- Backward compatible with existing job templates and UI configurations
- Graceful handling of missing parameters with appropriate defaults
- Non-V-Ray renderers get enhanced standard render element support without disruption
- Existing V-Ray workflows are enhanced but not modified in breaking ways

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
