### PR TITLE
fix: add VRay system environment variable detection

### DIFF
--- a/src/deadline/max_adaptor/MaxClient/max_client.py
+++ b/src/deadline/max_adaptor/MaxClient/max_client.py
@@ -81,9 +81,14 @@ class MaxClient(ClientInterface):
         # Set up logger interceptor when renderer is set
         self.logger_interceptor.setup()
 
-        render_handler = get_render_handler(renderer["renderer"])
-
-        self.actions.update(render_handler.action_dict)
+        try:
+            render_handler = get_render_handler(renderer["renderer"])
+            self.actions.update(render_handler.action_dict)
+        except Exception as e:
+            # Log the error and close Max to ensure clean exit
+            logger.error(f"Failed to initialize renderer: {e}")
+            self.close()
+            raise
 
     def close(self, args: Optional[dict] = None) -> None:
         # Tear down logger interceptor before closing

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -7,6 +7,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import math
 import os
 import sys
+from typing import Any
 
 from pymxs import runtime as rt
 
@@ -20,7 +21,7 @@ sys.stderr = sys.__stderr__
 class VrayHandler(DefaultMaxHandler):
     """Render Handler for V-Ray"""
 
-    def __init__(self, gpu):
+    def __init__(self, gpu: bool) -> None:
         """
         Initializes the V-Ray and V-Ray Handler
         """
@@ -34,26 +35,26 @@ class VrayHandler(DefaultMaxHandler):
         Raises RuntimeError with actionable message if variables are missing.
         """
         # Get 3ds Max year using the same formula as max_render_submitter.py
-        max_version = rt.maxVersion()
+        max_version: Any = rt.maxVersion()
         # Convert to int to handle both real values and mock objects
-        version_major = int(max_version[0])
-        year = 2000 + math.ceil(version_major / 1000.0) - 2
+        version_major: int = int(max_version[0])
+        year: int = 2000 + math.ceil(version_major / 1000.0) - 2
 
         # Define required environment variables
-        required_vars = [
+        required_vars: list[str] = [
             f"VRAY_FOR_3DSMAX{year}_MAIN",
             f"VRAY_FOR_3DSMAX{year}_PLUGINS",
             f"VRAY_MDL_PATH_3DSMAX{year}",
         ]
 
         # Check for missing variables
-        missing_vars = [var for var in required_vars if var not in os.environ]
+        missing_vars: list[str] = [var for var in required_vars if var not in os.environ]
 
         if missing_vars:
             error_msg = (
                 f"V-Ray renderer detected, but required environment variables are missing.\n"
-                f"Please set the following variables in your host configuration script:\n"
-                f"{chr(10).join(f'  - {var}' for var in missing_vars)}"
+                f"Please set the following variables in to the system environment variables:\n"
+                f"{os.linesep.join(f'  - {var}' for var in missing_vars)}"
             )
             print(error_msg, flush=True)
             raise RuntimeError(error_msg)
@@ -61,7 +62,7 @@ class VrayHandler(DefaultMaxHandler):
             # Print confirmation that VRay environment is properly configured
             success_msg = (
                 f"V-Ray environment validated successfully for 3ds Max {year}:\n"
-                f"{chr(10).join(f'  - {var}: {os.environ[var]}' for var in required_vars)}"
+                f"{os.linesep.join(f'  - {var}: {os.environ[var]}' for var in required_vars)}"
             )
             print(success_msg, flush=True)
 

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -4,6 +4,8 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
+import math
+import os
 import sys
 
 from pymxs import runtime as rt
@@ -24,6 +26,44 @@ class VrayHandler(DefaultMaxHandler):
         """
         super().__init__()
         self.gpu: bool = gpu
+        self._validate_vray_environment()
+
+    def _validate_vray_environment(self) -> None:
+        """
+        Validates that required VRay environment variables are set.
+        Raises RuntimeError with actionable message if variables are missing.
+        """
+        # Get 3ds Max year using the same formula as max_render_submitter.py
+        max_version = rt.maxVersion()
+        # Convert to int to handle both real values and mock objects
+        version_major = int(max_version[0])
+        year = 2000 + math.ceil(version_major / 1000.0) - 2
+
+        # Define required environment variables
+        required_vars = [
+            f"VRAY_FOR_3DSMAX{year}_MAIN",
+            f"VRAY_FOR_3DSMAX{year}_PLUGINS",
+            f"VRAY_MDL_PATH_3DSMAX{year}",
+        ]
+
+        # Check for missing variables
+        missing_vars = [var for var in required_vars if var not in os.environ]
+
+        if missing_vars:
+            error_msg = (
+                f"V-Ray renderer detected, but required environment variables are missing.\n"
+                f"Please set the following variables in your host configuration script:\n"
+                f"{chr(10).join(f'  - {var}' for var in missing_vars)}"
+            )
+            print(error_msg, flush=True)
+            raise RuntimeError(error_msg)
+        else:
+            # Print confirmation that VRay environment is properly configured
+            success_msg = (
+                f"V-Ray environment validated successfully for 3ds Max {year}:\n"
+                f"{chr(10).join(f'  - {var}: {os.environ[var]}' for var in required_vars)}"
+            )
+            print(success_msg, flush=True)
 
     def check_renderer(self) -> None:
         """

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-import os
-import sys
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -10,234 +8,141 @@ import pytest
 class TestVrayHandler:
     """Tests for VrayHandler environment variable validation"""
 
-    @patch.dict(
-        os.environ,
-        {
-            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
-            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
-            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
-        },
-        clear=True,
+    @pytest.mark.parametrize(
+        "max_version,year,gpu,env_vars",
+        [
+            pytest.param(
+                [27000, 27, 0, 0, 0],
+                2025,
+                False,
+                {
+                    "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+                    "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+                    "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+                },
+                id="3dsmax_2025_cpu",
+            ),
+            pytest.param(
+                [28000, 28, 0, 0, 0],
+                2026,
+                True,
+                {
+                    "VRAY_FOR_3DSMAX2026_MAIN": "C:\\ProgramData\\VRay\\main",
+                    "VRAY_FOR_3DSMAX2026_PLUGINS": "C:\\ProgramData\\VRay\\plugins",
+                    "VRAY_MDL_PATH_3DSMAX2026": "C:\\Program Files\\VRay\\mdl",
+                },
+                id="3dsmax_2026_gpu",
+            ),
+            pytest.param(
+                [26000, 26, 0, 0, 4098],
+                2024,
+                False,
+                {
+                    "VRAY_FOR_3DSMAX2024_MAIN": "/path/to/main",
+                    "VRAY_FOR_3DSMAX2024_PLUGINS": "/path/to/plugins",
+                    "VRAY_MDL_PATH_3DSMAX2024": "/path/to/mdl",
+                },
+                id="3dsmax_2024_cpu",
+            ),
+        ],
     )
-    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
-    def test_vray_handler_with_all_env_vars(self, mock_rt: Mock) -> None:
-        """Test VRay handler initializes successfully with all env vars"""
-        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
-
-        # Mock 3ds Max 2025: #(27000, 27, 0, 0, 0)
-        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
-
-        # Should not raise
-        handler = VrayHandler(gpu=False)
-        assert handler is not None
-        assert handler.gpu is False
-
-    @patch.dict(
-        os.environ,
-        {
-            "VRAY_FOR_3DSMAX2026_MAIN": "C:\\ProgramData\\VRay\\main",
-            "VRAY_FOR_3DSMAX2026_PLUGINS": "C:\\ProgramData\\VRay\\plugins",
-            "VRAY_MDL_PATH_3DSMAX2026": "C:\\Program Files\\VRay\\mdl",
-        },
-        clear=True,
-    )
-    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
-    def test_vray_gpu_handler_with_all_env_vars(self, mock_rt: Mock) -> None:
-        """Test VRay GPU handler also validates environment"""
-        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
-
-        # Mock 3ds Max 2026: #(28000, 28, 0, 0, 0)
-        mock_rt.maxVersion.return_value = [28000, 28, 0, 0, 0]
-
-        # Should not raise
-        handler = VrayHandler(gpu=True)
-        assert handler is not None
-        assert handler.gpu is True
-
-    def test_vray_handler_missing_all_env_vars(self) -> None:
-        """Test VRay handler fails with missing env vars"""
-        with patch.dict("os.environ", {}, clear=True):
-            with patch("pymxs.runtime") as mock_rt:
-                # Mock 3ds Max 2025: #(27000, 27, 0, 0, 0)
-                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
-
-                # Clear the module cache to ensure fresh import after patching
-                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
-                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
+    def test_vray_handler_with_valid_env_vars(
+        self, max_version: list[int], year: int, gpu: bool, env_vars: dict[str, str]
+    ) -> None:
+        """Test VRay handler initializes successfully with all required env vars"""
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+                mock_rt.maxVersion.return_value = max_version
 
                 from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
                     VrayHandler,
                 )
 
-                # Expect RuntimeError
+                handler = VrayHandler(gpu=gpu)
+                assert handler is not None
+                assert handler.gpu is gpu
+
+    @pytest.mark.parametrize(
+        "env_vars,expected_missing",
+        [
+            pytest.param(
+                {},
+                [
+                    "VRAY_FOR_3DSMAX2025_MAIN",
+                    "VRAY_FOR_3DSMAX2025_PLUGINS",
+                    "VRAY_MDL_PATH_3DSMAX2025",
+                ],
+                id="all_missing",
+            ),
+            pytest.param(
+                {
+                    "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+                    "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+                },
+                ["VRAY_FOR_3DSMAX2025_MAIN"],
+                id="missing_main",
+            ),
+            pytest.param(
+                {
+                    "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+                    "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+                },
+                ["VRAY_FOR_3DSMAX2025_PLUGINS"],
+                id="missing_plugins",
+            ),
+            pytest.param(
+                {
+                    "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+                    "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+                },
+                ["VRAY_MDL_PATH_3DSMAX2025"],
+                id="missing_mdl_path",
+            ),
+            pytest.param(
+                {
+                    "VRAY_FOR_3DSMAX2024_MAIN": "/path/to/main",
+                    "VRAY_FOR_3DSMAX2024_PLUGINS": "/path/to/plugins",
+                    "VRAY_MDL_PATH_3DSMAX2024": "/path/to/mdl",
+                },
+                [
+                    "VRAY_FOR_3DSMAX2025_MAIN",
+                    "VRAY_FOR_3DSMAX2025_PLUGINS",
+                    "VRAY_MDL_PATH_3DSMAX2025",
+                ],
+                id="wrong_year_2024_instead_of_2025",
+            ),
+        ],
+    )
+    def test_vray_handler_missing_env_vars(
+        self, env_vars: dict[str, str], expected_missing: list[str]
+    ) -> None:
+        """Test VRay handler fails with missing environment variables"""
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                    VrayHandler,
+                )
+
                 with pytest.raises(RuntimeError) as exc_info:
                     VrayHandler(gpu=False)
 
-                # Verify error message
                 error_msg = str(exc_info.value)
                 assert "V-Ray renderer detected" in error_msg
                 assert "required environment variables are missing" in error_msg
-                assert "VRAY_FOR_3DSMAX2025_MAIN" in error_msg
-                assert "VRAY_FOR_3DSMAX2025_PLUGINS" in error_msg
-                assert "VRAY_MDL_PATH_3DSMAX2025" in error_msg
 
-    def test_vray_handler_missing_main_variable(self) -> None:
-        """Test VRay handler fails with missing MAIN variable"""
-        env_vars = {
-            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
-            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
-        }
-        with patch.dict("os.environ", env_vars, clear=True):
-            with patch("pymxs.runtime") as mock_rt:
-                # Mock 3ds Max 2025
-                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+                # Check that all expected missing variables are in the error message
+                for var in expected_missing:
+                    assert var in error_msg
 
-                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
-                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
-
-                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
-                    VrayHandler,
-                )
-
-                # Expect RuntimeError
-                with pytest.raises(RuntimeError) as exc_info:
-                    VrayHandler(gpu=False)
-
-                # Verify error message contains the missing variable
-                error_msg = str(exc_info.value)
-                assert "VRAY_FOR_3DSMAX2025_MAIN" in error_msg
-                # Should not mention the variables that are present
-                assert "VRAY_FOR_3DSMAX2025_PLUGINS" not in error_msg
-                assert "VRAY_MDL_PATH_3DSMAX2025" not in error_msg
-
-    def test_vray_handler_missing_plugins_variable(self) -> None:
-        """Test VRay handler fails with missing PLUGINS variable"""
-        env_vars = {
-            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
-            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
-        }
-        with patch.dict("os.environ", env_vars, clear=True):
-            with patch("pymxs.runtime") as mock_rt:
-                # Mock 3ds Max 2025
-                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
-
-                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
-                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
-
-                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
-                    VrayHandler,
-                )
-
-                # Expect RuntimeError
-                with pytest.raises(RuntimeError) as exc_info:
-                    VrayHandler(gpu=False)
-
-                # Verify error message contains the missing variable
-                error_msg = str(exc_info.value)
-                assert "VRAY_FOR_3DSMAX2025_PLUGINS" in error_msg
-
-    def test_vray_handler_missing_mdl_path_variable(self) -> None:
-        """Test VRay handler fails with missing MDL_PATH variable"""
-        env_vars = {
-            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
-            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
-        }
-        with patch.dict("os.environ", env_vars, clear=True):
-            with patch("pymxs.runtime") as mock_rt:
-                # Mock 3ds Max 2025
-                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
-
-                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
-                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
-
-                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
-                    VrayHandler,
-                )
-
-                # Expect RuntimeError
-                with pytest.raises(RuntimeError) as exc_info:
-                    VrayHandler(gpu=False)
-
-                # Verify error message contains the missing variable
-                error_msg = str(exc_info.value)
-                assert "VRAY_MDL_PATH_3DSMAX2025" in error_msg
-
-    @patch.dict(
-        os.environ,
-        {
-            "VRAY_FOR_3DSMAX2024_MAIN": "/path/to/main",
-            "VRAY_FOR_3DSMAX2024_PLUGINS": "/path/to/plugins",
-            "VRAY_MDL_PATH_3DSMAX2024": "/path/to/mdl",
-        },
-        clear=True,
-    )
-    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
-    def test_vray_handler_with_3dsmax_2024(self, mock_rt: Mock) -> None:
-        """Test VRay handler with 3ds Max 2024"""
-        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
-
-        # Mock 3ds Max 2024: #(26000, 26, 0, 0, 4098)
-        mock_rt.maxVersion.return_value = [26000, 26, 0, 0, 4098]
-
-        # Should not raise
-        handler = VrayHandler(gpu=False)
-        assert handler is not None
-
-    def test_vray_handler_wrong_year_env_vars(self) -> None:
-        """Test VRay handler fails when env vars are for wrong year"""
-        env_vars = {
-            "VRAY_FOR_3DSMAX2024_MAIN": "/path/to/main",
-            "VRAY_FOR_3DSMAX2024_PLUGINS": "/path/to/plugins",
-            "VRAY_MDL_PATH_3DSMAX2024": "/path/to/mdl",
-        }
-        with patch.dict("os.environ", env_vars, clear=True):
-            with patch("pymxs.runtime") as mock_rt:
-                # Mock 3ds Max 2025 but env vars are for 2024
-                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
-
-                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
-                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
-
-                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
-                    VrayHandler,
-                )
-
-                # Expect RuntimeError because 2025 variables are missing
-                with pytest.raises(RuntimeError) as exc_info:
-                    VrayHandler(gpu=False)
-
-                # Verify error message asks for 2025 variables
-                error_msg = str(exc_info.value)
-                assert "VRAY_FOR_3DSMAX2025_MAIN" in error_msg
-                assert "VRAY_FOR_3DSMAX2025_PLUGINS" in error_msg
-                assert "VRAY_MDL_PATH_3DSMAX2025" in error_msg
-
-    def test_vray_handler_multiple_missing_vars(self) -> None:
-        """Test VRay handler lists all missing variables"""
-        env_vars = {
-            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
-            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
-        }
-        with patch.dict("os.environ", env_vars, clear=True):
-            with patch("pymxs.runtime") as mock_rt:
-                # Mock 3ds Max 2025
-                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
-
-                # Clear module cache after patching pymxs
-                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
-                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
-
-                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
-                    VrayHandler,
-                )
-
-                # Expect RuntimeError
-                with pytest.raises(RuntimeError) as exc_info:
-                    VrayHandler(gpu=False)
-
-                # Verify error message contains only the missing variable
-                error_msg = str(exc_info.value)
-                assert "VRAY_MDL_PATH_3DSMAX2025" in error_msg
-                # Present variables should not be in the error
-                assert "VRAY_FOR_3DSMAX2025_MAIN" not in error_msg
-                assert "VRAY_FOR_3DSMAX2025_PLUGINS" not in error_msg
+                # Check that present variables are not in the error message
+                all_vars = {
+                    "VRAY_FOR_3DSMAX2025_MAIN",
+                    "VRAY_FOR_3DSMAX2025_PLUGINS",
+                    "VRAY_MDL_PATH_3DSMAX2025",
+                }
+                present_vars = all_vars - set(expected_missing)
+                for var in present_vars:
+                    if var in env_vars:
+                        assert var not in error_msg

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
@@ -1,0 +1,243 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+class TestVrayHandler:
+    """Tests for VrayHandler environment variable validation"""
+
+    @patch.dict(
+        os.environ,
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+        clear=True,
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_vray_handler_with_all_env_vars(self, mock_rt: Mock) -> None:
+        """Test VRay handler initializes successfully with all env vars"""
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        # Mock 3ds Max 2025: #(27000, 27, 0, 0, 0)
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        # Should not raise
+        handler = VrayHandler(gpu=False)
+        assert handler is not None
+        assert handler.gpu is False
+
+    @patch.dict(
+        os.environ,
+        {
+            "VRAY_FOR_3DSMAX2026_MAIN": "C:\\ProgramData\\VRay\\main",
+            "VRAY_FOR_3DSMAX2026_PLUGINS": "C:\\ProgramData\\VRay\\plugins",
+            "VRAY_MDL_PATH_3DSMAX2026": "C:\\Program Files\\VRay\\mdl",
+        },
+        clear=True,
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_vray_gpu_handler_with_all_env_vars(self, mock_rt: Mock) -> None:
+        """Test VRay GPU handler also validates environment"""
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        # Mock 3ds Max 2026: #(28000, 28, 0, 0, 0)
+        mock_rt.maxVersion.return_value = [28000, 28, 0, 0, 0]
+
+        # Should not raise
+        handler = VrayHandler(gpu=True)
+        assert handler is not None
+        assert handler.gpu is True
+
+    def test_vray_handler_missing_all_env_vars(self) -> None:
+        """Test VRay handler fails with missing env vars"""
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("pymxs.runtime") as mock_rt:
+                # Mock 3ds Max 2025: #(27000, 27, 0, 0, 0)
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                # Clear the module cache to ensure fresh import after patching
+                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
+                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
+
+                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                    VrayHandler,
+                )
+
+                # Expect RuntimeError
+                with pytest.raises(RuntimeError) as exc_info:
+                    VrayHandler(gpu=False)
+
+                # Verify error message
+                error_msg = str(exc_info.value)
+                assert "V-Ray renderer detected" in error_msg
+                assert "required environment variables are missing" in error_msg
+                assert "VRAY_FOR_3DSMAX2025_MAIN" in error_msg
+                assert "VRAY_FOR_3DSMAX2025_PLUGINS" in error_msg
+                assert "VRAY_MDL_PATH_3DSMAX2025" in error_msg
+
+    def test_vray_handler_missing_main_variable(self) -> None:
+        """Test VRay handler fails with missing MAIN variable"""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        }
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("pymxs.runtime") as mock_rt:
+                # Mock 3ds Max 2025
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
+                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
+
+                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                    VrayHandler,
+                )
+
+                # Expect RuntimeError
+                with pytest.raises(RuntimeError) as exc_info:
+                    VrayHandler(gpu=False)
+
+                # Verify error message contains the missing variable
+                error_msg = str(exc_info.value)
+                assert "VRAY_FOR_3DSMAX2025_MAIN" in error_msg
+                # Should not mention the variables that are present
+                assert "VRAY_FOR_3DSMAX2025_PLUGINS" not in error_msg
+                assert "VRAY_MDL_PATH_3DSMAX2025" not in error_msg
+
+    def test_vray_handler_missing_plugins_variable(self) -> None:
+        """Test VRay handler fails with missing PLUGINS variable"""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        }
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("pymxs.runtime") as mock_rt:
+                # Mock 3ds Max 2025
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
+                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
+
+                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                    VrayHandler,
+                )
+
+                # Expect RuntimeError
+                with pytest.raises(RuntimeError) as exc_info:
+                    VrayHandler(gpu=False)
+
+                # Verify error message contains the missing variable
+                error_msg = str(exc_info.value)
+                assert "VRAY_FOR_3DSMAX2025_PLUGINS" in error_msg
+
+    def test_vray_handler_missing_mdl_path_variable(self) -> None:
+        """Test VRay handler fails with missing MDL_PATH variable"""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+        }
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("pymxs.runtime") as mock_rt:
+                # Mock 3ds Max 2025
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
+                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
+
+                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                    VrayHandler,
+                )
+
+                # Expect RuntimeError
+                with pytest.raises(RuntimeError) as exc_info:
+                    VrayHandler(gpu=False)
+
+                # Verify error message contains the missing variable
+                error_msg = str(exc_info.value)
+                assert "VRAY_MDL_PATH_3DSMAX2025" in error_msg
+
+    @patch.dict(
+        os.environ,
+        {
+            "VRAY_FOR_3DSMAX2024_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2024_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2024": "/path/to/mdl",
+        },
+        clear=True,
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_vray_handler_with_3dsmax_2024(self, mock_rt: Mock) -> None:
+        """Test VRay handler with 3ds Max 2024"""
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        # Mock 3ds Max 2024: #(26000, 26, 0, 0, 4098)
+        mock_rt.maxVersion.return_value = [26000, 26, 0, 0, 4098]
+
+        # Should not raise
+        handler = VrayHandler(gpu=False)
+        assert handler is not None
+
+    def test_vray_handler_wrong_year_env_vars(self) -> None:
+        """Test VRay handler fails when env vars are for wrong year"""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2024_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2024_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2024": "/path/to/mdl",
+        }
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("pymxs.runtime") as mock_rt:
+                # Mock 3ds Max 2025 but env vars are for 2024
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
+                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
+
+                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                    VrayHandler,
+                )
+
+                # Expect RuntimeError because 2025 variables are missing
+                with pytest.raises(RuntimeError) as exc_info:
+                    VrayHandler(gpu=False)
+
+                # Verify error message asks for 2025 variables
+                error_msg = str(exc_info.value)
+                assert "VRAY_FOR_3DSMAX2025_MAIN" in error_msg
+                assert "VRAY_FOR_3DSMAX2025_PLUGINS" in error_msg
+                assert "VRAY_MDL_PATH_3DSMAX2025" in error_msg
+
+    def test_vray_handler_multiple_missing_vars(self) -> None:
+        """Test VRay handler lists all missing variables"""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+        }
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("pymxs.runtime") as mock_rt:
+                # Mock 3ds Max 2025
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                # Clear module cache after patching pymxs
+                if "deadline.max_adaptor.MaxClient.render_handlers.vray_handler" in sys.modules:
+                    del sys.modules["deadline.max_adaptor.MaxClient.render_handlers.vray_handler"]
+
+                from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                    VrayHandler,
+                )
+
+                # Expect RuntimeError
+                with pytest.raises(RuntimeError) as exc_info:
+                    VrayHandler(gpu=False)
+
+                # Verify error message contains only the missing variable
+                error_msg = str(exc_info.value)
+                assert "VRAY_MDL_PATH_3DSMAX2025" in error_msg
+                # Present variables should not be in the error
+                assert "VRAY_FOR_3DSMAX2025_MAIN" not in error_msg
+                assert "VRAY_FOR_3DSMAX2025_PLUGINS" not in error_msg


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues
- When a user runs 3dsmax VRay without the environment variables set, the adapter does not give a clear indication why there is a failure.

### What was the solution? (How)
- Add an environment variable check before starting the adapter. Raise a runtime error, kill the adaptor w/ an appropriate error message.
- Handle different versions of 3dsmax by doing some release year parsing.

### What is the impact of this change?
- Better error handling and failure detection if the environment setup is not working well.

### How was this change tested?
- hatch build
- hatch run fmt
- hatch run lint
- hatch run test (New tests added)
- Running integration tests, with and without the environment variable set. All passed accordingly.

The error logs correctly show the missing environment variables are missing.
```
STDOUT: Performing action: {"name": "renderer", "args": {"renderer": "V_Ray_7_Hotfix_2"}}
STDOUT: Logger interceptor set up for render element manager
STDOUT: V-Ray renderer detected, but required environment variables are missing.
STDERR: Failed to initialize renderer: V-Ray renderer detected, but required environment variables are missing.
STDOUT: Please set the following variables in your host configuration script:
STDERR: Please set the following variables in your host configuration script:
STDOUT:   - VRAY_FOR_3DSMAX2026_MAIN
STDERR:   - VRAY_FOR_3DSMAX2026_MAIN
STDOUT: Logger interceptor torn down
STDERR: - 00:58:25.094 INFO: Begin resolve assembly...
STDOUT: Performing action: {"name": "close", "args": null}
```

### Was this change documented?
- This is an error message.

### Is this a breaking change?
- No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*