### PR TITLE
docs: Kiro Powers to design, implement and test loop

### DIFF
--- a/.kiro/powers/3dsmax-design-power/POWER.md
+++ b/.kiro/powers/3dsmax-design-power/POWER.md
@@ -2,7 +2,7 @@
 name: "3dsmax-design-power"
 displayName: "3ds Max Design Power"
 description: "Structured design assistant for 3ds Max and V-Ray features in Deadline Cloud. Creates comprehensive design documents covering data structures, UX changes, job templates, and adapter modifications."
-keywords: ["3dsmax", "vray", "design", "maxscript", "pymxs", "deadline", "render"]
+keywords: ["3dsmax", "vray", "design", "maxscript", "pymxs"]
 author: "AWS Deadline Cloud Team"
 ---
 
@@ -59,113 +59,14 @@ def export_vrscene(self, data: dict) -> None:
 4. **Flag new sections** with `<!-- REVIEW: description -->` comments in the appendix
 5. **Don't include review tags** in final generated code
 
-## Available Steering Files
-
-This power has three steering files for detailed workflows:
-
-- **design-workflow.md** - Step-by-step guide for creating design documents
-- **research-guide.md** - How to research MAXScript/pymxs APIs and V-Ray documentation
-- **deadline-cloud-architecture.md** - Architecture overview of submitter → adaptor → MaxClient flow
-
-## Design Document Structure
-
-Every design document MUST follow this four-section structure:
-
-### 1. Data Structures to Change or Add
-
-Define all data model changes including:
-- New dataclasses or TypedDicts
-- Modifications to existing data structures
-- Job parameter schemas
-- Configuration objects
-- Type annotations (use `Any` for pymxs objects)
-
-### 2. UX Changes (Submitter Dialog)
-
-Document all user-facing changes:
-- New UI controls (dropdowns, checkboxes, text fields)
-- Control placement and grouping
-- Default values and validation
-- Tooltips and help text
-- Conditional visibility logic
-
-### 3. Job Template and Bundle Changes
-
-Specify modifications to:
-- Job template YAML structure
-- New parameters and their types
-- Parameter dependencies and conditions
-- Asset references and attachments
-
-### 4. Adapter Server-Client Changes
-
-Detail the runtime implementation:
-- Handler modifications (DefaultMaxHandler, VrayHandler, etc.)
-- New action handlers
-- MaxClient changes
-- Path mapping considerations
-- pymxs/MAXScript API usage
-
 ## Research Requirements
 
-Before finalizing any design, perform this research:
-
-### 1. 3ds Max and V-Ray Documentation
-- MAXScript API reference
-- pymxs Python bindings
-- V-Ray MAXScript properties
-- Renderer class IDs and detection
-
-### 2. Deadline 10 Historical Implementation
-If Deadline 10 code is not available, ASK THE USER to provide relevant code snippets.
-
-### 3. Internet Research
-Query the internet when documentation is unclear or incomplete.
+Before finalizing any design, research 3ds Max/V-Ray APIs, Deadline 10 implementation, and internet sources. Refer to **research-guide.md** for details.
 
 ## Key Technical Patterns
 
-### pymxs and MAXScript Integration
-
-**Key Insight**: All MAXScript methods documented for 3ds Max will work in pymxs!
-
-```python
-from pymxs import runtime as rt
-
-# MAXScript methods work identically in pymxs:
-re_mgr = rt.maxOps.GetCurRenderElementMgr()
-re_mgr.AddRenderElement(rt.VRayLightSelect())
-```
-
-### V-Ray Renderer Detection
-
-```python
-VRAY_STANDARD_CLASS_IDS = ["#(1941615238, 2012806412)", "#(1941615238L, 2012806412L)"]
-VRAY_RT_CLASS_IDS = ["#(1770671000, 1323107829)", "#(1770671000L, 1323107829L)"]
-
-def is_vray_rt() -> bool:
-    renderer_class_id = str(rt.renderers.current.classid)
-    return any(cid in renderer_class_id for cid in VRAY_RT_CLASS_IDS)
-```
-
-### V-Ray Settings Access
-
-```python
-# Standard V-Ray: direct access
-rt.renderers.current.output_splitfilename = path
-
-# V-Ray RT: nested V_Ray_settings object
-rt.renderers.current.V_Ray_settings.output_splitfilename = path
-```
-
-## Example Designs
-
-Reference these existing design documents:
-- `design/vray_output_paths_design.md` - V-Ray output path handling
-- `design/vray_out_buffer.md` - VFB output filename handling
-- `design/vrmesh.md` - VRMesh path mapping
+Refer to **research-guide.md** for pymxs/MAXScript patterns, V-Ray renderer detection, and settings access.
 
 ## External References
 
-- [GitHub Discussion #163 - Render Elements Design](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/163)
-- [GitHub Discussion #164 - MAXScript/pymxs Integration](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/164)
-- [OpenJD Sessions for Python](https://github.com/OpenJobDescription/openjd-sessions-for-python)
+Refer to **external-references.md** for GitHub discussions and documentation links.

--- a/.kiro/powers/3dsmax-design-power/POWER.md
+++ b/.kiro/powers/3dsmax-design-power/POWER.md
@@ -1,0 +1,171 @@
+---
+name: "3dsmax-design-power"
+displayName: "3ds Max Design Power"
+description: "Structured design assistant for 3ds Max and V-Ray features in Deadline Cloud. Creates comprehensive design documents covering data structures, UX changes, job templates, and adapter modifications."
+keywords: ["3dsmax", "vray", "design", "maxscript", "pymxs", "deadline", "render"]
+author: "AWS Deadline Cloud Team"
+---
+
+# 3ds Max Design Power
+
+## Overview
+
+A structured design assistant for creating comprehensive feature designs for 3ds Max and V-Ray integration with AWS Deadline Cloud. This power helps create well-structured design documents following a consistent four-section format that covers all aspects of implementation.
+
+## Code Snippet Style Guide
+
+When including code in design documents, use **concise inline snippets** in the main sections and put **full implementations in an appendix**.
+
+### Inline Code Format
+
+Show only the relevant changes with context:
+
+```python
+def existing_function():
+    ...existing logic...
+    
+    # NEW: Add feature X support
+    if feature_x_enabled:
+        self._configure_feature_x(data)
+    
+    ...rest of function...
+```
+
+### Appendix Format
+
+Put complete implementations in a clearly marked appendix section:
+
+```markdown
+---
+
+## Appendix: Full Code Implementations
+
+<!-- REVIEW: New export_vrscene implementation -->
+
+### A.1 VrayHandler.export_vrscene (Full Implementation)
+
+\`\`\`python
+def export_vrscene(self, data: dict) -> None:
+    """Full implementation here..."""
+    # Complete code
+\`\`\`
+```
+
+### Guidelines
+
+1. **Data structures are the exception**: Always show full definitions - they anchor the design
+2. **Other sections**: Show what changes and where, not full implementations
+3. **Use `...` or comments** to indicate existing/unchanged code
+4. **Flag new sections** with `<!-- REVIEW: description -->` comments in the appendix
+5. **Don't include review tags** in final generated code
+
+## Available Steering Files
+
+This power has three steering files for detailed workflows:
+
+- **design-workflow.md** - Step-by-step guide for creating design documents
+- **research-guide.md** - How to research MAXScript/pymxs APIs and V-Ray documentation
+- **deadline-cloud-architecture.md** - Architecture overview of submitter → adaptor → MaxClient flow
+
+## Design Document Structure
+
+Every design document MUST follow this four-section structure:
+
+### 1. Data Structures to Change or Add
+
+Define all data model changes including:
+- New dataclasses or TypedDicts
+- Modifications to existing data structures
+- Job parameter schemas
+- Configuration objects
+- Type annotations (use `Any` for pymxs objects)
+
+### 2. UX Changes (Submitter Dialog)
+
+Document all user-facing changes:
+- New UI controls (dropdowns, checkboxes, text fields)
+- Control placement and grouping
+- Default values and validation
+- Tooltips and help text
+- Conditional visibility logic
+
+### 3. Job Template and Bundle Changes
+
+Specify modifications to:
+- Job template YAML structure
+- New parameters and their types
+- Parameter dependencies and conditions
+- Asset references and attachments
+
+### 4. Adapter Server-Client Changes
+
+Detail the runtime implementation:
+- Handler modifications (DefaultMaxHandler, VrayHandler, etc.)
+- New action handlers
+- MaxClient changes
+- Path mapping considerations
+- pymxs/MAXScript API usage
+
+## Research Requirements
+
+Before finalizing any design, perform this research:
+
+### 1. 3ds Max and V-Ray Documentation
+- MAXScript API reference
+- pymxs Python bindings
+- V-Ray MAXScript properties
+- Renderer class IDs and detection
+
+### 2. Deadline 10 Historical Implementation
+If Deadline 10 code is not available, ASK THE USER to provide relevant code snippets.
+
+### 3. Internet Research
+Query the internet when documentation is unclear or incomplete.
+
+## Key Technical Patterns
+
+### pymxs and MAXScript Integration
+
+**Key Insight**: All MAXScript methods documented for 3ds Max will work in pymxs!
+
+```python
+from pymxs import runtime as rt
+
+# MAXScript methods work identically in pymxs:
+re_mgr = rt.maxOps.GetCurRenderElementMgr()
+re_mgr.AddRenderElement(rt.VRayLightSelect())
+```
+
+### V-Ray Renderer Detection
+
+```python
+VRAY_STANDARD_CLASS_IDS = ["#(1941615238, 2012806412)", "#(1941615238L, 2012806412L)"]
+VRAY_RT_CLASS_IDS = ["#(1770671000, 1323107829)", "#(1770671000L, 1323107829L)"]
+
+def is_vray_rt() -> bool:
+    renderer_class_id = str(rt.renderers.current.classid)
+    return any(cid in renderer_class_id for cid in VRAY_RT_CLASS_IDS)
+```
+
+### V-Ray Settings Access
+
+```python
+# Standard V-Ray: direct access
+rt.renderers.current.output_splitfilename = path
+
+# V-Ray RT: nested V_Ray_settings object
+rt.renderers.current.V_Ray_settings.output_splitfilename = path
+```
+
+## Example Designs
+
+Reference these existing design documents:
+- `design/vray_output_paths_design.md` - V-Ray output path handling
+- `design/vray_out_buffer.md` - VFB output filename handling
+- `design/vrmesh.md` - VRMesh path mapping
+
+## External References
+
+- [GitHub Discussion #163 - Render Elements Design](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/163)
+- [GitHub Discussion #164 - MAXScript/pymxs Integration](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/164)
+- [OpenJD Sessions for Python](https://github.com/OpenJobDescription/openjd-sessions-for-python)

--- a/.kiro/powers/3dsmax-design-power/steering/deadline-cloud-architecture.md
+++ b/.kiro/powers/3dsmax-design-power/steering/deadline-cloud-architecture.md
@@ -1,0 +1,347 @@
+---
+inclusion: manual
+---
+
+# Deadline Cloud for 3ds Max Architecture Guide
+
+This guide explains the architecture of the Deadline Cloud for 3ds Max integration to help with design decisions.
+
+## High-Level Architecture
+
+```
++------------------------------------------------------------------+
+|                        3ds Max (Artist Workstation)              |
+|  +------------------------------------------------------------+  |
+|  |                    Submitter Dialog                        |  |
+|  |  - Collects job settings from user                         |  |
+|  |  - Reads scene information                                 |  |
+|  |  - Creates job bundle                                      |  |
+|  +------------------------------------------------------------+  |
++------------------------------------------------------------------+
+                              |
+                              | Job Bundle (YAML + assets)
+                              v
++------------------------------------------------------------------+
+|                      AWS Deadline Cloud                          |
+|  - Schedules jobs                                                |
+|  - Distributes tasks to workers                                  |
+|  - Manages job queues                                            |
++------------------------------------------------------------------+
+                              |
+                              | Task assignment
+                              v
++------------------------------------------------------------------+
+|                    Worker (Render Node)                          |
+|  +------------------------------------------------------------+  |
+|  |                   Adaptor Server                           |  |
+|  |  - Receives tasks from Deadline Cloud                      |  |
+|  |  - Manages 3ds Max process lifecycle                       |  |
+|  |  - Sends actions to MaxClient                              |  |
+|  +------------------------------------------------------------+  |
+|                              |                                   |
+|                              | Actions (JSON)                    |
+|                              v                                   |
+|  +------------------------------------------------------------+  |
+|  |                      MaxClient                             |  |
+|  |  - Runs inside 3ds Max process                             |  |
+|  |  - Executes actions via render handlers                    |  |
+|  |  - Uses pymxs to control 3ds Max                           |  |
+|  +------------------------------------------------------------+  |
++------------------------------------------------------------------+
+```
+
+## Component Details
+
+### 1. Submitter (`src/deadline/max_submitter/`)
+
+The submitter runs inside 3ds Max on the artist's workstation.
+
+**Key Files:**
+- `ui/` - Dialog UI components
+- `job_bundle/` - Job template and bundle creation
+- `scene_utils.py` - Scene analysis utilities
+
+**Responsibilities:**
+- Display job submission dialog
+- Collect user settings
+- Analyze scene (cameras, renderers, frame range)
+- Create job bundle with template and assets
+- Submit to Deadline Cloud
+
+### 2. Job Bundle
+
+The job bundle is a directory containing:
+- `template.yaml` - Job template with parameters and steps
+- `parameter_values.yaml` - User-provided parameter values
+- Asset references (scene file, textures, etc.)
+
+**Template Structure:**
+```yaml
+specificationVersion: jobtemplate-2023-09
+name: "3ds Max Render"
+parameterDefinitions:
+  - name: MaxSceneFile
+    type: PATH
+    objectType: FILE
+  - name: Frames
+    type: STRING
+  # ... more parameters
+
+steps:
+  - name: Render
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: Frame
+          type: INT
+          range: "{{Param.Frames}}"
+    script:
+      actions:
+        onRun:
+          command: "{{Task.Attachment.runScript.Path}}"
+```
+
+### 3. Adaptor Server (`src/deadline/max_adaptor/`)
+
+The adaptor server runs on the worker node and manages the 3ds Max process.
+
+**Key Files:**
+- `MaxAdaptor/adaptor.py` - Main adaptor class
+- `MaxAdaptor/` - Server-side logic
+
+**Responsibilities:**
+- Start/stop 3ds Max process
+- Send initialization actions (scene file, renderer, etc.)
+- Send per-task actions (frame number, output path)
+- Handle errors and logging
+
+### 4. MaxClient (`src/deadline/max_adaptor/MaxClient/`)
+
+The MaxClient runs inside the 3ds Max process and executes actions.
+
+**Key Files:**
+- `max_client.py` - Main client class
+- `render_handlers/` - Renderer-specific handlers
+  - `default_max_handler.py` - Base handler
+  - `vray_handler.py` - V-Ray specific
+  - `arnold_handler.py` - Arnold specific
+
+**Responsibilities:**
+- Receive actions from adaptor server
+- Route actions to appropriate handler
+- Execute pymxs commands
+- Report progress and errors
+
+### 5. Shared Utilities (`src/deadline/max_shared/`)
+
+Shared code used by both submitter and adaptor.
+
+**Key Files:**
+- `utilities/max_utils.py` - Common 3ds Max utilities
+- `utilities/vray_utils.py` - V-Ray specific utilities
+
+## Data Flow: Submitter to Render
+
+### 1. Job Submission
+
+```
+User fills dialog -> Submitter creates bundle -> Submit to Deadline Cloud
+                         |
+                         +-- template.yaml (job definition)
+                         +-- parameter_values.yaml (user settings)
+                         +-- asset references
+```
+
+### 2. Task Execution
+
+```
+Deadline Cloud assigns task to worker
+         |
+         v
+Adaptor Server receives task
+         |
+         +-- Init actions (once per job):
+         |   +-- scene_file: Load the .max file
+         |   +-- renderer: Set up render handler
+         |   +-- state_set: Configure state sets
+         |   +-- camera: Set camera (if single camera)
+         |
+         +-- Run actions (per frame):
+             +-- frame: Set frame number
+             +-- output_file_path: Set output directory
+             +-- output_file_name: Set output filename
+             +-- camera: Set camera (if per-task)
+             +-- start_render: Execute render
+```
+
+### 3. Action Execution in MaxClient
+
+```
+MaxClient receives action
+         |
+         v
+Route to handler method
+         |
+         v
+Execute pymxs commands
+         |
+         v
+Report result to adaptor
+```
+
+## Adding a New Feature
+
+### Step 1: Submitter Changes
+
+1. Add UI controls to collect user input
+2. Add parameters to job template
+3. Write parameter values to bundle
+
+### Step 2: Adaptor Changes
+
+1. Read parameters from job bundle
+2. Create actions to send to MaxClient
+3. Add to init_data or run_data as appropriate
+
+### Step 3: MaxClient Changes
+
+1. Add handler method for new action
+2. Register action in handler's action_dict
+3. Implement pymxs logic
+
+### Step 4: Shared Utilities (if needed)
+
+1. Add utility functions used by both submitter and adaptor
+2. Keep renderer-specific code in appropriate modules
+
+## Action Types
+
+### Init Actions (once per job)
+
+| Action | Handler Method | Purpose |
+|--------|---------------|---------|
+| `scene_file` | `set_scene_file()` | Load .max scene |
+| `renderer` | `set_renderer()` | Initialize render handler |
+| `state_set` | `set_state_set()` | Configure state sets |
+| `camera` | `set_camera()` | Set camera (single) |
+| `output_file_path` | `set_output_file_path()` | Set output directory |
+| `output_file_name` | `set_output_file_name()` | Set output filename |
+| `output_file_format` | `set_output_file_format()` | Set output format |
+
+### Run Actions (per task/frame)
+
+| Action | Handler Method | Purpose |
+|--------|---------------|---------|
+| `frame` | `set_frame()` | Set frame to render |
+| `camera` | `set_camera()` | Set camera (per-task) |
+| `start_render` | `start_render()` | Execute render |
+
+## Path Mapping
+
+Assets may be at different paths on worker vs. artist workstation.
+
+**OpenJD provides:**
+- `ClientInterface.map_path(path)` - Map a single path
+- `ClientInterface.path_mapping_rules()` - Get mapping rules
+
+**Usage in handlers:**
+```python
+# In handler (map_path injected by MaxClient)
+if self.map_path:
+    mapped_path = self.map_path(original_path)
+```
+
+## Error Handling
+
+1. **Submitter**: Validate inputs before submission
+2. **Adaptor**: Catch and report errors to Deadline Cloud
+3. **MaxClient**: Log errors and raise exceptions
+4. **Handlers**: Use try/except and return warnings list
+
+## Testing Strategy
+
+1. **Unit tests**: Mock pymxs, test handler logic
+2. **Integration tests**: Test with real 3ds Max (manual)
+3. **Job bundle tests**: Validate generated YAML
+
+Test files location: `test/unit/`
+
+## External References
+
+- [GitHub Discussion #163 - Render Elements Design Document](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/163) - Comprehensive design example with full data flow
+- [GitHub Discussion #164 - MAXScript and pymxs Integration](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/164) - Understanding pymxs API bindings
+- [OpenJD Sessions for Python](https://github.com/OpenJobDescription/openjd-sessions-for-python) - Core library for running Jobs in Sessions
+
+## OpenJD Sessions Overview
+
+The `openjd-sessions-for-python` library provides the runtime for executing Jobs defined by Open Job Description. Key concepts:
+
+### Session Lifecycle
+```python
+from openjd.sessions import Session, ActionStatus, ActionState
+
+with Session(
+    session_id="demo",
+    job_parameter_values=job_parameters,
+    callback=action_complete_callback
+) as session:
+    # Enter environments (job → step)
+    session.enter_environment(environment=env)
+    
+    # Run tasks
+    session.run_task(
+        step_script=step.script,
+        task_parameter_values=task_parameters
+    )
+    
+    # Exit environments (reverse order)
+    session.exit_environment(identifier=env_id)
+```
+
+### Action States
+- `ActionState.RUNNING` - Action in progress
+- `ActionState.SUCCEEDED` - Action completed successfully
+- `ActionState.FAILED` - Action failed
+- `ActionState.CANCELED` - Action was canceled
+
+### Parameter Flow
+```
+Job Template → decode_job_template() → preprocess_job_parameters()
+    → create_job() → Session → run_task(task_parameter_values)
+```
+
+For deep code analysis, clone the repository:
+```bash
+git clone https://github.com/OpenJobDescription/openjd-sessions-for-python /context/openjd-sessions
+```
+
+## Design Document Example: Render Elements
+
+The Render Elements implementation (Discussion #163) demonstrates the complete design pattern:
+
+### Three-Tier Architecture
+1. **Submitter**: UI widget + data class properties
+2. **Shared Utilities**: pymxs operations for detection/validation/configuration
+3. **Adaptor**: Manager class + handler integration
+
+### Parameter Flow
+```
+UI Settings → RenderSubmitterUISettings → Job Template Parameters
+    → OpenJD Parameter Values → Adaptor init_data → RenderElementManager
+    → pymxs Operations
+```
+
+### Key Components
+- `RenderElementsWidget` - Authentic Deadline 10 UI
+- `RenderSubmitterUISettings` - 8 new properties for configuration
+- `RenderElementManager` - Comprehensive pymxs operations
+- `DefaultMaxHandler` - Automatic workflow integration
+
+### Parameter Naming Convention
+```python
+# OpenJD (PascalCase) → Adaptor (snake_case)
+param_mapping = {
+    "RenderElements": "render_elements",
+    "VRayRenderElementsVFBControl": "vray_render_elements_vfb_control",
+    "IgnoreRenderElementsByName": "ignore_render_elements_by_name",
+}
+```

--- a/.kiro/powers/3dsmax-design-power/steering/design-doc-structure.md
+++ b/.kiro/powers/3dsmax-design-power/steering/design-doc-structure.md
@@ -1,0 +1,42 @@
+---
+inclusion: manual
+---
+
+# Design Document Structure
+
+Every design document MUST follow this four-section structure:
+
+## 1. Data Structures to Change or Add
+
+Define all data model changes including:
+- New dataclasses or TypedDicts
+- Modifications to existing data structures
+- Job parameter schemas
+- Configuration objects
+- Type annotations (use `Any` for pymxs objects)
+
+## 2. UX Changes (Submitter Dialog)
+
+Document all user-facing changes:
+- New UI controls (dropdowns, checkboxes, text fields)
+- Control placement and grouping
+- Default values and validation
+- Tooltips and help text
+- Conditional visibility logic
+
+## 3. Job Template and Bundle Changes
+
+Specify modifications to:
+- Job template YAML structure
+- New parameters and their types
+- Parameter dependencies and conditions
+- Asset references and attachments
+
+## 4. Adapter Server-Client Changes
+
+Detail the runtime implementation:
+- Handler modifications (DefaultMaxHandler, VrayHandler, etc.)
+- New action handlers
+- MaxClient changes
+- Path mapping considerations
+- pymxs/MAXScript API usage

--- a/.kiro/powers/3dsmax-design-power/steering/design-workflow.md
+++ b/.kiro/powers/3dsmax-design-power/steering/design-workflow.md
@@ -1,0 +1,245 @@
+---
+inclusion: manual
+---
+
+# 3ds Max Design Workflow Guide
+
+This guide walks through creating a comprehensive design document for a new 3ds Max / V-Ray feature.
+
+## Step 1: Understand the Feature Request
+
+Before starting the design:
+1. Clarify the user's goal and expected outcome
+2. Identify which renderers are affected (V-Ray Standard, V-Ray RT, Arnold, etc.)
+3. Determine if this is a new feature or modification to existing behavior
+4. Ask clarifying questions if the scope is unclear
+
+## Step 2: Research Phase
+
+### 2.1 Search 3ds Max / V-Ray Documentation
+
+Look up relevant MAXScript and pymxs APIs:
+- Property names and types
+- Method signatures
+- Class IDs for renderer detection
+- Version-specific differences
+
+Key search terms:
+- "MAXScript [property name]"
+- "pymxs [object type]"
+- "V-Ray MAXScript [feature]"
+- "3ds Max Python API [topic]"
+
+### 2.2 Check Deadline 10 Implementation
+
+If the feature existed in Deadline 10, review:
+- How was it implemented in `3dsmax.py`?
+- What MAXScript was used in `customize.ms`?
+- How was submission handled in `SubmitMaxToDeadline_Functions.ms`?
+
+**If Deadline 10 code is not available, ask the user:**
+> "I need to reference the Deadline 10 implementation for [feature]. Could you provide the relevant code from [specific file]?"
+
+### 2.3 Internet Research
+
+Search for:
+- Community solutions and workarounds
+- Known issues and limitations
+- Version compatibility notes
+- Best practices
+
+## Step 3: Design the Data Structures
+
+Data structures anchor the design - **always include full definitions** for new types:
+
+```python
+from typing import Any, Optional
+from dataclasses import dataclass
+from enum import Enum
+
+class FeatureMode(Enum):
+    """Mode options for Feature X."""
+    OPTION_A = "option_a"
+    OPTION_B = "option_b"
+
+@dataclass
+class FeatureSettings:
+    """Settings for Feature X workflow."""
+    
+    enabled: bool = False
+    mode: FeatureMode = FeatureMode.OPTION_A
+    output_path: Optional[str] = None
+    
+    # Processing options
+    compress_output: bool = True
+    verbose_level: int = 3
+```
+
+Consider:
+- What data flows from submitter to adapter?
+- What state needs to be maintained during rendering?
+- What types should be used (use `Any` for pymxs objects)?
+
+**Note:** Data structures are the exception to the "concise snippets" rule - show them in full since they anchor the entire design.
+
+## Step 4: Design the UX
+
+Sketch out the submitter dialog changes:
+
+1. **Control Type**: Dropdown, checkbox, text field, etc.
+2. **Placement**: Which group/section does it belong to?
+3. **Default Value**: What's the sensible default?
+4. **Validation**: What values are valid?
+5. **Dependencies**: Does it depend on other settings?
+
+Example:
+```
+Group: V-Ray Settings
+├── [Checkbox] Enable Feature X (default: unchecked)
+│   └── [Dropdown] Feature X Mode (visible when enabled)
+│       ├── Option A
+│       └── Option B
+└── [Text Field] Custom Path (optional)
+```
+
+## Step 5: Design Job Template Changes
+
+Define the job bundle modifications:
+
+```yaml
+parameterDefinitions:
+  - name: FeatureXEnabled
+    type: STRING
+    default: "false"
+    allowedValues: ["true", "false"]
+    
+  - name: FeatureXMode
+    type: STRING
+    default: "option_a"
+    allowedValues: ["option_a", "option_b"]
+    userInterface:
+      control: DROPDOWN
+      label: "Feature X Mode"
+```
+
+Consider:
+- Parameter types and constraints
+- Conditional parameters
+- Asset references
+
+## Step 6: Design Adapter Changes
+
+Plan the runtime implementation using **concise inline snippets** that show what changes:
+
+### Handler Changes (Inline)
+```python
+class VrayHandler(DefaultMaxHandler):
+    def __init__(self, gpu: bool) -> None:
+        super().__init__()
+        ...existing init...
+        
+        # NEW: Register feature X action
+        self.action_dict["feature_x"] = self.configure_feature_x
+
+    def configure_feature_x(self, data: dict[str, Any]) -> None:
+        """Configure Feature X before rendering."""
+        # See Appendix A.1 for full implementation
+        ...
+```
+
+### pymxs Implementation (Inline)
+```python
+def _apply_feature_x(self, mode: str) -> None:
+    vray = rt.renderers.current
+    if is_vray_rt():
+        vray = rt.renderers.current.V_Ray_settings
+    
+    # NEW: Set feature X property
+    vray.feature_x_mode = mode
+```
+
+Put full implementations in the **Appendix** section with review flags.
+
+## Step 7: Plan Testing
+
+Define unit tests with mocked pymxs:
+
+```python
+@patch('deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt')
+def test_feature_x_configuration(self, mock_rt):
+    """Test Feature X is correctly configured."""
+    # Setup
+    handler = VrayHandler(gpu=False)
+    
+    # Execute
+    handler.configure_feature_x({"feature_x_enabled": True, "feature_x_mode": "option_a"})
+    
+    # Verify
+    assert mock_rt.renderers.current.some_property == expected_value
+```
+
+## Step 8: Document Files to Modify
+
+Create a summary table:
+
+| File | Changes |
+|------|---------|
+| `src/deadline/max_submitter/ui/...` | Add UI controls |
+| `src/deadline/max_submitter/job_bundle/template.yaml` | Add parameters |
+| `src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py` | Add handler method |
+| `src/deadline/max_shared/utilities/max_utils.py` | Add utility functions |
+| `test/unit/.../test_vray_handler.py` | Add unit tests |
+
+## Common Pitfalls
+
+1. **Forgetting V-Ray RT**: Always handle both standard V-Ray and V-Ray RT
+2. **Missing type annotations**: All non-pymxs code needs proper types
+3. **Hardcoded paths**: Use path mapping for cross-platform support
+4. **No error handling**: pymxs operations can fail silently
+5. **Untested edge cases**: Test with missing/invalid data
+
+## Step 9: Create the Appendix
+
+Put all full code implementations in a clearly marked appendix at the end of the design document.
+
+### Appendix Format
+
+```markdown
+---
+
+## Appendix: Full Code Implementations
+
+<!-- REVIEW: Brief description of what's new -->
+
+### A.1 ClassName.method_name (Full Implementation)
+
+**File:** `src/deadline/max_adaptor/...`
+
+\`\`\`python
+def method_name(self, data: dict) -> None:
+    """
+    Full docstring here.
+    """
+    # Complete implementation
+    ...
+\`\`\`
+
+### A.2 New Utility Module
+
+**File:** `src/deadline/max_shared/utilities/new_utils.py` (new file)
+
+\`\`\`python
+"""
+Module docstring.
+"""
+# Full module code
+\`\`\`
+```
+
+### Guidelines
+
+1. **Flag sections for review** with `<!-- REVIEW: description -->` HTML comments
+2. **Include file paths** for each code block
+3. **Number appendix sections** (A.1, A.2, etc.) for easy reference
+4. **Don't include review tags** in final generated code - they're for design review only
+5. **Reference appendix from main sections** with "See Appendix A.X for full implementation"

--- a/.kiro/powers/3dsmax-design-power/steering/external-references.md
+++ b/.kiro/powers/3dsmax-design-power/steering/external-references.md
@@ -1,0 +1,21 @@
+---
+inclusion: manual
+---
+
+# External References
+
+Use these links when designing features. Only fetch URLs when the keywords match your design topic.
+
+## GitHub Discussions
+
+| Keywords | Link | Description |
+|----------|------|-------------|
+| render elements, AOV, passes, VFB, split buffer, element naming, RenderElementManager, beauty pass | [Discussion #163](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/163) | Comprehensive render elements design - covers submitter UI, job template parameters, adaptor integration, V-Ray VFB control, and state management for 90+ render element types |
+| pymxs, maxscript, python binding, rt.maxOps, render element properties, VRayLightSelect, VRayDenoiser, VRayCryptomatte | [Discussion #164](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/164) | MAXScript/pymxs integration tips - confirms all MAXScript methods work in pymxs, includes full property lists for V-Ray render elements (enabled, vrayVFB, denoise, deep_output, etc.) |
+| vrmesh, VRayProxy, path mapping, asset remapping, proxy.fileName, _apply_path_mapping | [Discussion #191](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/191) | VRMesh path mapping design - covers VRayProxy path remapping, map_path injection pattern, handler hooks for asset path translation |
+
+## Documentation
+
+| Keywords | Link | Description |
+|----------|------|-------------|
+| openjd, session, job template, step, task, environment, action, onEnter, onExit, onRun | [OpenJD Sessions](https://github.com/OpenJobDescription/openjd-sessions-for-python) | OpenJD Sessions for Python - runtime library for executing Open Job Description jobs, includes Session management, action execution, and job template processing |

--- a/.kiro/powers/3dsmax-design-power/steering/research-guide.md
+++ b/.kiro/powers/3dsmax-design-power/steering/research-guide.md
@@ -1,0 +1,242 @@
+---
+inclusion: manual
+---
+
+# Research Guide for 3ds Max Designs
+
+This guide covers how to research and validate design decisions for 3ds Max and V-Ray features.
+
+## Key Insight: MAXScript = pymxs
+
+**All MAXScript methods documented for 3ds Max work in pymxs!**
+
+The Autodesk documentation doesn't clearly explain the binding, but testing confirms that ALL MAXScript methods are available in pymxs. For example:
+
+```python
+from pymxs import runtime as rt
+
+# MAXScript: maxOps.GetCurRenderElementMgr()
+# Works identically in pymxs:
+re_mgr = rt.maxOps.GetCurRenderElementMgr()
+re_mgr.AddRenderElement(rt.VRayLightSelect())
+```
+
+Reference: [GitHub Discussion #164](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/164)
+
+## 3ds Max Documentation Sources
+
+### Official Autodesk Documentation
+
+1. **MAXScript Reference**
+   - Search: "3ds Max MAXScript [topic]"
+   - URL pattern: `help.autodesk.com/view/3DSMAX/[version]/ENU/?guid=...`
+   - Covers: All MAXScript functions, objects, and properties
+
+2. **pymxs Python API**
+   - Search: "3ds Max pymxs [topic]"
+   - Key concepts:
+     - `pymxs.runtime` (aliased as `rt`) provides MAXScript access
+     - Most MAXScript translates directly to pymxs
+     - Use `rt.execute()` for complex MAXScript strings
+
+3. **3ds Max Python API**
+   - Search: "3ds Max Python API [topic]"
+   - Covers: Native Python bindings (separate from pymxs)
+
+### V-Ray Documentation
+
+1. **V-Ray MAXScript Reference**
+   - URL: `docs.chaos.com/display/VMAX/MAXScript`
+   - Covers: All V-Ray-specific properties and methods
+
+2. **V-Ray Render Elements**
+   - URL: `docs.chaos.com/display/VMAX/Render+Elements`
+   - Covers: LightMix, cryptomatte, AOVs, etc.
+
+3. **V-Ray Frame Buffer (VFB)**
+   - URL: `docs.chaos.com/display/VMAX/V-Ray+Frame+Buffer`
+   - Covers: VFB settings, output options
+
+## Key MAXScript/pymxs Patterns
+
+### Accessing the Current Renderer
+
+```python
+from pymxs import runtime as rt
+
+renderer = rt.renderers.current
+renderer_name = str(renderer)
+renderer_class_id = str(renderer.classid)
+```
+
+### V-Ray Renderer Detection
+
+```python
+# Class IDs (may have L suffix for 64-bit)
+VRAY_STANDARD = ["#(1941615238, 2012806412)", "#(1941615238L, 2012806412L)"]
+VRAY_RT = ["#(1770671000, 1323107829)", "#(1770671000L, 1323107829L)"]
+
+def get_renderer_type() -> str:
+    class_id = str(rt.renderers.current.classid)
+    if any(cid in class_id for cid in VRAY_STANDARD):
+        return "vray"
+    elif any(cid in class_id for cid in VRAY_RT):
+        return "vrayrt"
+    return "unknown"
+```
+
+### V-Ray Settings Access Pattern
+
+```python
+def get_vray_settings():
+    """Get V-Ray settings object, handling RT nested structure."""
+    if get_renderer_type() == "vrayrt":
+        return rt.renderers.current.V_Ray_settings
+    return rt.renderers.current
+```
+
+### Common V-Ray Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `output_on` | bool | Enable V-Ray VFB |
+| `output_splitgbuffer` | bool | Enable split render channels |
+| `output_splitfilename` | str | Output path for split channels |
+| `output_splitbitmap` | bitmap | Required for render elements |
+| `output_splitRGB` | bool | Include RGB channel |
+| `output_splitAlpha` | bool | Include Alpha channel |
+| `output_rawFileName` | str | Raw .vrimg file path |
+| `output_saveRawFile` | bool | Enable raw file saving |
+| `output_separateFolders` | bool | Separate folders per element |
+
+### Scene Object Access
+
+```python
+# All objects
+for obj in rt.objects:
+    print(obj.name, rt.classOf(obj))
+
+# Specific class
+proxies = [obj for obj in rt.objects if rt.classOf(obj) == rt.VRayProxy]
+
+# By name
+node = rt.getNodeByName("ObjectName")
+
+# Cameras
+for cam in rt.cameras:
+    print(cam.name)
+```
+
+### Render Elements Access
+
+```python
+# Get render element manager
+re_mgr = rt.maxOps.GetCurRenderElementMgr()
+
+# Iterate render elements
+for i in range(re_mgr.NumRenderElements()):
+    element = re_mgr.GetRenderElement(i)
+    print(f"{element.elementName}: enabled={element.enabled}")
+
+# Add a render element
+re_mgr.AddRenderElement(rt.VRayLightSelect())
+
+# V-Ray element properties (all have 'enabled' and 'vrayVFB')
+element.enabled = False
+element.vrayVFB = False
+```
+
+## Deadline 10 Code Reference
+
+### Key Files to Reference
+
+1. **Plugin Execution**: `3dsmax/plugins/3dsmax/3dsmax.py`
+   - `SetVraySplitBufferFile()` - Split buffer path setting
+   - `SetVrayRawBufferFile()` - Raw buffer path setting
+   - `IsVrayRT()` - V-Ray RT detection
+
+2. **MAXScript Customization**: `3dsmax/plugins/3dsmax/customize.ms`
+   - `getRendererIdString()` - Renderer detection
+   - V-Ray settings schema (lines 1780-1890)
+   - Settings access pattern (lines 1476-1479)
+
+3. **Submission Logic**: `3dsmax/submission/3dsmax/Main/SubmitMaxToDeadline_Functions.ms`
+   - Job info parameter writing
+   - Scene analysis and validation
+
+### If Code Not Available
+
+Ask the user:
+> "I need to reference the Deadline 10 implementation for [specific feature]. Could you provide the relevant code from:
+> - `3dsmax/plugins/3dsmax/3dsmax.py` (lines X-Y)
+> - `3dsmax/plugins/3dsmax/customize.ms` (function name)
+> 
+> Specifically, I'm looking for how [feature] was implemented."
+
+## Internet Research Guidelines
+
+### When to Search
+
+1. Documentation is unclear or incomplete
+2. Looking for version-specific behavior
+3. Finding community workarounds
+4. Verifying API behavior
+
+### Effective Search Queries
+
+- `"MAXScript" "[property name]" site:forums.autodesk.com`
+- `"V-Ray" "MAXScript" "[feature]" site:forums.chaosgroup.com`
+- `"pymxs" "[topic]" site:stackoverflow.com`
+- `"3ds Max" "[error message]"`
+
+### Evaluating Sources
+
+**Prefer:**
+- Official documentation
+- Autodesk/Chaos Group forums (official responses)
+- Stack Overflow (high-voted answers)
+- Recent posts (within 2-3 years)
+
+**Be cautious with:**
+- Old forum posts (API may have changed)
+- Unofficial tutorials (may have errors)
+- AI-generated content (may hallucinate)
+
+## Knowledge Gap Protocol
+
+When you encounter a knowledge gap:
+
+1. **Document what you know**
+   - What API/feature is involved?
+   - What have you found so far?
+   - What specific information is missing?
+
+2. **Ask the user clearly**
+   > "I need clarification on [topic]. Specifically:
+   > - [Question 1]
+   > - [Question 2]
+   > 
+   > Do you have documentation or code examples for this?"
+
+3. **Propose alternatives if possible**
+   > "I'm not certain about [X], but based on [Y], I believe we could:
+   > - Option A: [description]
+   > - Option B: [description]
+   > 
+   > Which approach would you prefer, or do you have more information?"
+
+## Version Compatibility Notes
+
+### V-Ray Version Differences
+
+- Property names may change between versions (e.g., `output_rawFileName` vs `output_rawFilename`)
+- New features may not exist in older versions
+- Class IDs are generally stable
+
+### 3ds Max Version Differences
+
+- pymxs availability (2017+)
+- Python version (3.7+ in recent versions)
+- API changes between major versions
+
+Always note which versions your design targets and any version-specific handling needed.

--- a/.kiro/powers/3dsmax-design-power/steering/research-guide.md
+++ b/.kiro/powers/3dsmax-design-power/steering/research-guide.md
@@ -6,6 +6,35 @@ inclusion: manual
 
 This guide covers how to research and validate design decisions for 3ds Max and V-Ray features.
 
+## 3ds Max Documentation Sources
+
+**Note**: If Kiro cannot fetch these URLs, ask the user to provide an HTML copy or suggest using scraper tools like Firecrawl.
+
+### Official Autodesk Documentation
+
+1. **MAXScript Reference**
+   - Search: "3ds Max MAXScript [topic]"
+   - URL: https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=GUID-6FC81BE7-58FF-4C63-8362-0BDCFA9F904C
+   - Covers: All MAXScript functions, objects, and properties
+
+2. **3ds Max Python API (pymxs)**
+   - URL: https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=MAXDEV_Python_using_pymxs_pymxs_module_html
+   - Covers: pymxs module and Python bindings for MAXScript
+
+### V-Ray Documentation
+
+1. **V-Ray MAXScript Reference**
+   - URL: https://support.chaos.com/hc/en-us/articles/4411319570577-Using-MAXScript-with-V-Ray
+   - Covers: All V-Ray-specific properties and methods
+
+2. **V-Ray Render Elements**
+   - URL: https://documentation.chaos.com/space/VMAX/113588095/Render+Elements
+   - Covers: LightMix, cryptomatte, AOVs, etc.
+
+3. **V-Ray Frame Buffer (VFB)**
+   - URL: https://documentation.chaos.com/space/VMAX/113578174/V-Ray+Frame+Buffer
+   - Covers: VFB settings, output options
+
 ## Key Insight: MAXScript = pymxs
 
 **All MAXScript methods documented for 3ds Max work in pymxs!**
@@ -22,40 +51,6 @@ re_mgr.AddRenderElement(rt.VRayLightSelect())
 ```
 
 Reference: [GitHub Discussion #164](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/discussions/164)
-
-## 3ds Max Documentation Sources
-
-### Official Autodesk Documentation
-
-1. **MAXScript Reference**
-   - Search: "3ds Max MAXScript [topic]"
-   - URL pattern: `help.autodesk.com/view/3DSMAX/[version]/ENU/?guid=...`
-   - Covers: All MAXScript functions, objects, and properties
-
-2. **pymxs Python API**
-   - Search: "3ds Max pymxs [topic]"
-   - Key concepts:
-     - `pymxs.runtime` (aliased as `rt`) provides MAXScript access
-     - Most MAXScript translates directly to pymxs
-     - Use `rt.execute()` for complex MAXScript strings
-
-3. **3ds Max Python API**
-   - Search: "3ds Max Python API [topic]"
-   - Covers: Native Python bindings (separate from pymxs)
-
-### V-Ray Documentation
-
-1. **V-Ray MAXScript Reference**
-   - URL: `docs.chaos.com/display/VMAX/MAXScript`
-   - Covers: All V-Ray-specific properties and methods
-
-2. **V-Ray Render Elements**
-   - URL: `docs.chaos.com/display/VMAX/Render+Elements`
-   - Covers: LightMix, cryptomatte, AOVs, etc.
-
-3. **V-Ray Frame Buffer (VFB)**
-   - URL: `docs.chaos.com/display/VMAX/V-Ray+Frame+Buffer`
-   - Covers: VFB settings, output options
 
 ## Key MAXScript/pymxs Patterns
 
@@ -148,7 +143,15 @@ element.vrayVFB = False
 
 ## Deadline 10 Code Reference
 
-### Key Files to Reference
+**Important**: Do not try to find the Deadline 10 code. Ask the user if it's available as part of the design process.
+
+> "Does the Deadline 10 implementation for [specific feature] exist? If so, could you provide the relevant code from:
+> - `3dsmax/plugins/3dsmax/3dsmax.py`
+> - `3dsmax/plugins/3dsmax/customize.ms`
+> 
+> Specifically, I'm looking for how [feature] was implemented."
+
+### Key Files to Reference (if provided)
 
 1. **Plugin Execution**: `3dsmax/plugins/3dsmax/3dsmax.py`
    - `SetVraySplitBufferFile()` - Split buffer path setting
@@ -163,15 +166,6 @@ element.vrayVFB = False
 3. **Submission Logic**: `3dsmax/submission/3dsmax/Main/SubmitMaxToDeadline_Functions.ms`
    - Job info parameter writing
    - Scene analysis and validation
-
-### If Code Not Available
-
-Ask the user:
-> "I need to reference the Deadline 10 implementation for [specific feature]. Could you provide the relevant code from:
-> - `3dsmax/plugins/3dsmax/3dsmax.py` (lines X-Y)
-> - `3dsmax/plugins/3dsmax/customize.ms` (function name)
-> 
-> Specifically, I'm looking for how [feature] was implemented."
 
 ## Internet Research Guidelines
 
@@ -188,19 +182,6 @@ Ask the user:
 - `"V-Ray" "MAXScript" "[feature]" site:forums.chaosgroup.com`
 - `"pymxs" "[topic]" site:stackoverflow.com`
 - `"3ds Max" "[error message]"`
-
-### Evaluating Sources
-
-**Prefer:**
-- Official documentation
-- Autodesk/Chaos Group forums (official responses)
-- Stack Overflow (high-voted answers)
-- Recent posts (within 2-3 years)
-
-**Be cautious with:**
-- Old forum posts (API may have changed)
-- Unofficial tutorials (may have errors)
-- AI-generated content (may hallucinate)
 
 ## Knowledge Gap Protocol
 
@@ -224,19 +205,3 @@ When you encounter a knowledge gap:
    > - Option B: [description]
    > 
    > Which approach would you prefer, or do you have more information?"
-
-## Version Compatibility Notes
-
-### V-Ray Version Differences
-
-- Property names may change between versions (e.g., `output_rawFileName` vs `output_rawFilename`)
-- New features may not exist in older versions
-- Class IDs are generally stable
-
-### 3ds Max Version Differences
-
-- pymxs availability (2017+)
-- Python version (3.7+ in recent versions)
-- API changes between major versions
-
-Always note which versions your design targets and any version-specific handling needed.

--- a/.kiro/powers/3dsmax-dev-power/POWER.md
+++ b/.kiro/powers/3dsmax-dev-power/POWER.md
@@ -1,0 +1,102 @@
+---
+name: "3dsmax-dev-power"
+displayName: "3ds Max Dev Power"
+description: "Development power for deadline-cloud-for-3ds-max - build, lint, test, and run integration tests with 3ds Max and V-Ray."
+keywords: ["3dsmax", "deadline", "build", "test", "lint", "integration", "vray", "adaptor"]
+author: "AWS Deadline Cloud Team"
+---
+
+# 3ds Max Dev Power
+
+Development power for building, testing, and debugging the deadline-cloud-for-3ds-max project.
+
+## Overview
+
+This project is a Python package that provides:
+- **3ds Max Adaptor**: Runs 3ds Max renders on Deadline Cloud workers
+- **3ds Max Submitter**: UI for submitting jobs from 3ds Max to Deadline Cloud
+
+## Available Steering Files
+
+- **build-and-test.md** - Complete build and test workflow
+- **integration-testing.md** - Guide for running and creating integration tests
+- **troubleshooting.md** - Common issues and solutions
+
+## Prerequisites
+
+- Python 3.9+ (3ds Max 2026 uses Python 3.11)
+- 3ds Max 2025 or 2026 with V-Ray (for integration tests)
+- Hatch (Python build tool): `pip install hatch`
+
+## Quick Commands
+
+### Build
+```powershell
+hatch build -t wheel
+```
+
+### Lint & Format
+```powershell
+hatch run fmt    # Format code
+hatch run lint   # Run linter
+hatch run typing # Type checking
+```
+
+### Unit Tests
+```powershell
+hatch run test                              # All tests
+hatch run test test/unit/path/to/test.py   # Specific file
+hatch run test -k "test_vray"              # Pattern match
+```
+
+### Integration Tests
+
+Two scripts available:
+
+| Script | Use Case |
+|--------|----------|
+| `test-3dsmax-openjd-run.ps1` | General testing via OpenJD CLI |
+| `test-3dsmax-adapter-run.ps1` | **Path mapping tests** - runs adaptor directly |
+
+```powershell
+# Basic V-Ray test
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/vray_simple_test/expected_job_bundle"
+
+# Path mapping test (use adapter script!)
+.\scripts\test-3dsmax-adapter-run.ps1 `
+    -JobBundleDir "test/integ/test_scripts/vray_vrmesh_test_remap/expected_job_bundle" `
+    -PathMappingFile "test/integ/test_scripts/vray_vrmesh_test_remap/path_mapping_rules.json"
+```
+
+## Test Bundles
+
+| Bundle | Description |
+|--------|-------------|
+| `vray_simple_test` | Basic V-Ray render |
+| `vray_vrmesh_test` | V-Ray with VRayProxy |
+| `vray_vrmesh_test_remap` | VRMesh with path mapping |
+| `scanline_simple_test` | Scanline renderer |
+| `arnold_simple_test` | Arnold renderer |
+
+## Checking Logs
+
+```powershell
+# View recent logs
+Get-Content 'C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log' -Tail 100
+
+# Search for errors
+Select-String -Path 'C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log' -Pattern "error|exception" -CaseSensitive:$false
+```
+
+## Project Structure
+
+```
+src/deadline/
+├── max_adaptor/      # Adaptor (runs on worker)
+│   └── MaxClient/    # 3ds Max client and render handlers
+└── max_submitter/    # Submitter UI (runs in 3ds Max)
+test/
+├── unit/             # Unit tests
+└── integ/            # Integration tests
+scripts/              # Test runner scripts
+```

--- a/.kiro/powers/3dsmax-dev-power/steering/build-and-test.md
+++ b/.kiro/powers/3dsmax-dev-power/steering/build-and-test.md
@@ -1,0 +1,103 @@
+# Build and Test Workflow
+
+Complete build and test workflow for deadline-cloud-for-3ds-max.
+
+## Step 1: Build the Wheel
+
+Always build a fresh wheel before testing:
+
+```powershell
+hatch build -t wheel
+```
+
+This creates a wheel in `dist/deadline_cloud_for_3ds_max-*.whl`
+
+## Step 2: Run Linting and Formatting
+
+Before committing, ensure code passes all checks:
+
+```powershell
+# Format code
+hatch run fmt
+
+# Run linter
+hatch run lint
+
+# Run type checker
+hatch run typing
+```
+
+## Step 3: Run Unit Tests
+
+Run the full unit test suite:
+
+```powershell
+hatch run test
+```
+
+For faster iteration, run specific tests:
+
+```powershell
+# Run tests for a specific module
+hatch run test test/unit/deadline_adaptor_for_3ds_max/MaxClient/
+
+# Run a single test file
+hatch run test test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
+
+# Run tests matching a pattern
+hatch run test -k "test_vray"
+```
+
+## Step 4: Run Integration Tests
+
+Integration tests require 3ds Max to be installed.
+
+### Basic V-Ray Test
+
+```powershell
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/vray_simple_test/expected_job_bundle"
+```
+
+### Test with Path Mapping
+
+**Important**: Use `test-3dsmax-adapter-run.ps1` for path mapping tests:
+
+```powershell
+.\scripts\test-3dsmax-adapter-run.ps1 `
+    -JobBundleDir "test/integ/test_scripts/vray_vrmesh_test_remap/expected_job_bundle" `
+    -PathMappingFile "test/integ/test_scripts/vray_vrmesh_test_remap/path_mapping_rules.json"
+```
+
+### Skip Wheel Installation (faster iteration)
+
+```powershell
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/vray_simple_test/expected_job_bundle" -SkipInstall
+```
+
+## Step 5: Check Logs
+
+After running integration tests:
+
+```powershell
+# View last 100 lines
+Get-Content 'C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log' -Tail 100
+
+# Search for errors
+Select-String -Path 'C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log' -Pattern "error|exception" -CaseSensitive:$false | Select-Object -Last 20
+```
+
+## Common Issues
+
+### Wrong Python Version
+Ensure 3ds Max Python is being used:
+```powershell
+& "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" --version
+```
+
+### Wheel Not Found
+Build the wheel first: `hatch build -t wheel`
+
+### Path Mapping Not Working
+- Use `test-3dsmax-adapter-run.ps1` for path mapping tests
+- Path mapping rules only work with absolute paths
+- `test-3dsmax-openjd-run.ps1` does NOT pass rules to adaptor's `map_path()`

--- a/.kiro/powers/3dsmax-dev-power/steering/dev-guide.md
+++ b/.kiro/powers/3dsmax-dev-power/steering/dev-guide.md
@@ -1,0 +1,103 @@
+# Dev Guide
+
+## Python Environment
+
+**IMPORTANT**: Use 3ds Max's Python for running integration tests and adaptor code:
+- 3ds Max 2026: `C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe`
+- 3ds Max 2025: `C:\Program Files\Autodesk\3ds Max 2025\Python\python.exe`
+
+The system Python may not have the required dependencies (pytest, pyyaml, etc.) installed. The test scripts automatically use 3ds Max Python.
+
+## Build & Install Workflow
+
+### Build
+
+```powershell
+hatch build
+```
+
+This creates a wheel file in `dist/` folder.
+
+### Install to 3ds Max Python
+
+```powershell
+$wheel = (Get-ChildItem dist\*.whl | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
+& "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip install $wheel --force-reinstall --no-deps 2>&1 | Out-File -FilePath "tmp/pip_install.txt" -Encoding utf8
+Select-String -Path "tmp/pip_install.txt" -Pattern "Successfully installed"
+```
+
+### Code Quality
+
+```powershell
+hatch run fmt      # Format code
+hatch run lint     # Run linter
+hatch run typing   # Type checking
+```
+
+### Unit Tests
+
+```powershell
+hatch run test                              # All tests
+hatch run test test/unit/path/to/test.py   # Specific file
+hatch run test -k "test_vray"              # Pattern match
+```
+
+## Integration Tests
+
+See **integration-testing.md** for full details on running tests with OpenJD run or adaptor run scripts.
+
+**Scripts**: `test-3dsmax-openjd-run.ps1` (general) | `test-3dsmax-adapter-run.ps1` (path mapping)
+
+```powershell
+# Parameters
+-JobBundleDir "path/to/bundle"
+-PathMappingFile "path/to/rules.json"  # adapter script only
+-MaxVersion "2026"
+-SkipInstall                           # Skip wheel reinstall
+-ShowOutput
+```
+
+## Creating Test Bundles
+
+```
+test/integ/test_scripts/my_test/
+├── expected_job_bundle/
+│   ├── template.yaml
+│   └── parameter_values.yaml
+├── scene/my_scene.max
+└── tempout/
+```
+
+**parameter_values.yaml**:
+```yaml
+parameterValues:
+  - name: MaxSceneFile
+    value: C:/path/to/scene.max
+  - name: Frames
+    value: "0"
+  - name: OutputFilePath
+    value: C:/path/to/output/
+```
+
+**path_mapping_rules.json**:
+```json
+{"version":"pathmapping-1.0","path_mapping_rules":[{"source_path_format":"WINDOWS","source_path":"C:/original","destination_path":"C:/remapped"}]}
+```
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| No wheel found | `hatch build -t wheel` |
+| Hatch not found | `pip install hatch` |
+| Import errors | `pip install -r requirements-testing.txt` |
+| Test hangs | `Get-Process 3dsmax* \| Stop-Process -Force` |
+| Path mapping fails | Use `test-3dsmax-adapter-run.ps1`, not openjd script |
+| VRayProxy not found | V-Ray not loaded |
+| Log not appearing | Use `self.log_to_console()` not `print()` |
+
+**Logs**: `C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log`
+
+```powershell
+Select-String -Path '...\Max.log' -Pattern "error|VRMesh" -CaseSensitive:$false
+```

--- a/.kiro/powers/3dsmax-dev-power/steering/integration-testing.md
+++ b/.kiro/powers/3dsmax-dev-power/steering/integration-testing.md
@@ -1,6 +1,6 @@
 # Integration Testing Guide
 
-How to run and create integration tests for the 3ds Max adaptor.
+How to run and create integration tests for the 3ds Max adaptor using OpenJD run or adaptor run scripts.
 
 ## Running Integration Tests
 
@@ -32,13 +32,77 @@ How to run and create integration tests for the 3ds Max adaptor.
     -ShowOutput
 ```
 
-### Available Test Bundles
+## Ready-to-Run Test Commands
+
+### VRMesh Path Mapping Test (V-Ray with path remapping)
+```powershell
+Remove-Item "test/integ/test_scripts/vray_vrmesh_remap_test/output/*" -Force -ErrorAction SilentlyContinue
+$env:PATH = "C:\Users\RDP\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/vray_vrmesh_remap_test/expected_job_bundle" -PathMappingFile "test/integ/test_scripts/vray_vrmesh_remap_test/path_mapping_rules.json" -SkipInstall 2>&1 | Out-File -FilePath "tmp/vrmesh_remap_test_output.txt" -Encoding utf8
+```
+
+### V-Ray Render Elements Test (V-Ray CPU or GPU)
+```powershell
+Remove-Item "test/integ/test_scripts/vray_re_test/output_images/*" -Force -ErrorAction SilentlyContinue
+$env:PATH = "C:\Users\RDP\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/vray_re_test/expected_job_bundle" -SkipInstall 2>&1 | Out-File -FilePath "tmp/vray_test_output.txt" -Encoding utf8
+```
+
+### LightMix Test (V-Ray GPU)
+```powershell
+Remove-Item "test/integ/test_scripts/lightmix/output_images/*" -Force -ErrorAction SilentlyContinue
+$env:PATH = "C:\Users\RDP\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/lightmix/expected_job_bundle" -SkipInstall 2>&1 | Out-File -FilePath "tmp/lightmix_test_output.txt" -Encoding utf8
+```
+
+### RE Enabled Test (Standard 3dsMax renderer)
+```powershell
+Remove-Item "test/integ/test_scripts/re_enabled_test/output_images/*" -Force -ErrorAction SilentlyContinue
+$env:PATH = "C:\Users\RDP\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/re_enabled_test/expected_job_bundle" -SkipInstall 2>&1 | Out-File -FilePath "tmp/re_enabled_test_output.txt" -Encoding utf8
+```
+
+### RE Disabled Test (Standard 3dsMax renderer)
+```powershell
+Remove-Item "test/integ/test_scripts/re_disabled_test/output_images/*" -Force -ErrorAction SilentlyContinue
+$env:PATH = "C:\Users\RDP\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/re_disabled_test/expected_job_bundle" -SkipInstall 2>&1 | Out-File -FilePath "tmp/re_disabled_test_output.txt" -Encoding utf8
+```
+
+## Output Locations and Expected Results
+
+| Test | Output Folder | Expected Files |
+|------|---------------|----------------|
+| vray_vrmesh_remap_test | `test/integ/test_scripts/vray_vrmesh_remap_test/output/` | 1 |
+| vray_re_test (CPU) | `test/integ/test_scripts/vray_re_test/output_images/` | ~64 |
+| vray_re_test (GPU) | `test/integ/test_scripts/vray_re_test/output_images/` | ~85 |
+| lightmix | `test/integ/test_scripts/lightmix/output_images/` | 7 |
+| re_enabled_test | `test/integ/test_scripts/re_enabled_test/output_images/` | 23 |
+| re_disabled_test | `test/integ/test_scripts/re_disabled_test/output_images/` | 1 |
+
+## Test Configuration Parameters
+
+Key parameters in `parameter_values.yaml`:
+- `VRayRenderElementsVFBControl: 'false'` - V-Ray VFB handles output (vray_re_test, lightmix)
+- `VRayRenderElementsVFBControl: 'true'` - 3dsMax framebuffer handles output
+- `VRaySplitBufferSupport: 'true'` - Enable split buffer for render elements
+
+Key parameters in `template.yaml`:
+- `renderer: V_Ray_7_Hotfix_2` - V-Ray CPU renderer
+- `renderer: V_Ray_GPU_7_Hotfix_2` - V-Ray GPU renderer
+
+## Available Test Bundles
 
 | Bundle | Description |
 |--------|-------------|
 | `vray_simple_test` | Basic V-Ray render |
 | `vray_vrmesh_test` | V-Ray with VRayProxy |
 | `vray_vrmesh_test_remap` | VRMesh with path mapping |
+| `vray_vrmesh_remap_test` | VRMesh path remapping test |
+| `vray_re_test` | V-Ray render elements (CPU/GPU) |
+| `lightmix` | V-Ray LightMix (GPU) |
+| `re_enabled_test` | Standard renderer with render elements |
+| `re_disabled_test` | Standard renderer without render elements |
 | `scanline_simple_test` | Scanline renderer |
 | `arnold_simple_test` | Arnold renderer |
 

--- a/.kiro/powers/3dsmax-dev-power/steering/integration-testing.md
+++ b/.kiro/powers/3dsmax-dev-power/steering/integration-testing.md
@@ -1,0 +1,128 @@
+# Integration Testing Guide
+
+How to run and create integration tests for the 3ds Max adaptor.
+
+## Running Integration Tests
+
+### Prerequisites
+
+1. 3ds Max 2025 or 2026 installed
+2. V-Ray installed (for V-Ray tests)
+3. Built wheel in `dist/` directory
+
+### Choosing the Right Test Script
+
+| Script | Use Case |
+|--------|----------|
+| `test-3dsmax-openjd-run.ps1` | General testing via OpenJD CLI |
+| `test-3dsmax-adapter-run.ps1` | **Path mapping tests** - runs adaptor directly |
+
+**Important**: For path mapping tests, use `test-3dsmax-adapter-run.ps1`. The OpenJD CLI script does NOT pass rules to `map_path()`.
+
+### Script Parameters
+
+```powershell
+.\scripts\test-3dsmax-adapter-run.ps1 `
+    -JobBundleDir "path/to/job_bundle" `
+    -WheelPath "dist/deadline_cloud_for_3ds_max-*.whl" `
+    -MaxVersion "2026" `
+    -Step 0 `
+    -PathMappingFile "path/to/path_mapping_rules.json" `
+    -SkipInstall `
+    -ShowOutput
+```
+
+### Available Test Bundles
+
+| Bundle | Description |
+|--------|-------------|
+| `vray_simple_test` | Basic V-Ray render |
+| `vray_vrmesh_test` | V-Ray with VRayProxy |
+| `vray_vrmesh_test_remap` | VRMesh with path mapping |
+| `scanline_simple_test` | Scanline renderer |
+| `arnold_simple_test` | Arnold renderer |
+
+## Creating New Test Bundles
+
+### Job Bundle Structure
+
+```
+test/integ/test_scripts/my_test/
+├── expected_job_bundle/
+│   ├── template.yaml          # OpenJD job template
+│   └── parameter_values.yaml  # Job parameters
+├── scene/
+│   └── my_scene.max          # 3ds Max scene file
+├── expected_images/          # Expected outputs (optional)
+└── tempout/                  # Render output directory
+```
+
+### Parameter Values Example
+
+```yaml
+parameterValues:
+  - name: MaxSceneFile
+    value: C:/path/to/scene.max
+  - name: Frames
+    value: "0"
+  - name: OutputFilePath
+    value: C:/path/to/output/
+  - name: OutputFileFormat
+    value: ".jpg"
+  - name: ImageWidth
+    value: "320"
+  - name: ImageHeight
+    value: "240"
+```
+
+## Testing Path Mapping
+
+### Path Mapping Rules File
+
+```json
+{
+  "version": "pathmapping-1.0",
+  "path_mapping_rules": [
+    {
+      "source_path_format": "WINDOWS",
+      "source_path": "C:/original/assets",
+      "destination_path": "C:/remapped/assets"
+    }
+  ]
+}
+```
+
+### Running with Path Mapping
+
+```powershell
+.\scripts\test-3dsmax-adapter-run.ps1 `
+    -JobBundleDir "test/integ/test_scripts/vray_vrmesh_test_remap/expected_job_bundle" `
+    -PathMappingFile "test/integ/test_scripts/vray_vrmesh_test_remap/path_mapping_rules.json"
+```
+
+### Important Notes
+
+1. **Absolute paths required**: Path mapping only works with absolute paths
+2. **Use correct script**: `test-3dsmax-adapter-run.ps1` passes rules to adaptor
+3. **On Deadline Cloud**: Worker agent provides actual path mapping rules
+
+## Debugging
+
+### Check 3ds Max Logs
+
+```powershell
+# View recent logs
+Get-Content 'C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log' -Tail 100
+
+# Search for patterns
+Select-String -Path 'C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log' -Pattern "VRMesh|VRayProxy|path mapping" -CaseSensitive:$false
+```
+
+### Common Log Patterns
+
+| Pattern | Description |
+|---------|-------------|
+| `LoadFromFile` | Scene file loading |
+| `VRMesh path mapping` | VRayProxy path mapping |
+| `Remapped VRayProxy` | Successfully remapped proxy |
+| `render_element_manager` | Render element config |

--- a/.kiro/powers/3dsmax-dev-power/steering/troubleshooting.md
+++ b/.kiro/powers/3dsmax-dev-power/steering/troubleshooting.md
@@ -1,0 +1,102 @@
+# Troubleshooting Guide
+
+Common issues and solutions when developing deadline-cloud-for-3ds-max.
+
+## Build Issues
+
+### "No wheel files found in dist directory"
+```powershell
+hatch build -t wheel
+```
+
+### Hatch not found
+```powershell
+pip install hatch
+```
+
+## Test Issues
+
+### Unit tests fail with import errors
+```powershell
+pip install -r requirements-testing.txt
+# Or use hatch environment
+hatch run test
+```
+
+### Integration test hangs
+3ds Max may be waiting for user input. Kill stuck processes:
+```powershell
+Get-Process 3dsmax* | Stop-Process -Force
+```
+
+### "3ds Max Python not found"
+```powershell
+Test-Path "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe"
+```
+Use `-MaxVersion` parameter if using a different version.
+
+## V-Ray Issues
+
+### "VRayProxy class not found"
+V-Ray is not loaded. Ensure V-Ray is installed and environment is set up.
+
+### VRMesh path not remapped
+
+**Solutions**:
+1. Use `test-3dsmax-adapter-run.ps1` (not openjd script)
+2. Ensure VRayProxy uses absolute paths
+3. Check path mapping rules match source path exactly
+
+**Why OpenJD CLI doesn't work**:
+- Applies path mapping to job parameters only
+- Adaptor receives empty rules
+- `map_path()` returns paths unchanged
+
+## Logging Issues
+
+### Can't find log messages
+```powershell
+Get-ChildItem 'C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\' -Filter "*.log" | Sort-Object LastWriteTime -Descending
+```
+
+### Log messages not appearing
+Use `self.log_to_console()` instead of `print()`:
+```python
+self.log_to_console("My debug message")
+```
+
+## Path Issues
+
+### Scene file not found
+1. Verify file exists: `Test-Path "C:/path/to/scene.max"`
+2. Use forward slashes in YAML/JSON
+3. Check `parameter_values.yaml` paths
+
+### Output directory doesn't exist
+```powershell
+New-Item -ItemType Directory -Path "test/integ/test_scripts/my_test/tempout" -Force
+```
+
+## Python Environment Issues
+
+### Wrong Python interpreter
+```powershell
+& "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -c "import sys; print(sys.executable)"
+```
+
+### Module not found in 3ds Max
+```powershell
+& "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip install dist\deadline_cloud_for_3ds_max-*.whl --force-reinstall --no-deps
+```
+
+## Render Issues
+
+### Render produces black image
+- Check camera name in job parameters
+- Verify scene renders in 3ds Max UI first
+- Check lights are enabled
+
+### Render elements not saved
+```powershell
+Select-String -Path 'C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log' -Pattern "render_element_manager" | Select-Object -Last 20
+```

--- a/scripts/update_installed_files.bat
+++ b/scripts/update_installed_files.bat
@@ -1,13 +1,14 @@
 @echo off
 REM Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-REM Quick batch script to update installed 3ds Max submitter files
+REM Quick batch script to update installed 3ds Max submitter and adaptor files
 REM This is faster than rebuilding the entire installer during development
 
-echo === 3ds Max Submitter File Updater ===
+echo === 3ds Max Submitter and Adaptor File Updater ===
 echo.
 
 set SOURCE_ROOT=src\deadline
 set DEST_ROOT=%USERPROFILE%\DeadlineCloudFor3dsMaxSubmitter\scripts\deadline
+set MAX_PYTHON="C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe"
 
 REM Check if source exists
 if not exist "%SOURCE_ROOT%" (
@@ -42,6 +43,71 @@ if %ERRORLEVEL% neq 0 (
     exit /b 1
 )
 echo   ✓ max_shared updated
+
+REM Also update the adaptor files in Python site-packages
+set ADAPTOR_DEST=%APPDATA%\Python\Python311\site-packages\deadline
+
+if exist "%ADAPTOR_DEST%" (
+    echo.
+    echo Updating max_adaptor files in site-packages...
+    xcopy /E /Y /I "%SOURCE_ROOT%\max_adaptor" "%ADAPTOR_DEST%\max_adaptor"
+    if %ERRORLEVEL% neq 0 (
+        echo WARNING: Failed to copy max_adaptor files
+    ) else (
+        echo   ✓ max_adaptor updated
+    )
+
+    echo Updating max_shared files in site-packages...
+    xcopy /E /Y /I "%SOURCE_ROOT%\max_shared" "%ADAPTOR_DEST%\max_shared"
+    if %ERRORLEVEL% neq 0 (
+        echo WARNING: Failed to copy max_shared files to site-packages
+    ) else (
+        echo   ✓ max_shared updated in site-packages
+    )
+) else (
+    echo.
+    echo NOTE: Adaptor site-packages directory not found: %ADAPTOR_DEST%
+    echo       Skipping adaptor update. Run 'pip install -e .' to install the adaptor.
+)
+
+REM Build and install the latest wheel
+echo.
+echo === Building and Installing Latest Wheel ===
+
+REM Check if 3ds Max Python exists
+if not exist %MAX_PYTHON% (
+    echo WARNING: 3ds Max 2026 Python not found at %MAX_PYTHON%
+    echo          Skipping wheel installation.
+    goto :skip_wheel
+)
+
+REM Build the wheel using hatch
+echo Building wheel with hatch...
+hatch build -t wheel
+if %ERRORLEVEL% neq 0 (
+    echo WARNING: Failed to build wheel with hatch
+    goto :skip_wheel
+)
+echo   ✓ Wheel built successfully
+
+REM Find the latest wheel file
+for /f "delims=" %%i in ('dir /b /o-d dist\deadline_cloud_for_3ds_max-*.whl 2^>nul') do (
+    set WHEEL_FILE=dist\%%i
+    goto :found_wheel
+)
+echo WARNING: No wheel file found in dist directory
+goto :skip_wheel
+
+:found_wheel
+echo Installing wheel: %WHEEL_FILE%
+%MAX_PYTHON% -m pip install "%WHEEL_FILE%" --force-reinstall
+if %ERRORLEVEL% neq 0 (
+    echo WARNING: Failed to install wheel
+) else (
+    echo   ✓ Wheel installed successfully
+)
+
+:skip_wheel
 
 echo.
 echo === Update Complete ===

--- a/src/deadline/max_shared/utilities/max_utils.py
+++ b/src/deadline/max_shared/utilities/max_utils.py
@@ -403,6 +403,9 @@ def configure_render_element_paths(
             # Update render element path
             try:
                 re_manager.SetRenderElementFilename(element_index, new_path)
+                # Update the RenderElementInfo object so validation uses the correct path
+                element.output_filename = new_path
+                element.has_output_path = True
                 _logger.debug(f"Updated render element '{element_name}' path to: {new_path}")
             except Exception as e:
                 warnings.append(f"Failed to update path for render element '{element_name}': {e}")
@@ -606,6 +609,9 @@ def configure_vray_render_elements(
                         if element.enabled and element.name not in ignore_list:
                             try:
                                 re_manager.SetRenderElementFilename(element.index, base_filename)
+                                # Update the RenderElementInfo object so validation uses the correct path
+                                element.output_filename = base_filename
+                                element.has_output_path = True
                                 filename_set_count += 1
                                 _logger.debug(
                                     f"Set V-Ray split buffer base filename for '{element.name}': {base_filename}"
@@ -857,6 +863,9 @@ def _configure_render_element_outputs_filename(
 
                 # Set the render element filename
                 re_manager.SetRenderElementFilename(element.index, full_path)
+                # Update the RenderElementInfo object so validation uses the correct path
+                element.output_filename = full_path
+                element.has_output_path = True
                 filename_set_count += 1
                 _logger.debug(
                     f"Set standard render element filename for '{element.name}': {full_path}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- We want to accelerate AI based development.

### What was the solution? (How)
- Lets add Kiro Powers for dev and design that can help 3dsmax.

### What is the impact of this change?
- 3dsmax-design-power, guidance on how to learn 3dsmax, and fit it with deadline-cloud adaptor
- 3dsmax-dev-power, guidance on how to debug the adaptor locally using OpenJD run or Adaptor run scripts.

### How was this change tested?
- Install it with Kiro by going to the powers tab. Click Add to install the power
- I've been using this power in my day-to-day workflow to design and debug new features.
  - Using LLM generated code beware! Read and understand the workflow.
- This is V1 of the dev and design power, we will keep improving on it.

### Was this change documented?
- This is a doc. 
- I am not adding explicit docs in README.md, as this is an team dev tool for the time being. 

### Did you modify schema files?
- [ ] Yes
- [X] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
   - [ ] Yes
   - [X] No

### Is this a breaking change?
- No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*