### PR TITLE
chore: add test and docs for integration_data_interface_version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,15 @@
 
 ### Was this change documented?
 
+### Did you modify schema files?
+- [ ] Yes
+- [ ] No
+
+If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
+See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
+   - [ ] Yes
+   - [ ] No
+
 ### Is this a breaking change?
 
 ----

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,6 +106,17 @@ your build of the adaptor for the one in the service.
 
 3. Open the 3ds Max integrated submitter, and in the Job-Specific Settings tab, enable the option 'Include Adaptor Wheels'. This option is only visible when the environment variable `DEADLINE_ENABLE_DEVELOPER_OPTIONS` is set to `true`. Then submit your test job.
 
+#### Adaptor Schema Files
+
+The adaptor uses two JSON schema files to define the contract between the 3ds Max submitter (running on artist workstations)
+and the 3ds Max adaptor (running on cloud render workers):
+
+- `src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json` - Defines the initialization data passed once when the adaptor starts
+- `src/deadline/max_adaptor/MaxAdaptor/schemas/run_data.schema.json` - Defines the per-task data passed for each frame/task to render
+
+**Important:** Whenever you modify either of these schema files, you **must** also update the `integration_data_interface_version`
+in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` following semantic versioning.
+
 ### Integration Test Workflow
 Integration tests are located under `test/integ` directory of this repository. If you are adding
 or modifying functionality, then you will want to be writing one or more integ tests to demonstrate that your

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py
@@ -2,13 +2,58 @@
 
 from __future__ import annotations
 
+import json
 import re
+from pathlib import Path
 from unittest.mock import Mock, PropertyMock, patch
 
 import jsonschema  # type: ignore
 import pytest
+from openjd.adaptor_runtime.adaptors import SemanticVersion
 from deadline.max_adaptor.MaxAdaptor import MaxAdaptor
 from deadline.max_adaptor.MaxAdaptor.adaptor import _FIRST_MAX_ACTIONS, MaxNotRunningError
+
+# Test data that exercises ALL properties in init_data schema
+# If the schema changes (properties added/removed/modified), this test data
+# must be updated AND the integration_data_interface_version must be bumped
+EXPECTED_INIT_DATA_PROPERTIES = {
+    "camera": "Camera001",
+    "output_file_path": "/path/to/output",
+    "output_file_name": "output_###",
+    "output_file_format": ".jpg",
+    "state_set": "State01",
+    "renderer": "Default_Scanline_Renderer",
+    "scene_file": "/path/to/scene.max",
+    "strict_error_checking": True,
+    "enabled_modify_render_elements": "false",
+    "render_elements": "false",
+    "render_elements_update_paths": "false",
+    "render_elements_include_name_in_path": "false",
+    "render_elements_include_type_in_path": "false",
+    "render_elements_include_name_in_filename": "false",
+    "render_elements_include_type_in_filename": "false",
+    "vray_render_elements_vfb_control": "false",
+    "vray_split_buffer_support": "false",
+    "ignore_render_elements_by_name": "element1,element2",
+}
+
+# Required fields for init_data schema
+EXPECTED_INIT_DATA_REQUIRED = ["renderer", "scene_file"]
+
+# Test data that exercises ALL properties in run_data schema
+# If the schema changes (properties added/removed/modified), this test data
+# must be updated AND the integration_data_interface_version must be bumped
+EXPECTED_RUN_DATA_PROPERTIES = {
+    "frame": 1,
+    "camera": "Camera001",
+}
+
+# Required fields for run_data schema
+EXPECTED_RUN_DATA_REQUIRED = ["frame"]
+
+# Expected version - must be bumped when schemas change
+EXPECTED_SCHEMA_VERSION_MAJOR = 0
+EXPECTED_SCHEMA_VERSION_MINOR = 1
 
 
 @pytest.fixture
@@ -41,6 +86,110 @@ def run_data() -> dict:
         dict: A run_data dictionary
     """
     return {"frame": 42}
+
+
+class TestMaxAdaptor_semantic_version:
+    def test_semantic_version(self, init_data: dict) -> None:
+        """Tests that the adaptor semantic version is in the expected format"""
+        adaptor = MaxAdaptor(init_data)
+        assert adaptor.integration_data_interface_version == SemanticVersion(major=0, minor=1)
+
+    def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(
+        self, init_data: dict
+    ) -> None:
+        """
+        Test to validate that if the init data or run data schema are changed, we also bump the
+        integration_data_interface_version. We load the schema files and validate expected test data
+        that we define as EXPECTED_INIT_DATA_PROPERTIES and EXPECTED_RUN_DATA_PROPERTIES
+        """
+        adaptor = MaxAdaptor(init_data)
+        semantic_version = adaptor.integration_data_interface_version
+
+        root_directory_path = Path(__file__).parent.parent.parent.parent.parent
+        schema_path = root_directory_path.joinpath(
+            "src", "deadline", "max_adaptor", "MaxAdaptor", "schemas"
+        )
+        init_data_path = schema_path.joinpath("init_data.schema.json")
+        run_data_path = schema_path.joinpath("run_data.schema.json")
+
+        # Load actual schemas
+        with init_data_path.open() as init_data_schema_file:
+            init_data_schema = json.load(init_data_schema_file)
+
+        with run_data_path.open() as run_data_schema_file:
+            run_data_schema = json.load(run_data_schema_file)
+
+        # Validate that our test data covers all schema properties
+        init_schema_properties = set(init_data_schema.get("properties", {}).keys())
+        expected_init_properties = set(EXPECTED_INIT_DATA_PROPERTIES.keys())
+
+        run_schema_properties = set(run_data_schema.get("properties", {}).keys())
+        expected_run_properties = set(EXPECTED_RUN_DATA_PROPERTIES.keys())
+
+        # Check init_data schema properties
+        assert init_schema_properties == expected_init_properties, (
+            f"If the init_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+            f"Schema properties have changed - "
+            f"Missing in test: {init_schema_properties - expected_init_properties}. "
+            f"Extra in test: {expected_init_properties - init_schema_properties}. "
+        )
+
+        # Check run_data schema properties
+        assert run_schema_properties == expected_run_properties, (
+            f"If the run_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+            f"Schema properties have changed - "
+            f"Missing in test: {run_schema_properties - expected_run_properties}. "
+            f"Extra in test: {expected_run_properties - run_schema_properties}. "
+        )
+
+        # Check init_data required fields
+        init_schema_required = set(init_data_schema.get("required", []))
+        expected_init_required = set(EXPECTED_INIT_DATA_REQUIRED)
+        assert init_schema_required == expected_init_required, (
+            f"If the init_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+            f"Schema required fields have changed - "
+            f"Missing in test: {init_schema_required - expected_init_required}. "
+            f"Extra in test: {expected_init_required - init_schema_required}. "
+        )
+
+        # Check run_data required fields
+        run_schema_required = set(run_data_schema.get("required", []))
+        expected_run_required = set(EXPECTED_RUN_DATA_REQUIRED)
+        assert run_schema_required == expected_run_required, (
+            f"If the run_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+            f"Schema required fields have changed - "
+            f"Missing in test: {run_schema_required - expected_run_required}. "
+            f"Extra in test: {expected_run_required - run_schema_required}. "
+        )
+
+        # Validate test data against schemas using jsonschema
+        try:
+            jsonschema.validate(EXPECTED_INIT_DATA_PROPERTIES, init_data_schema)
+        except jsonschema.ValidationError as e:
+            pytest.fail(
+                f"If the init_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+                f"Schema validation failed: {e.message}. "
+            )
+
+        try:
+            jsonschema.validate(EXPECTED_RUN_DATA_PROPERTIES, run_data_schema)
+        except jsonschema.ValidationError as e:
+            pytest.fail(
+                f"If the run_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+                f"Schema validation failed: {e.message}. "
+            )
+
+        # Verify version matches expected version
+        assert semantic_version.major == EXPECTED_SCHEMA_VERSION_MAJOR, (
+            f"If the init_data.schema.json or run_data.schema.json is changed, "
+            f"the integration_data_interface_version must be bumped. "
+            f"Expected major version {EXPECTED_SCHEMA_VERSION_MAJOR}, got {semantic_version.major}. "
+        )
+        assert semantic_version.minor == EXPECTED_SCHEMA_VERSION_MINOR, (
+            f"If the init_data.schema.json or run_data.schema.json is changed, "
+            f"the integration_data_interface_version must be bumped. "
+            f"Expected minor version {EXPECTED_SCHEMA_VERSION_MINOR}, got {semantic_version.minor}. "
+        )
 
 
 class TestMaxAdaptor_on_start:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/79

### What was the problem/requirement? (What/Why)
When the ``init_data.schema.yaml`` or ``run_data.schema.yaml`` is changed, the adaptor's ``integration_data_interface_version`` should also be increased. We have a note in the pull request template that this is a breaking change, but the instructions only indicate to include an ! in your conventional commit title and to add instructions for upgrading to the PR. However, they don't indicate that you need to increase the ``integration_data_interface_version``, which could be missed.

### What was the solution? (How)
Added tests that if the ``init_data.schema.yaml`` or ``run_data.schema.yaml`` is changed, the ``integration_data_interface_version`` is also increased.

Also added information to Pull request and Development files to serve as a reminder to contributor for bumping the schema version when required.

### What is the impact of this change?
Contributors will now be reminded to update the ``integration_data_interface_version`` if ``init_data`` or ``run_data`` schemas have been changed as the test will fail. Contributors can also see this documented on relevant sections.

### How was this change tested?
ran ``hatch run all:test`` after adding new test case

```
======================================== slowest 5 durations =========================================
0.13s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_max_init_timeout
0.03s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_server_init_fail
0.02s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_on_run_render_fail
0.02s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_on_run
0.02s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_stop::test_on_stop
======================================== 107 passed in 3.88s =========================================
```

### Was this change documented?
Yes, corresponding documentation changes also in PR.

### Is this a breaking change?
N/A, only test + documentation change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*