### PR TITLE
fix: Do not add render elements to init param if no render elements e…

### DIFF
--- a/src/deadline/max_submitter/create_job_bundle.py
+++ b/src/deadline/max_submitter/create_job_bundle.py
@@ -402,12 +402,13 @@ def _create_step_definitions(
         ):
             init_data["data"] += "camera: '{{Param.Camera}}'\n"
 
-        # Add render element parameters to init data
-        for param in RENDER_ELEMENT_PARAMS:
-            # Convert parameter name to snake_case for init data with proper mapping
-
-            init_data_key = RENDER_ELEMENT_PARAM_MAPPING.get(param, param.lower())
-            init_data["data"] += f"{init_data_key}: '{{{{Param.{param}}}}}'\n"
+        # Add render element parameters to init data only if render elements exist
+        render_elements = get_render_elements()
+        if render_elements:
+            for param in RENDER_ELEMENT_PARAMS:
+                # Convert parameter name to snake_case for init data with proper mapping
+                init_data_key = RENDER_ELEMENT_PARAM_MAPPING.get(param, param.lower())
+                init_data["data"] += f"{init_data_key}: '{{{{Param.{param}}}}}'\n"
 
     return job_template
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Submitter integration tests found a small bug, Init data attributes were added to the template for scenes with no render elements at all.
- This caused a validation issue when checking the submitter generated bundle. Prior integ tests all tested and generated bundles and scenes with render elements.
- The adaptor is backwards compatible to bundles w/o render elements, and we have an integ test case (minimal integ) to test it.

### What was the solution? (How)
- Check if the scene has Render Elements.

### What is the impact of this change?
- Fix bug caught by integration testing!

### How was this change tested?
```
& "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pytest test/integ -m submitter -o addopts="" -v
```

```
=================================================== warnings summary ==================================================== 
..\AppData\Roaming\Python\Python311\site-packages\_pytest\config\__init__.py:1474
  C:\Users\RDP\AppData\Roaming\Python\Python311\site-packages\_pytest\config\__init__.py:1474: PytestConfigWarning: Unknown config option: looponfailroots

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================== 1 passed, 4 deselected, 1 warning in 44.78s ====================================== 
```


```
& "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pytest test/integ -m adaptor -o addopts="" -v
```

```

test/integ/test_3dsmax_adaptors.py::TestAdaptors::test_minimal_scene_adapttor PASSED                                [ 25%]                          or PASSED                                [ 25%]
test/integ/test_3dsmax_render_elements.py::TestRenderElementsAdaptors::test_render_element_scene_adaptor[vray_re_test-fog.st_render_element_scene_adaptor[vray_re_test-fog.max-3] PASSED [ 50%]     
test/integ/test_3dsmax_render_elements.py::TestRenderElementsAdaptors::test_render_element_scene_adaptor[re_enabled_test-fst_render_element_scene_adaptor[re_enabled_test-fog.max-0] PASSED [ 75%]
test/integ/test_3dsmax_render_elements.py::TestRenderElementsAdaptors::test_render_element_scene_adaptor[re_disabled_test-fog.max-0] PASSED [100%]
=========================== warnings summary =========================== 
..\AppData\Roaming\Python\Python311\site-packages\_pytest\config\__init__.py:1474
  C:\Users\RDP\AppData\Roaming\Python\Python311\site-packages\_pytest\config\__init__.py:1474: PytestConfigWarning: Unknown config option: looponfailroots

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")      

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html  
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!test_render_element_scene_adaptor[vray_re_test-fog.max-3] passed 1 out of the required 1 times. Success!
test_render_element_scene_adaptor[re_enabled_test-fog.max-0] passed 1 out of the required 1 times. Success!
test_render_element_scene_adaptor[re_disabled_test-fog.max-0] passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
======== 4 passed, 1 deselected, 1 warning in 238.63s (0:03:58) ========
```

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*