### PR TITLE
feat: Fix Lightmix rendering with FBO split buffers

### DIFF
--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from pymxs import runtime as rt
 
+from deadline.max_shared.utilities.max_utils import set_vray_output_path
+
 from .default_max_handler import DefaultMaxHandler
 
 # Re-assign sys stdout and stderr to print in the console instead of the Max Listener
@@ -102,3 +104,19 @@ class VrayHandler(DefaultMaxHandler):
             if "V_Ray" not in current_renderer or "V_Ray_GPU" in current_renderer:
                 # Set to most recent version of V-Ray
                 rt.renderers.current = vray()
+
+    def start_render(self, data: dict) -> None:
+        """
+        Override to set V-Ray output path before rendering.
+
+        Always sets V-Ray output path for both standard V-Ray and V-Ray RT.
+        """
+        # Always set V-Ray output path
+        if self.output_dir and self.output_name:
+            set_vray_output_path(
+                output_path=self.output_dir,
+                output_name=self.output_name,
+                output_format=self.output_format or ".exr",
+            )
+
+        super().start_render(data)

--- a/src/deadline/max_shared/utilities/max_utils.py
+++ b/src/deadline/max_shared/utilities/max_utils.py
@@ -92,6 +92,51 @@ class RenderElementState:
         self.vray_vfb_states = []
 
 
+# V-Ray RT class IDs (GPU renderer)
+_VRAY_RT_CLASS_IDS: list[str] = [
+    "#(1770671000, 1323107829)",
+    "#(1770671000L, 1323107829L)",
+]
+
+
+def _is_vray_rt() -> bool:
+    """
+    Check if current renderer is V-Ray RT (GPU).
+
+    Uses both class ID detection (reliable) and name-based detection (fallback).
+
+    :returns: True if V-Ray RT, False otherwise
+    :return_type: bool
+    """
+    renderer: Any = rt.renderers.current
+    renderer_class_id: str = str(renderer.classid)
+    renderer_name: str = str(renderer)
+
+    # Primary: Class ID detection (most reliable)
+    class_id_match: bool = any(class_id in renderer_class_id for class_id in _VRAY_RT_CLASS_IDS)
+
+    # Fallback: Name-based detection
+    name_match: bool = "V_Ray_GPU" in renderer_name
+
+    return class_id_match or name_match
+
+
+def _get_vray_rt_settings() -> Optional[Any]:
+    """
+    Get the V-Ray RT settings object if current renderer is V-Ray RT.
+
+    V-Ray RT (GPU) uses nested V_Ray_settings object.
+    Standard V-Ray uses direct renderer access.
+
+    :returns: V_Ray_settings object for V-Ray RT, None for standard V-Ray
+    :return_type: Optional[Any]
+    """
+    if _is_vray_rt():
+        renderer: Any = rt.renderers.current
+        return renderer.V_Ray_settings
+    return None
+
+
 def get_render_elements() -> list[RenderElementInfo]:
     """
     Gets all render elements present in the max scene with their properties.
@@ -385,6 +430,48 @@ def configure_render_element_paths(
     return warnings
 
 
+def set_vray_output_path(
+    output_path: str,
+    output_name: str,
+    output_format: str = ".exr",
+) -> list[str]:
+    """
+    Set V-Ray split buffer output path for both standard V-Ray and V-Ray RT.
+
+    Only sets the output path (output_splitfilename).
+    Split buffer flags are controlled by configure_vray_render_elements().
+
+    :param output_path: base output directory path
+    :type output_path: str
+    :param output_name: base output filename
+    :type output_name: str
+    :param output_format: output file format/extension (default: .exr)
+    :type output_format: str
+    :returns: list of warning messages
+    :return_type: list[str]
+    """
+    warnings: list[str] = []
+    split_filepath: str = os.path.join(output_path, f"{output_name}{output_format}")
+
+    try:
+        # Always set for standard V-Ray
+        rt.renderers.current.output_splitfilename = split_filepath
+
+        # Also set for V-Ray RT if applicable
+        vray_rt_settings: Optional[Any] = _get_vray_rt_settings()
+        if vray_rt_settings is not None:
+            vray_rt_settings.output_splitfilename = split_filepath
+
+        _logger.info(f"V-Ray output path set to: {split_filepath}")
+
+    except Exception as e:
+        error_msg: str = f"Failed to set V-Ray output path: {e}"
+        _logger.error(error_msg)
+        warnings.append(error_msg)
+
+    return warnings
+
+
 def configure_vray_render_elements(
     render_elements: list[RenderElementInfo],
     settings: VRayRenderElementSettings,
@@ -442,7 +529,14 @@ def configure_vray_render_elements(
         # Configure global V-Ray VFB control if enabled
         if vfb_control:
             try:
+                # Always set for standard V-Ray
                 rt.renderers.current.output_on = False
+
+                # Also set for V-Ray RT if applicable
+                vray_rt_settings: Optional[Any] = _get_vray_rt_settings()
+                if vray_rt_settings is not None:
+                    vray_rt_settings.output_on = False
+
                 _logger.info(
                     "Disabled V-Ray VFB (output_on = False) - render elements will use 3ds Max framebuffer"
                 )
@@ -452,6 +546,7 @@ def configure_vray_render_elements(
         # Configure split buffer if enabled
         if split_buffer:
             try:
+                # Always set for standard V-Ray
                 rt.renderers.current.output_splitgbuffer = True
 
                 # Set the base filename for split files (critical for split buffer to work)
@@ -480,8 +575,37 @@ def configure_vray_render_elements(
                         f"Split buffer enabled but missing: {', '.join(missing_params)} - split files may not save correctly"
                     )
 
+                # Always set for standard V-Ray
                 rt.renderers.current.output_splitRGB = True
                 rt.renderers.current.output_splitAlpha = True
+
+                # Set output_splitbitmap to enable render elements to inherit the output path
+                # This is required for V-Ray render elements (like LightMix) to save correctly
+                # The bitmap needs to be created with the split filename
+                try:
+                    if output_path and output_name:
+                        # Create a bitmap for the split output
+                        split_bitmap = rt.bitmap(1, 1, filename=base_filepath)
+                        rt.renderers.current.output_splitbitmap = split_bitmap
+                        _logger.info(f"V-Ray output_splitbitmap set to: {base_filepath}")
+                except Exception as bitmap_e:
+                    _logger.warning(f"Could not set output_splitbitmap: {bitmap_e}")
+
+                # Also set for V-Ray RT if applicable
+                vray_rt_split_settings: Optional[Any] = _get_vray_rt_settings()
+                if vray_rt_split_settings is not None:
+                    vray_rt_split_settings.output_splitgbuffer = True
+                    vray_rt_split_settings.output_splitRGB = True
+                    vray_rt_split_settings.output_splitAlpha = True
+                    # Set output_splitbitmap for V-Ray RT as well
+                    try:
+                        if output_path and output_name:
+                            split_bitmap_rt = rt.bitmap(1, 1, filename=base_filepath)
+                            vray_rt_split_settings.output_splitbitmap = split_bitmap_rt
+                    except Exception as bitmap_rt_e:
+                        _logger.warning(
+                            f"Could not set output_splitbitmap for V-Ray RT: {bitmap_rt_e}"
+                        )
 
                 _logger.info("V-Ray split buffer configured")
             except Exception as e:

--- a/src/deadline/max_shared/utilities/max_utils.py
+++ b/src/deadline/max_shared/utilities/max_utils.py
@@ -106,7 +106,6 @@ def _is_vray_rt() -> bool:
     Uses both class ID detection (reliable) and name-based detection (fallback).
 
     :returns: True if V-Ray RT, False otherwise
-    :return_type: bool
     """
     renderer: Any = rt.renderers.current
     renderer_class_id: str = str(renderer.classid)
@@ -129,7 +128,6 @@ def _get_vray_rt_settings() -> Optional[Any]:
     Standard V-Ray uses direct renderer access.
 
     :returns: V_Ray_settings object for V-Ray RT, None for standard V-Ray
-    :return_type: Optional[Any]
     """
     if _is_vray_rt():
         renderer: Any = rt.renderers.current
@@ -146,7 +144,6 @@ def get_render_elements() -> list[RenderElementInfo]:
     index tracking for later manipulation.
 
     :returns: a list of RenderElementInfo objects containing render element information
-    :return_type: list[RenderElementInfo]
     """
     render_elements: list[RenderElementInfo] = []
 
@@ -214,9 +211,7 @@ def validate_render_element_paths(render_elements: list[RenderElementInfo]) -> l
     sanity check system for render elements.
 
     :param render_elements: list of RenderElementInfo objects from get_render_elements()
-    :type render_elements: list[RenderElementInfo]
     :returns: list of warning messages for render elements with path issues
-    :return_type: list[str]
     """
     warnings: list[str] = []
 
@@ -259,7 +254,6 @@ def get_render_elements_output_directories() -> set[str]:
     and the adaptor (for directory creation and validation).
 
     :returns: set of directory paths where render elements will be output
-    :return_type: set[str]
     """
     output_dirs: set[str] = set()
 
@@ -290,9 +284,7 @@ def purify_render_element_name(element_name: str) -> str:
     consistent naming between GUI submission and render execution.
 
     :param element_name: original render element name
-    :type element_name: str
     :returns: purified element name safe for file paths
-    :return_type: str
     """
     if not element_name:
         return "Element"
@@ -319,9 +311,7 @@ def get_render_element_by_name(element_name: str) -> Optional[RenderElementInfo]
     Gets a specific render element by name.
 
     :param element_name: name of the render element to find
-    :type element_name: str
     :returns: RenderElementInfo object or None if not found
-    :return_type: RenderElementInfo or None
     """
     render_elements: list[RenderElementInfo] = get_render_elements()
 
@@ -342,11 +332,8 @@ def validate_render_element_configuration(
     to ensure consistency between GUI configuration and render execution.
 
     :param render_elements: list of RenderElementInfo objects
-    :type render_elements: list[RenderElementInfo]
     :param settings: render element configuration settings
-    :type settings: RenderElementConfigurationSettings
     :returns: list of validation warnings
-    :return_type: list[str]
     """
     warnings: list[str] = []
 
@@ -381,11 +368,8 @@ def configure_render_element_paths(
     Deadline 10's path management system, including name/type inclusion options.
 
     :param render_elements: list of RenderElementInfo objects
-    :type render_elements: list[RenderElementInfo]
     :param settings: render element configuration settings
-    :type settings: RenderElementConfigurationSettings
     :returns: list of configuration warnings
-    :return_type: list[str]
     """
     warnings: list[str] = []
 
@@ -434,7 +418,7 @@ def set_vray_output_path(
     output_path: str,
     output_name: str,
     output_format: str = ".exr",
-) -> list[str]:
+) -> None:
     """
     Set V-Ray split buffer output path for both standard V-Ray and V-Ray RT.
 
@@ -442,15 +426,10 @@ def set_vray_output_path(
     Split buffer flags are controlled by configure_vray_render_elements().
 
     :param output_path: base output directory path
-    :type output_path: str
     :param output_name: base output filename
-    :type output_name: str
     :param output_format: output file format/extension (default: .exr)
-    :type output_format: str
-    :returns: list of warning messages
-    :return_type: list[str]
+    :raises RuntimeError: if V-Ray output path cannot be set
     """
-    warnings: list[str] = []
     split_filepath: str = os.path.join(output_path, f"{output_name}{output_format}")
 
     try:
@@ -467,9 +446,7 @@ def set_vray_output_path(
     except Exception as e:
         error_msg: str = f"Failed to set V-Ray output path: {e}"
         _logger.error(error_msg)
-        warnings.append(error_msg)
-
-    return warnings
+        raise RuntimeError(error_msg) from e
 
 
 def configure_vray_render_elements(
@@ -490,19 +467,12 @@ def configure_vray_render_elements(
     file format specification.
 
     :param render_elements: list of RenderElementInfo objects
-    :type render_elements: list[RenderElementInfo]
     :param settings: V-Ray render element settings
-    :type settings: VRayRenderElementSettings
     :param output_path: output directory path for split buffer files
-    :type output_path: str
     :param output_name: base output filename for split buffer files
-    :type output_name: str
     :param output_file_format: output file format/extension for split buffer files (default: .png)
-    :type output_file_format: str
     :param ignore_list: list of render element names to ignore (disable)
-    :type ignore_list: list[str]
     :returns: list of configuration warnings
-    :return_type: list[str]
     """
     warnings: list[str] = []
 
@@ -728,9 +698,7 @@ def store_original_render_element_state(
     to enable restoration after rendering completes.
 
     :param render_elements: list of RenderElementInfo objects
-    :type render_elements: list[RenderElementInfo]
     :returns: RenderElementState object containing original state information
-    :return_type: RenderElementState
     """
     original_state = RenderElementState()
 
@@ -774,9 +742,7 @@ def restore_original_render_element_state(original_state: RenderElementState) ->
     using previously stored state information.
 
     :param original_state: RenderElementState object containing original state information
-    :type original_state: RenderElementState
     :returns: list of restoration warnings
-    :return_type: list[str]
     """
     warnings: list[str] = []
 
@@ -918,7 +884,6 @@ def _is_renderer_vray() -> tuple[bool, str]:
     matches the V-Ray pattern used throughout the Deadline integration.
 
     :returns: tuple of (is_vray, renderer_name)
-    :return_type: tuple[bool, str]
     """
     try:
         current_renderer = str(rt.renderers.current)
@@ -943,15 +908,10 @@ def _build_render_element_path(
     based on Deadline 10's path building logic.
 
     :param base_path: original base path
-    :type base_path: str
     :param element_name: render element name
-    :type element_name: str
     :param element_type: render element type
-    :type element_type: str
     :param settings: render element configuration settings
-    :type settings: RenderElementConfigurationSettings
     :returns: constructed path
-    :return_type: str
     """
     try:
         path_obj: Path = Path(base_path)
@@ -1004,7 +964,6 @@ def detect_missing_render_elements() -> list[MissingRenderElementInfo]:
     matching Deadline 10's missing element detection system.
 
     :returns: list of typed dictionaries containing missing element information
-    :return_type: list[MissingRenderElementInfo]
     """
     missing_elements: list[MissingRenderElementInfo] = []
 
@@ -1044,9 +1003,7 @@ def validate_render_element_names(render_elements: list[RenderElementInfo]) -> l
     render element name checking system.
 
     :param render_elements: list of RenderElementInfo objects
-    :type render_elements: list[RenderElementInfo]
     :returns: list of validation warnings
-    :return_type: list[str]
     """
     warnings: list[str] = []
 
@@ -1095,9 +1052,7 @@ def resolve_duplicate_render_element_names(render_elements: list[RenderElementIn
     duplicate name handling system.
 
     :param render_elements: list of RenderElementInfo objects
-    :type render_elements: list[RenderElementInfo]
     :returns: dictionary mapping original names to suggested unique names
-    :return_type: dict[str, str]
     """
     name_resolutions: dict[str, str] = {}
     name_counts: dict[str, int] = {}
@@ -1141,11 +1096,8 @@ def preview_render_element_paths(
     matching Deadline 10's path preview functionality.
 
     :param render_elements: list of RenderElementInfo objects
-    :type render_elements: list[RenderElementInfo]
     :param settings: render element configuration settings
-    :type settings: RenderElementConfigurationSettings
     :returns: dictionary mapping element names to preview paths
-    :return_type: dict[str, str]
     """
     path_previews: dict[str, str] = {}
 
@@ -1197,9 +1149,7 @@ def analyze_render_element_compatibility(
     renderer-specific render element validation.
 
     :param render_elements: list of RenderElementInfo objects
-    :type render_elements: list[RenderElementInfo]
     :returns: typed dictionary containing compatibility analysis
-    :return_type: RenderElementCompatibilityAnalysis
     """
     analysis: RenderElementCompatibilityAnalysis = {
         "total_elements": len(render_elements),
@@ -1278,7 +1228,6 @@ def get_render_element_statistics() -> RenderElementStatistics:
     render element reporting system.
 
     :returns: typed dictionary containing render element statistics
-    :return_type: RenderElementStatistics
     """
     stats: RenderElementStatistics = {
         "total_elements": 0,

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -50,6 +50,48 @@ ALLOWED_EXTENSIONS = [
     ["V-Ray Image Format (*.vrimg)", ".vrimg"],
 ]
 
+# Render Elements Preset Configurations
+# Each preset defines the render element settings values
+RENDER_ELEMENTS_PRESETS: dict[str, dict[str, bool]] = {
+    "Default": {
+        "enabled_modify_render_elements": False,
+        "render_elements": True,
+        "render_elements_update_paths": True,
+        "render_elements_include_name_in_path": True,
+        "render_elements_include_type_in_path": False,
+        "render_elements_include_name_in_filename": True,
+        "render_elements_include_type_in_filename": False,
+        "vray_render_elements_vfb_control": True,
+        "vray_split_buffer_support": True,
+    },
+    "VRay with 3dsMax Render Buffer": {
+        # Uses 3ds Max framebuffer (disables V-Ray VFB)
+        # Split buffer enabled for render element output
+        "enabled_modify_render_elements": True,
+        "render_elements": True,
+        "render_elements_update_paths": True,
+        "render_elements_include_name_in_path": True,
+        "render_elements_include_type_in_path": False,
+        "render_elements_include_name_in_filename": True,
+        "render_elements_include_type_in_filename": False,
+        "vray_render_elements_vfb_control": True,  # Disables V-Ray VFB (output_on = False)
+        "vray_split_buffer_support": True,  # Enables split buffer for render elements
+    },
+    "VRay Render Buffer": {
+        # Uses V-Ray VFB (frame buffer) for output
+        # Split buffer enabled for render elements to save to individual files
+        "enabled_modify_render_elements": True,
+        "render_elements": True,
+        "render_elements_update_paths": True,
+        "render_elements_include_name_in_path": True,
+        "render_elements_include_type_in_path": False,
+        "render_elements_include_name_in_filename": True,
+        "render_elements_include_type_in_filename": False,
+        "vray_render_elements_vfb_control": False,  # Keeps V-Ray VFB enabled (output_on = True)
+        "vray_split_buffer_support": True,  # Enables split buffer for render elements
+    },
+}
+
 # Materials allowed for custom override on submit
 SCENE_TWEAKS_MATS = [
     "Standard Grayscale Material",

--- a/src/deadline/max_submitter/ui/render_elements_widget.py
+++ b/src/deadline/max_submitter/ui/render_elements_widget.py
@@ -12,6 +12,7 @@ import logging
 from qtpy.QtCore import Qt, Signal  # type: ignore
 from qtpy.QtWidgets import (  # type: ignore
     QCheckBox,
+    QComboBox,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
@@ -27,6 +28,7 @@ from deadline.max_shared.utilities.max_utils import (
     get_render_elements,
     validate_render_element_paths,
 )
+from deadline.max_submitter.data_const import RENDER_ELEMENTS_PRESETS
 
 _logger = logging.getLogger(__name__)
 
@@ -84,50 +86,64 @@ class RenderElementsWidget(QWidget):
         layout = QGridLayout(render_elements_group)
         main_layout.addWidget(render_elements_group)
 
-        # Row 0: Modify Render Elements checkbox (main control)
+        # Row 0: Preset Configuration dropdown (inside render elements group)
+        preset_label = QLabel("Preset Configurations:")
+        self.preset_combo = QComboBox()
+        for preset_name in RENDER_ELEMENTS_PRESETS.keys():
+            self.preset_combo.addItem(preset_name, preset_name)
+        self.preset_combo.setToolTip(
+            "Select a preset configuration for render elements settings.\n"
+            "Default: Standard settings with modification disabled.\n"
+            "VRay with 3dsMax Render Buffer: Uses 3ds Max framebuffer for V-Ray render elements.\n"
+            "VRay Render Buffer: Uses V-Ray's native VFB for render element output."
+        )
+        layout.addWidget(preset_label, 0, 0)
+        layout.addWidget(self.preset_combo, 0, 1)
+
+        # Row 1: Modify Render Elements checkbox (main control)
         self.modify_render_elements_checkbox = QCheckBox("Modify Render Elements")
         self.modify_render_elements_checkbox.setChecked(False)  # Default unchecked
         self.modify_render_elements_checkbox.setToolTip(
             "Enable or disable modification of render elements settings. "
             "When unchecked, all render elements setting changes on the worker will be disabled."
         )
-        layout.addWidget(self.modify_render_elements_checkbox, 0, 0, 1, 2)
+        layout.addWidget(self.modify_render_elements_checkbox, 1, 0, 1, 2)
 
-        # Row 1: Output Render Elements checkbox
+        # Row 2: Output Render Elements checkbox
         self.render_elements_checkbox = QCheckBox("Output Render Elements")
         self.render_elements_checkbox.setToolTip(
             "Enable or disable render elements output during rendering"
         )
-        layout.addWidget(self.render_elements_checkbox, 1, 0, 1, 2)
+        layout.addWidget(self.render_elements_checkbox, 2, 0, 1, 2)
 
-        # Row 2: Update Render Element Paths checkbox
+        # Row 3: Update Render Element Paths checkbox
         self.update_paths_checkbox = QCheckBox("Update Render Element Paths")
         self.update_paths_checkbox.setToolTip(
             "Automatically update render element output paths based on naming settings"
         )
-        layout.addWidget(self.update_paths_checkbox, 2, 0, 1, 2)
+        layout.addWidget(self.update_paths_checkbox, 3, 0, 1, 2)
 
-        # Row 3: Path naming options
+        # Row 4: Path naming options
         self.include_name_in_path_checkbox = QCheckBox("Include Render Element Name in Path")
         self.include_name_in_path_checkbox.setToolTip(
             "Add render element name as subdirectory in output path"
         )
-        layout.addWidget(self.include_name_in_path_checkbox, 3, 0)
+        layout.addWidget(self.include_name_in_path_checkbox, 4, 0)
 
         self.include_type_in_path_checkbox = QCheckBox("Include Render Element Type in Path")
         self.include_type_in_path_checkbox.setToolTip(
             "Add render element type as subdirectory in output path"
         )
-        layout.addWidget(self.include_type_in_path_checkbox, 3, 1)
+        layout.addWidget(self.include_type_in_path_checkbox, 4, 1)
 
-        # Row 4: Filename naming options
+        # Row 5: Filename naming options
         self.include_name_in_filename_checkbox = QCheckBox(
             "Include Render Element Name in Filename"
         )
         self.include_name_in_filename_checkbox.setToolTip(
             "Add render element name to output filename"
         )
-        layout.addWidget(self.include_name_in_filename_checkbox, 4, 0)
+        layout.addWidget(self.include_name_in_filename_checkbox, 5, 0)
 
         self.include_type_in_filename_checkbox = QCheckBox(
             "Include Render Element Type in Filename"
@@ -135,34 +151,34 @@ class RenderElementsWidget(QWidget):
         self.include_type_in_filename_checkbox.setToolTip(
             "Add render element type to output filename"
         )
-        layout.addWidget(self.include_type_in_filename_checkbox, 4, 1)
+        layout.addWidget(self.include_type_in_filename_checkbox, 5, 1)
 
-        # Row 5: V-Ray specific options
+        # Row 6: V-Ray specific options
         self.vray_vfb_control_checkbox = QCheckBox("V-Ray Render Elements VFB Control")
         self.vray_vfb_control_checkbox.setToolTip(
             "Automatically control V-Ray VFB settings for render elements during rendering"
         )
-        layout.addWidget(self.vray_vfb_control_checkbox, 5, 0)
+        layout.addWidget(self.vray_vfb_control_checkbox, 6, 0)
 
         self.vray_split_buffer_checkbox = QCheckBox("V-Ray Split Buffer Support")
         self.vray_split_buffer_checkbox.setToolTip(
             "Enable V-Ray split buffer support for render elements"
         )
-        layout.addWidget(self.vray_split_buffer_checkbox, 5, 1)
+        layout.addWidget(self.vray_split_buffer_checkbox, 6, 1)
 
-        # Row 6: Ignore by Name section
+        # Row 7: Ignore by Name section
         ignore_label = QLabel("Ignore Render Elements by Name:")
-        layout.addWidget(ignore_label, 6, 0, 1, 2)
+        layout.addWidget(ignore_label, 7, 0, 1, 2)
 
-        # Row 7: Ignore elements list
+        # Row 8: Ignore elements list
         self.ignore_elements_list = QListWidget()
         self.ignore_elements_list.setMaximumHeight(80)
         self.ignore_elements_list.setToolTip(
             "List of render element names to ignore during rendering"
         )
-        layout.addWidget(self.ignore_elements_list, 7, 0, 1, 2)
+        layout.addWidget(self.ignore_elements_list, 8, 0, 1, 2)
 
-        # Row 8: Ignore list management buttons
+        # Row 9: Ignore list management buttons
         ignore_buttons_layout = QHBoxLayout()
         self.add_ignore_btn = QPushButton("Add Element")
         self.add_ignore_btn.setToolTip("Add selected detected element to ignore list")
@@ -175,30 +191,30 @@ class RenderElementsWidget(QWidget):
 
         ignore_buttons_widget = QWidget()
         ignore_buttons_widget.setLayout(ignore_buttons_layout)
-        layout.addWidget(ignore_buttons_widget, 8, 0, 1, 2)
+        layout.addWidget(ignore_buttons_widget, 9, 0, 1, 2)
 
-        # Row 9: Detected elements list
+        # Row 10: Detected elements list
         detected_label = QLabel("Detected Render Elements:")
-        layout.addWidget(detected_label, 9, 0, 1, 2)
+        layout.addWidget(detected_label, 10, 0, 1, 2)
 
         self.detected_elements_list = QListWidget()
         self.detected_elements_list.setMaximumHeight(120)
         self.detected_elements_list.setToolTip(
             "List of render elements detected in the current scene"
         )
-        layout.addWidget(self.detected_elements_list, 10, 0, 1, 2)
+        layout.addWidget(self.detected_elements_list, 11, 0, 1, 2)
 
-        # Row 11: Refresh button
+        # Row 12: Refresh button
         self.refresh_elements_btn = QPushButton("Refresh Detected Elements")
         self.refresh_elements_btn.setToolTip("Refresh the list of detected render elements")
-        layout.addWidget(self.refresh_elements_btn, 11, 0, 1, 2)
+        layout.addWidget(self.refresh_elements_btn, 12, 0, 1, 2)
 
-        # Row 12: Validation feedback
+        # Row 13: Validation feedback
         self.validation_feedback_label = QLabel("")
         self.validation_feedback_label.setStyleSheet("color: red;")
         self.validation_feedback_label.setWordWrap(True)
         self.validation_feedback_label.setMinimumHeight(40)
-        layout.addWidget(self.validation_feedback_label, 12, 0, 1, 2)
+        layout.addWidget(self.validation_feedback_label, 13, 0, 1, 2)
 
         # Store all controllable widgets for easy enable/disable
         self._controllable_widgets = [
@@ -224,6 +240,9 @@ class RenderElementsWidget(QWidget):
         """
         Connect all widget signals to their respective handlers.
         """
+        # Preset configuration dropdown
+        self.preset_combo.currentIndexChanged.connect(self._on_preset_changed)
+
         # main control
         self.modify_render_elements_checkbox.stateChanged.connect(
             self._on_modify_render_elements_changed
@@ -253,6 +272,51 @@ class RenderElementsWidget(QWidget):
         """
         # Trigger the main control handler to set initial state
         self._on_modify_render_elements_changed(self.modify_render_elements_checkbox.checkState())
+
+    def _on_preset_changed(self, index: int) -> None:
+        """
+        Handle preset configuration dropdown changes.
+        Applies the selected preset's values to all render element checkboxes.
+
+        :param index: the index of the selected preset
+        :type index: int
+        """
+        preset_name = self.preset_combo.currentData()
+        if preset_name not in RENDER_ELEMENTS_PRESETS:
+            return
+
+        preset_values = RENDER_ELEMENTS_PRESETS[preset_name]
+
+        # Apply preset values to checkboxes
+        self.modify_render_elements_checkbox.setChecked(
+            preset_values.get("enabled_modify_render_elements", False)
+        )
+        self.render_elements_checkbox.setChecked(preset_values.get("render_elements", True))
+        self.update_paths_checkbox.setChecked(
+            preset_values.get("render_elements_update_paths", True)
+        )
+        self.include_name_in_path_checkbox.setChecked(
+            preset_values.get("render_elements_include_name_in_path", True)
+        )
+        self.include_type_in_path_checkbox.setChecked(
+            preset_values.get("render_elements_include_type_in_path", False)
+        )
+        self.include_name_in_filename_checkbox.setChecked(
+            preset_values.get("render_elements_include_name_in_filename", True)
+        )
+        self.include_type_in_filename_checkbox.setChecked(
+            preset_values.get("render_elements_include_type_in_filename", False)
+        )
+        self.vray_vfb_control_checkbox.setChecked(
+            preset_values.get("vray_render_elements_vfb_control", True)
+        )
+        self.vray_split_buffer_checkbox.setChecked(
+            preset_values.get("vray_split_buffer_support", True)
+        )
+
+        # Refresh UI state to enable/disable controls based on new values
+        self._refresh_ui_state()
+        self._on_settings_changed()
 
     def _on_modify_render_elements_changed(self, state):
         """

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -238,15 +238,15 @@ class SceneSettingsWidget(QWidget):
         self.render_elements_widget.validation_changed.connect(
             self._on_render_elements_validation_changed
         )
-        lyt.addWidget(self.render_elements_widget, 12, 0, 4, 5)
+        lyt.addWidget(self.render_elements_widget, 12, 0, 5, 5)
 
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 16, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 17, 0)
 
-        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 17, 0)
+        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 18, 0)
 
         self._fill_cameras_box(0)
 

--- a/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
+++ b/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
@@ -565,12 +565,11 @@ def test_set_vray_output_path_standard_vray(mock_rt: MagicMock) -> None:
     output_format: str = ".exr"
 
     # WHEN - Set V-Ray output path
-    warnings: list[str] = set_vray_output_path(output_path, output_name, output_format)
+    set_vray_output_path(output_path, output_name, output_format)
 
     # THEN - Should set path on standard renderer only
     expected_path: str = f"C:/output{os.sep}test_render.exr"
     assert mock_renderer.output_splitfilename == expected_path
-    assert warnings == []
 
 
 @patch("deadline.max_shared.utilities.max_utils.rt")
@@ -591,13 +590,38 @@ def test_set_vray_output_path_vray_rt(mock_rt: MagicMock) -> None:
     output_format: str = ".png"
 
     # WHEN - Set V-Ray output path
-    warnings: list[str] = set_vray_output_path(output_path, output_name, output_format)
+    set_vray_output_path(output_path, output_name, output_format)
 
     # THEN - Should set path on both standard renderer and RT settings
     expected_path: str = f"C:/output{os.sep}test_render.png"
     assert mock_renderer.output_splitfilename == expected_path
     assert mock_vray_settings.output_splitfilename == expected_path
-    assert warnings == []
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_set_vray_output_path_raises_on_failure(mock_rt: MagicMock) -> None:
+    """Test set_vray_output_path raises RuntimeError when setting path fails."""
+    import pytest
+
+    from deadline.max_shared.utilities.max_utils import set_vray_output_path
+
+    # GIVEN - Mock renderer that raises exception when setting output_splitfilename
+    mock_renderer = MagicMock()
+    mock_renderer.classid = "#(1941615238, 2012806412)"
+    mock_renderer.__str__.return_value = "V_Ray_6"  # type: ignore[attr-defined]
+    type(mock_renderer).output_splitfilename = property(
+        fget=lambda self: None,
+        fset=MagicMock(side_effect=Exception("V-Ray API error")),
+    )
+    mock_rt.renderers.current = mock_renderer
+
+    output_path: str = "C:/output"
+    output_name: str = "test_render"
+    output_format: str = ".exr"
+
+    # WHEN/THEN - Should raise RuntimeError
+    with pytest.raises(RuntimeError, match="Failed to set V-Ray output path"):
+        set_vray_output_path(output_path, output_name, output_format)
 
 
 @patch("deadline.max_shared.utilities.max_utils.rt")

--- a/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
+++ b/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
@@ -542,3 +542,124 @@ def test_configure_render_element_outputs_filename_with_special_characters(mock_
 
     for i, expected_filename in enumerate(expected_filenames):
         mock_re_manager.SetRenderElementFilename.assert_any_call(i, expected_filename)
+
+
+# ============================================================================
+# V-Ray RT Tests
+# ============================================================================
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_set_vray_output_path_standard_vray(mock_rt: MagicMock) -> None:
+    """Test set_vray_output_path sets path for standard V-Ray only."""
+    from deadline.max_shared.utilities.max_utils import set_vray_output_path
+
+    # GIVEN - Mock standard V-Ray renderer
+    mock_renderer = MagicMock()
+    mock_renderer.classid = "#(1941615238, 2012806412)"
+    mock_renderer.__str__.return_value = "V_Ray_6"  # type: ignore[attr-defined]
+    mock_rt.renderers.current = mock_renderer
+
+    output_path: str = "C:/output"
+    output_name: str = "test_render"
+    output_format: str = ".exr"
+
+    # WHEN - Set V-Ray output path
+    warnings: list[str] = set_vray_output_path(output_path, output_name, output_format)
+
+    # THEN - Should set path on standard renderer only
+    expected_path: str = f"C:/output{os.sep}test_render.exr"
+    assert mock_renderer.output_splitfilename == expected_path
+    assert warnings == []
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_set_vray_output_path_vray_rt(mock_rt: MagicMock) -> None:
+    """Test set_vray_output_path sets path for both standard V-Ray and V-Ray RT."""
+    from deadline.max_shared.utilities.max_utils import set_vray_output_path
+
+    # GIVEN - Mock V-Ray RT renderer
+    mock_renderer = MagicMock()
+    mock_renderer.classid = "#(1770671000, 1323107829)"
+    mock_renderer.__str__.return_value = "V_Ray_GPU_6"  # type: ignore[attr-defined]
+    mock_vray_settings = MagicMock()
+    mock_renderer.V_Ray_settings = mock_vray_settings
+    mock_rt.renderers.current = mock_renderer
+
+    output_path: str = "C:/output"
+    output_name: str = "test_render"
+    output_format: str = ".png"
+
+    # WHEN - Set V-Ray output path
+    warnings: list[str] = set_vray_output_path(output_path, output_name, output_format)
+
+    # THEN - Should set path on both standard renderer and RT settings
+    expected_path: str = f"C:/output{os.sep}test_render.png"
+    assert mock_renderer.output_splitfilename == expected_path
+    assert mock_vray_settings.output_splitfilename == expected_path
+    assert warnings == []
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_render_elements_sets_rt_settings(mock_rt: MagicMock) -> None:
+    """Test configure_vray_render_elements sets both standard and RT settings."""
+    from deadline.max_shared.utilities.max_utils import (
+        configure_vray_render_elements,
+        VRayRenderElementSettings,
+    )
+
+    # GIVEN - Mock V-Ray RT renderer
+    mock_renderer = MagicMock()
+    mock_renderer.classid = "#(1770671000, 1323107829)"
+    mock_renderer.__str__.return_value = "V_Ray_GPU_6"  # type: ignore[attr-defined]
+    mock_renderer.output_on = True
+    mock_renderer.output_splitgbuffer = False
+    mock_renderer.output_splitRGB = False
+    mock_renderer.output_splitAlpha = False
+
+    mock_vray_settings = MagicMock()
+    mock_vray_settings.output_on = True
+    mock_vray_settings.output_splitgbuffer = False
+    mock_vray_settings.output_splitRGB = False
+    mock_vray_settings.output_splitAlpha = False
+    mock_renderer.V_Ray_settings = mock_vray_settings
+
+    mock_rt.renderers.current = mock_renderer
+
+    # Mock render element manager
+    mock_re_manager = Mock()
+    mock_rt.maxOps.GetCurRenderElementMgr.return_value = mock_re_manager
+
+    # Create VRay render element
+    vray_element = _create_mock_vray_render_element(
+        "VRayDiffuseFilter", "VRayDiffuseFilter", True, 0
+    )
+
+    settings = VRayRenderElementSettings(
+        vray_render_elements_vfb_control=True,
+        vray_split_buffer_support=True,
+    )
+
+    # WHEN - Configure VRay render elements
+    warnings: list[str] = configure_vray_render_elements(
+        [vray_element],
+        settings,
+        output_path="C:/output",
+        output_name="test",
+        output_file_format=".png",
+    )
+
+    # THEN - Both standard and RT settings should be configured
+    assert mock_renderer.output_on is False
+    assert mock_vray_settings.output_on is False
+
+    assert mock_renderer.output_splitgbuffer is True
+    assert mock_vray_settings.output_splitgbuffer is True
+
+    assert mock_renderer.output_splitRGB is True
+    assert mock_vray_settings.output_splitRGB is True
+
+    assert mock_renderer.output_splitAlpha is True
+    assert mock_vray_settings.output_splitAlpha is True
+
+    assert isinstance(warnings, list)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Customers have asked to support 3dsMax with VRay and rendering the lightmix render element with every light as a split file. This allows users to do post processing and composition by adjusting each light layer.

### What was the solution? (How)
- No new feature toggles, we were only missing the output path setting specifically in the VRay settings struct. Before, we were setting the generic 3dsmax setting only.
- Added a new "presets" drop down with the correct setting for VRay FBO (lightmix case) and 3dsmax FBO (split elements, maxbatch case)

### What is the impact of this change?
- Enable users to use VRay with 3dsmax on deadline cloud better!
- Make it easier for users to use our submitter, especially when there are so many toggles.

<img width="540" height="728" alt="Screenshot 2026-01-07 at 10 38 41 AM" src="https://github.com/user-attachments/assets/5cb8cf0e-7c36-425e-8e92-9a7c25079322" />

### How was this change tested?
- Created a Vray scene based on 3dsmax samples, added a VRay camera, Vray lights
- Exported a job bundle, and added an integ test - https://github.com/aws-deadline/deadline-cloud-for-3ds-max/pull/182 
  - I split up the test because the test is a bunch of large binaries.
- The integ test verifies the different lights are rendered as unique files.

### Was this change documented?
- NA, I will go update the user docs separately.

### Is this a breaking change?
- No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*