### PR TITLE
feat: Implement vrmesh handling

### DIFF
--- a/src/deadline/max_adaptor/MaxClient/max_client.py
+++ b/src/deadline/max_adaptor/MaxClient/max_client.py
@@ -23,6 +23,9 @@ try:
     from max_adaptor.MaxClient.render_handlers import (  # type: ignore[import]
         get_render_handler,
     )
+    from max_adaptor.MaxClient.render_handlers.default_max_handler import (  # type: ignore[import]
+        DefaultMaxHandler,
+    )
     from max_adaptor.MaxClient.render_element_manager import (  # type: ignore[import]
         RenderElementManager,
     )
@@ -34,6 +37,9 @@ except (ImportError, ModuleNotFoundError):
     from deadline.max_adaptor.MaxClient.render_handlers import (  # type: ignore[import]
         get_render_handler,
     )
+    from deadline.max_adaptor.MaxClient.render_handlers.default_max_handler import (  # type: ignore[import]
+        DefaultMaxHandler,
+    )
     from deadline.max_adaptor.MaxClient.render_element_manager import (  # type: ignore[import]
         RenderElementManager,
     )
@@ -41,6 +47,7 @@ except (ImportError, ModuleNotFoundError):
         LoggerInterceptor,
     )
     from openjd.adaptor_runtime_client import ClientInterface  # type: ignore[import]
+
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +66,9 @@ class MaxClient(ClientInterface):
         # Initialize logger interceptor for render element logging
         self.logger_interceptor = LoggerInterceptor()
 
+        # Store handler reference for injecting map_path
+        self._render_handler: Optional[DefaultMaxHandler] = None
+
         # List of actions that can be performed by the action queue
         self.actions.update(
             {
@@ -72,7 +82,7 @@ class MaxClient(ClientInterface):
             }
         )
 
-    def set_renderer(self, renderer: dict):
+    def set_renderer(self, renderer: dict) -> None:
         """
         Determines which render handler to use.
         """
@@ -82,7 +92,12 @@ class MaxClient(ClientInterface):
         self.logger_interceptor.setup()
 
         try:
-            render_handler = get_render_handler(renderer["renderer"])
+            render_handler: DefaultMaxHandler = get_render_handler(renderer["renderer"])
+            self._render_handler = render_handler
+
+            # Inject map_path function into handler for path mapping
+            render_handler.map_path = self.map_path
+
             self.actions.update(render_handler.action_dict)
         except Exception as e:
             # Log the error and close Max to ensure clean exit

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import pymxs  # noqa
 from pymxs import runtime as rt
@@ -49,6 +49,9 @@ class DefaultMaxHandler:
         self._executable_handler: MaxExecutableHandler = MaxExecutableHandler()
         # Initialize render element manager as private attribute
         self._render_element_manager: Optional["RenderElementManager"] = None
+        # Path mapping function injected by MaxClient
+        # Uses Callable type since map_path comes from ClientInterface
+        self.map_path: Optional[Callable[[str], str]] = None
 
     @property
     def render_element_manager(self) -> Optional["RenderElementManager"]:
@@ -304,7 +307,7 @@ class DefaultMaxHandler:
 
         self.check_renderer()
 
-    def set_scene_file(self, data: dict):
+    def set_scene_file(self, data: dict) -> None:
         """
         Opens a scene file in 3dsMax in quiet mode. This means that any popups after start up get ignored
         (e.g. missing XRefs) so they don't halt the adaptor.
@@ -321,9 +324,21 @@ class DefaultMaxHandler:
         try:
             rt.SetQuietMode(True)
             rt.loadMaxFile(file_path, quiet=True)
+
+            # Apply path mapping after scene load
+            if self.map_path is not None:
+                self._apply_path_mapping()
+
         except Exception:
             self.log_to_console(f"Error: while opening '{file_path}'")
             raise RuntimeError(f"Error: while opening '{file_path}'")
+
+    def _apply_path_mapping(self) -> None:
+        """
+        Applies path mapping to scene assets after scene load.
+        Override in subclasses to handle renderer-specific assets.
+        """
+        pass  # Base implementation does nothing
 
     def log_to_console(self, message: str) -> None:
         """

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -105,6 +105,65 @@ class VrayHandler(DefaultMaxHandler):
                 # Set to most recent version of V-Ray
                 rt.renderers.current = vray()
 
+    def _apply_path_mapping(self) -> None:
+        """
+        Applies path mapping to V-Ray specific assets.
+
+        Currently handles:
+        - VRayProxy objects (.vrmesh files)
+
+        TODO: Add support for VRayHDRI (HDR environment maps)
+        TODO: Add support for VRayMesh (V-Ray mesh export files)
+        TODO: Add support for VRayFur (fur/hair geometry files)
+        TODO: Add support for VRayScene (V-Ray scene files .vrscene)
+        """
+        if self.map_path is None:
+            return
+
+        self._apply_vray_proxy_path_mapping()
+
+    def _apply_vray_proxy_path_mapping(self) -> None:
+        """
+        Applies path mapping to all VRayProxy objects in the scene.
+        """
+        # Check if VRayProxy class exists
+        if not hasattr(rt, "VRayProxy"):
+            self.log_to_console("VRayProxy class not found - V-Ray may not be loaded")
+            return
+
+        # rt.objects returns pymxs objects (dynamically typed)
+        proxies: list[Any] = [obj for obj in rt.objects if rt.classOf(obj) == rt.VRayProxy]
+
+        if not proxies:
+            self.log_to_console("No VRayProxy objects found in scene")
+            return
+
+        mapped_count: int = 0
+        for proxy in proxies:
+            original_path: Any = getattr(proxy, "fileName", None)
+            if not original_path:
+                continue
+
+            original_path_str: str = str(original_path)
+
+            # Use the injected map_path function (guaranteed non-None by caller)
+            assert self.map_path is not None  # For mypy
+            self.log_to_console(f"Requesting Path Mapping for path '{original_path_str}'.")
+            mapped_path: str = self.map_path(original_path_str)
+            self.log_to_console(f"Mapped path '{original_path_str}' to '{mapped_path}'.")
+
+            if mapped_path != original_path_str:
+                try:
+                    proxy.fileName = mapped_path
+                    mapped_count += 1
+                    self.log_to_console(
+                        f"Remapped VRayProxy '{proxy.name}': {original_path_str} -> {mapped_path}"
+                    )
+                except Exception as e:
+                    self.log_to_console(f"Warning: Failed to remap VRayProxy '{proxy.name}': {e}")
+
+        self.log_to_console(f"VRMesh path mapping complete: {mapped_count} proxies remapped")
+
     def start_render(self, data: dict) -> None:
         """
         Override to set V-Ray output path before rendering.

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_path_mapping.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_path_mapping.py
@@ -1,0 +1,349 @@
+﻿# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+
+class TestVrayProxyPathMapping:
+    """Tests for VrayHandler path mapping functionality."""
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_no_vray_proxy_class(self, mock_rt: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        """Test graceful handling when VRayProxy class doesn't exist."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="/mapped/path")
+
+        del mock_rt.VRayProxy
+
+        handler._apply_vray_proxy_path_mapping()
+
+        captured = capsys.readouterr()
+        assert "VRayProxy class not found" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_no_proxies_in_scene(self, mock_rt: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        """Test handling when no VRayProxy objects exist."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+        mock_rt.objects = []
+        mock_rt.VRayProxy = MagicMock()
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="/mapped/path")
+
+        handler._apply_vray_proxy_path_mapping()
+
+        handler.map_path.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "No VRayProxy objects found" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_applies_path_mapping(self, mock_rt: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        """Test that path mapping is correctly applied to VRayProxy objects."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        mock_proxy = MagicMock()
+        mock_proxy.name = "TreeProxy"
+        mock_proxy.fileName = "C:/Assets/tree.vrmesh"
+
+        mock_rt.objects = [mock_proxy]
+        mock_rt.classOf.return_value = mock_rt.VRayProxy
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="/session/Assets/tree.vrmesh")
+
+        handler._apply_vray_proxy_path_mapping()
+
+        handler.map_path.assert_called_once_with("C:/Assets/tree.vrmesh")
+        assert mock_proxy.fileName == "/session/Assets/tree.vrmesh"
+
+        captured = capsys.readouterr()
+        assert "Remapped VRayProxy 'TreeProxy'" in captured.out
+        assert "1 proxies remapped" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_skips_when_path_unchanged(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test that proxy is not modified when path mapping returns same path."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        mock_proxy = MagicMock()
+        mock_proxy.name = "LocalProxy"
+        mock_proxy.fileName = "/already/local/path.vrmesh"
+
+        mock_rt.objects = [mock_proxy]
+        mock_rt.classOf.return_value = mock_rt.VRayProxy
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="/already/local/path.vrmesh")
+
+        handler._apply_vray_proxy_path_mapping()
+
+        handler.map_path.assert_called_once_with("/already/local/path.vrmesh")
+
+        captured = capsys.readouterr()
+        assert "Remapped VRayProxy" not in captured.out
+        assert "0 proxies remapped" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_handles_mapping_failure(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test warning is printed when path mapping fails."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        mock_proxy = MagicMock()
+        mock_proxy.name = "BrokenProxy"
+        original_filename = "C:/Assets/broken.vrmesh"
+
+        type(mock_proxy).fileName = PropertyMock(
+            side_effect=[original_filename, Exception("Access denied")]
+        )
+
+        mock_rt.objects = [mock_proxy]
+        mock_rt.classOf.return_value = mock_rt.VRayProxy
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="/session/Assets/broken.vrmesh")
+
+        handler._apply_vray_proxy_path_mapping()
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert "BrokenProxy" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_no_mapping_when_map_path_not_injected(self, mock_rt: MagicMock) -> None:
+        """Test no path mapping when map_path function not injected."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        mock_proxy = MagicMock()
+        mock_proxy.name = "TreeProxy"
+        mock_proxy.fileName = "C:/Assets/tree.vrmesh"
+
+        mock_rt.objects = [mock_proxy]
+        mock_rt.classOf.return_value = mock_rt.VRayProxy
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = None
+
+        handler._apply_path_mapping()
+
+        assert mock_proxy.fileName == "C:/Assets/tree.vrmesh"
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_multiple_proxies(self, mock_rt: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        """Test path mapping with multiple VRayProxy objects."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        mock_proxy1 = MagicMock()
+        mock_proxy1.name = "TreeProxy"
+        mock_proxy1.fileName = "C:/Assets/tree.vrmesh"
+
+        mock_proxy2 = MagicMock()
+        mock_proxy2.name = "RockProxy"
+        mock_proxy2.fileName = "C:/Assets/rock.vrmesh"
+
+        mock_proxy3 = MagicMock()
+        mock_proxy3.name = "LocalProxy"
+        mock_proxy3.fileName = "/local/path.vrmesh"
+
+        mock_rt.objects = [mock_proxy1, mock_proxy2, mock_proxy3]
+        mock_rt.classOf.return_value = mock_rt.VRayProxy
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+
+        def mock_map_path(path: str) -> str:
+            if path.startswith("C:/Assets/"):
+                return path.replace("C:/Assets/", "/session/Assets/")
+            return path
+
+        handler.map_path = MagicMock(side_effect=mock_map_path)
+
+        handler._apply_vray_proxy_path_mapping()
+
+        assert mock_proxy1.fileName == "/session/Assets/tree.vrmesh"
+        assert mock_proxy2.fileName == "/session/Assets/rock.vrmesh"
+
+        captured = capsys.readouterr()
+        assert "2 proxies remapped" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_skips_proxy_without_filename(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test that proxies without fileName attribute are skipped."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        mock_proxy = MagicMock(spec=["name"])
+        mock_proxy.name = "EmptyProxy"
+
+        mock_rt.objects = [mock_proxy]
+        mock_rt.classOf.return_value = mock_rt.VRayProxy
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="/mapped/path")
+
+        handler._apply_vray_proxy_path_mapping()
+
+        handler.map_path.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "0 proxies remapped" in captured.out
+
+
+class TestDefaultMaxHandlerPathMapping:
+    """Tests for DefaultMaxHandler path mapping base functionality."""
+
+    def test_apply_path_mapping_base_does_nothing(self) -> None:
+        """Test that base _apply_path_mapping does nothing."""
+        from deadline.max_adaptor.MaxClient.render_handlers.default_max_handler import (
+            DefaultMaxHandler,
+        )
+
+        handler = DefaultMaxHandler()
+        handler.map_path = MagicMock(return_value="/mapped/path")
+
+        handler._apply_path_mapping()
+
+        handler.map_path.assert_not_called()
+
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt")
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.path.isfile")
+    def test_set_scene_file_calls_apply_path_mapping(
+        self, mock_isfile: MagicMock, mock_rt: MagicMock
+    ) -> None:
+        """Test that set_scene_file calls _apply_path_mapping when map_path is set."""
+        mock_isfile.return_value = True
+
+        from deadline.max_adaptor.MaxClient.render_handlers.default_max_handler import (
+            DefaultMaxHandler,
+        )
+
+        handler = DefaultMaxHandler()
+        handler.map_path = MagicMock(return_value="/mapped/path")
+
+        original_apply = handler._apply_path_mapping
+        call_tracker = MagicMock()
+
+        def tracked_apply() -> None:
+            call_tracker()
+            original_apply()
+
+        handler._apply_path_mapping = tracked_apply  # type: ignore[method-assign]
+
+        handler.set_scene_file({"scene_file": "/path/to/scene.max"})
+
+        call_tracker.assert_called_once()
+
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt")
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.path.isfile")
+    def test_set_scene_file_skips_path_mapping_when_not_injected(
+        self, mock_isfile: MagicMock, mock_rt: MagicMock
+    ) -> None:
+        """Test that set_scene_file skips _apply_path_mapping when map_path is None."""
+        mock_isfile.return_value = True
+
+        from deadline.max_adaptor.MaxClient.render_handlers.default_max_handler import (
+            DefaultMaxHandler,
+        )
+
+        handler = DefaultMaxHandler()
+        handler.map_path = None
+
+        call_tracker = MagicMock()
+        original_apply = handler._apply_path_mapping
+
+        def tracked_apply() -> None:
+            call_tracker()
+            original_apply()
+
+        handler._apply_path_mapping = tracked_apply  # type: ignore[method-assign]
+
+        handler.set_scene_file({"scene_file": "/path/to/scene.max"})
+
+        call_tracker.assert_not_called()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

V-Ray scenes using VRayProxy objects (.vrmesh files) require path mapping when rendering on Deadline Cloud workers. Without this, proxy file paths pointing to the original artist workstation locations would fail to resolve on render nodes.

### What was the solution? (How)

- Added a `map_path` callable attribute to `DefaultMaxHandler` that gets injected by `MaxClient` after renderer initialization
- Implemented `_apply_path_mapping()` hook in `DefaultMaxHandler` (no-op base) that's called after scene load
- Overrode `_apply_path_mapping()` in `VrayHandler` to iterate all VRayProxy objects and remap their `fileName` property using the injected path mapping function

### What is the impact of this change?

V-Ray scenes with VRayProxy objects will now correctly resolve .vrmesh file paths on Deadline Cloud workers, enabling successful renders of scenes that use proxy geometry.

### How was this change tested?
- A separate PR is being added for integration testing. I split it up because the integ test is all image files.

- Added comprehensive unit tests in `test_vray_path_mapping.py` covering:
  - No VRayProxy class available
  - No proxies in scene
  - Single and multiple proxy path mapping
  - Path unchanged scenarios
  - Mapping failure handling
  - Missing fileName attribute handling
  - Base handler behavior verification

### Was this change documented?

No documentation changes required - this is internal implementation.

### Did you modify schema files?
- [ ] Yes
- [X] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
   - [ ] Yes
   - [X] No

### Is this a breaking change?
- No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

----
Design doc:
# VRMesh Path Mapping Design Document

## Overview

This document describes the design for VRayProxy (.vrmesh) path mapping support in the Deadline Cloud for 3ds Max adaptor. VRayProxy objects reference external mesh files that need path remapping when rendering on Deadline Cloud workers.

## Problem Statement

V-Ray scenes using VRayProxy objects store absolute file paths to `.vrmesh` files. When these scenes are submitted to Deadline Cloud:

1. The original paths point to the artist's workstation (e.g., `C:/Assets/tree.vrmesh`)
2. On render workers, assets are mounted at different locations (e.g., `/session/Assets/tree.vrmesh`)
3. Without path mapping, V-Ray fails to load proxy geometry, causing render failures

## External References

- [V-Ray for 3ds Max - VRayProxy](https://documentation.chaos.com/space/VMAX/113575423) - Official V-Ray proxy documentation
- [3ds Max MAXScript Reference](https://help.autodesk.com/view/MAXDEV/2024/ENU/?guid=GUID-F039181A-C072-4469-A329-AE60FF7535E7) - Autodesk MAXScript documentation
- [OpenJD Path Mapping](https://github.com/OpenJobDescription/openjd-sessions-for-python) - OpenJD path mapping implementation

---

## 1. Data Structures to Change or Add

### 1.1 DefaultMaxHandler Changes

Add a callable attribute for path mapping injection:

```python
# In default_max_handler.py
from typing import Callable, Optional

class DefaultMaxHandler:
    def __init__(self):
        # ... existing code ...
        
        # Path mapping function injected by MaxClient
        # Uses Callable type since map_path comes from ClientInterface
        self.map_path: Optional[Callable[[str], str]] = None
```

### 1.2 MaxClient Changes

Store handler reference for path mapping injection:

```python
# In max_client.py
from typing import TYPE_CHECKING, Optional

if TYPE_CHECKING:
    from deadline.max_adaptor.MaxClient.render_handlers.default_max_handler import (
        DefaultMaxHandler,
    )

class MaxClient(ClientInterface):
    def __init__(self, server_path: str) -> None:
        # ... existing code ...
        
        # Store handler reference for injecting map_path
        self._render_handler: Optional[DefaultMaxHandler] = None
```

### 1.3 Type Annotations

VRayProxy objects from pymxs are dynamically typed. Use `Any` for pymxs objects:

```python
from typing import Any

# rt.objects returns pymxs objects (dynamically typed)
proxies: list[Any] = [obj for obj in rt.objects if rt.classOf(obj) == rt.VRayProxy]
```

---

## 2. UX Changes (Submitter Dialog)

**No UX changes required.**

Path mapping is handled automatically by the OpenJD runtime based on job attachment configurations. Users configure path mapping rules at the queue level, not per-job.

---

## 3. Job Template and Bundle Changes

**No job template changes required.**

The existing asset attachment system handles path mapping rules. VRMesh files should be included in job attachments like any other asset dependency.

---

## 4. Adapter Server-Client Changes

### 4.1 MaxClient: Inject map_path into Handler

When the renderer is set, inject the `map_path` function from `ClientInterface`:

```python
# In max_client.py
def set_renderer(self, renderer: dict) -> None:
    """
    Determines which render handler to use.
    """
    logger.debug("setting render handler")
    self.logger_interceptor.setup()

    try:
        render_handler: DefaultMaxHandler = get_render_handler(renderer["renderer"])
        self._render_handler = render_handler

        # Inject map_path function into handler for path mapping
        render_handler.map_path = self.map_path

        self.actions.update(render_handler.action_dict)
    except Exception as e:
        logger.error(f"Failed to initialize renderer: {e}")
        self.close()
        raise
```

### 4.2 DefaultMaxHandler: Path Mapping Hook

Add a hook method called after scene load:

```python
# In default_max_handler.py
def set_scene_file(self, data: dict) -> None:
    """
    Opens a scene file in 3dsMax in quiet mode.
    """
    logger.debug("opening max scene")
    file_path = data.get("scene_file", "")
    if not os.path.isfile(file_path):
        raise FileNotFoundError(f"Error: The scene file '{file_path}' does not exist")
    
    try:
        rt.SetQuietMode(True)
        rt.loadMaxFile(file_path, quiet=True)

        # Apply path mapping after scene load
        if self.map_path is not None:
            self._apply_path_mapping()

    except Exception:
        self.log_to_console(f"Error: while opening '{file_path}'")
        raise RuntimeError(f"Error: while opening '{file_path}'")

def _apply_path_mapping(self) -> None:
    """
    Applies path mapping to scene assets after scene load.
    Override in subclasses to handle renderer-specific assets.
    """
    pass  # Base implementation does nothing
```

### 4.3 VrayHandler: VRayProxy Path Mapping

Override `_apply_path_mapping()` to handle V-Ray specific assets:

```python
# In vray_handler.py
def _apply_path_mapping(self) -> None:
    """
    Applies path mapping to V-Ray specific assets.

    Currently handles:
    - VRayProxy objects (.vrmesh files)
    """
    if self.map_path is None:
        return

    self._apply_vray_proxy_path_mapping()

def _apply_vray_proxy_path_mapping(self) -> None:
    """
    Applies path mapping to all VRayProxy objects in the scene.
    """
    # Check if VRayProxy class exists
    if not hasattr(rt, "VRayProxy"):
        self.log_to_console("VRayProxy class not found - V-Ray may not be loaded")
        return

    # rt.objects returns pymxs objects (dynamically typed)
    proxies: list[Any] = [obj for obj in rt.objects if rt.classOf(obj) == rt.VRayProxy]

    if not proxies:
        self.log_to_console("No VRayProxy objects found in scene")
        return

    mapped_count: int = 0
    for proxy in proxies:
        original_path: Any = getattr(proxy, "fileName", None)
        if not original_path:
            continue

        original_path_str: str = str(original_path)

        # Use the injected map_path function
        assert self.map_path is not None  # For mypy
        self.log_to_console(f"Requesting Path Mapping for path '{original_path_str}'.")
        mapped_path: str = self.map_path(original_path_str)
        self.log_to_console(f"Mapped path '{original_path_str}' to '{mapped_path}'.")

        if mapped_path != original_path_str:
            try:
                proxy.fileName = mapped_path
                mapped_count += 1
                self.log_to_console(
                    f"Remapped VRayProxy '{proxy.name}': {original_path_str} -> {mapped_path}"
                )
            except Exception as e:
                self.log_to_console(f"Warning: Failed to remap VRayProxy '{proxy.name}': {e}")

    self.log_to_console(f"VRMesh path mapping complete: {mapped_count} proxies remapped")
```

### 4.4 pymxs API Usage

Key pymxs/MAXScript APIs used:

| API | Purpose |
|-----|---------|
| `rt.objects` | Iterate all scene objects |
| `rt.classOf(obj)` | Get object class for type checking |
| `rt.VRayProxy` | VRayProxy class reference |
| `proxy.fileName` | VRayProxy file path property (read/write) |
| `proxy.name` | Object name for logging |

### 4.5 Execution Flow

```
MaxClient.set_renderer()
    +-- Inject map_path into render_handler

DefaultMaxHandler.set_scene_file()
    +-- rt.loadMaxFile(file_path, quiet=True)
    +-- if map_path: _apply_path_mapping()

VrayHandler._apply_path_mapping()
    +-- _apply_vray_proxy_path_mapping()
        +-- Find all VRayProxy objects
        +-- For each proxy:
        |   +-- Get original fileName
        |   +-- Call map_path(original_path)
        |   +-- Set proxy.fileName = mapped_path
        +-- Log summary
```

---

## Future Extensibility

The `_apply_path_mapping()` hook pattern allows easy extension for other V-Ray asset types:

- **VRayHDRI** - HDR environment maps
- **VRayBitmap** - V-Ray texture maps
- **VRayMesh** - V-Ray mesh export files
- **VRayScene** - V-Ray scene files (.vrscene)

Each can be added as a separate method called from `_apply_path_mapping()`:

```python
def _apply_path_mapping(self) -> None:
    if self.map_path is None:
        return

    self._apply_vray_proxy_path_mapping()
    # Future: self._apply_vray_hdri_path_mapping()
    # Future: self._apply_vray_bitmap_path_mapping()
```

---

## Testing Strategy

Unit tests cover:
1. No VRayProxy class available (V-Ray not loaded)
2. No proxies in scene
3. Single proxy path mapping
4. Multiple proxies with mixed mapping results
5. Path unchanged scenarios (no remapping needed)
6. Mapping failure handling (exception safety)
7. Missing fileName attribute handling
8. Base handler no-op behavior
9. Integration with set_scene_file flow

See: `test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_path_mapping.py`
