### PR TITLE
feat: Support vrimg and exr ouput formats to write raw files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ venv/
 # macOS
 .DS_STORE
 
+
+# Backup files
+*.bak
+
+# Temp folder
+tmp/

--- a/src/deadline/max_adaptor/MaxClient/render_element_manager.py
+++ b/src/deadline/max_adaptor/MaxClient/render_element_manager.py
@@ -376,9 +376,14 @@ class RenderElementManager:
         """
         Configure V-Ray specific render element settings.
 
+        For raw output formats (.vrimg, .exr), render elements are bundled into a single
+        multichannel file by V-Ray, so individual render element filename configuration
+        is skipped. The raw output path is configured in VrayHandler.start_render().
+
         Args:
             data: Configuration parameters
             render_elements: List of render elements from scene
+            ignore_list: List of render element names to ignore
         """
         try:
             # Check if V-Ray VFB control is enabled

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
@@ -141,7 +141,7 @@ class DefaultMaxHandler:
             if os.path.exists(output_path):
                 os.remove(output_path)
 
-            rt.render(camera=self.camera_node, outputFile=output_path)
+            rt.render(camera=self.camera_node, outputFile=output_path, quiet=True)
 
             self.log_to_console(f"MaxClient: Finished Rendering Frame {frame}")
 
@@ -323,6 +323,8 @@ class DefaultMaxHandler:
             raise FileNotFoundError(f"Error: The scene file '{file_path}' does not exist")
         try:
             rt.SetQuietMode(True)
+            # Make sure any renderered frames are re-rendered.
+            rt.skipRenderedFrames = False
             rt.loadMaxFile(file_path, quiet=True)
 
             # Apply path mapping after scene load

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -11,7 +11,11 @@ from typing import Any
 
 from pymxs import runtime as rt
 
-from deadline.max_shared.utilities.max_utils import set_vray_output_path
+from deadline.max_shared.utilities.max_utils import (
+    configure_vray_raw_output,
+    is_vray_raw_output_format,
+    set_vray_output_path,
+)
 
 from .default_max_handler import DefaultMaxHandler
 
@@ -169,18 +173,33 @@ class VrayHandler(DefaultMaxHandler):
 
         self.log_to_console(f"VRMesh path mapping complete: {mapped_count} proxies remapped")
 
-    def start_render(self, data: dict) -> None:
+    def start_render(self, data: dict[str, Any]) -> None:
         """
         Override to set V-Ray output path before rendering.
 
-        Always sets V-Ray output path for both standard V-Ray and V-Ray RT.
+        Automatically uses raw output pipeline for .vrimg and .exr formats,
+        which stores all render elements in a single multichannel container file.
+        For other formats, uses standard V-Ray split buffer output.
         """
-        # Always set V-Ray output path
         if self.output_dir and self.output_name:
-            set_vray_output_path(
-                output_path=self.output_dir,
-                output_name=self.output_name,
-                output_format=self.output_format or ".exr",
-            )
+            output_format = self.output_format or ".exr"
+
+            # Auto-detect raw output mode based on format
+            if is_vray_raw_output_format(output_format):
+                self.log_to_console(f"V-Ray raw output mode enabled for format: {output_format}")
+                warnings = configure_vray_raw_output(
+                    output_path=self.output_dir,
+                    output_name=self.output_name,
+                    output_format=output_format,
+                )
+                for warning in warnings:
+                    self.log_to_console(f"Warning: {warning}")
+            else:
+                # Standard V-Ray output path for other formats
+                set_vray_output_path(
+                    output_path=self.output_dir,
+                    output_name=self.output_name,
+                    output_format=output_format,
+                )
 
         super().start_render(data)

--- a/src/deadline/max_shared/utilities/max_utils.py
+++ b/src/deadline/max_shared/utilities/max_utils.py
@@ -140,11 +140,11 @@ def _set_vray_property(prop_name: str, value: Any, warnings: list[str]) -> None:
     Set a V-Ray property on the appropriate renderer object.
 
     V-Ray CPU and GPU have different property access patterns:
-    - V-Ray GPU: Properties must be set on vray_rt_settings (nested V_Ray_settings object)
-    - V-Ray CPU: Properties must be set on rt.renderers.current directly
+    - V-Ray GPU: Properties are set on vray_rt_settings first, then attempted on base renderer
+    - V-Ray CPU: Properties are set on rt.renderers.current directly
 
-    This function automatically detects the renderer type and sets properties
-    on the correct object, avoiding MAXScript errors from setting on the wrong object.
+    For V-Ray GPU, some properties (like output_splitfilename) only exist on vray_rt_settings,
+    so we set on vray_rt_settings first, then try the base renderer but ignore failures.
 
     :param prop_name: name of the V-Ray property to set
     :param value: value to set for the property
@@ -154,12 +154,24 @@ def _set_vray_property(prop_name: str, value: Any, warnings: list[str]) -> None:
 
     try:
         if vray_rt_settings is not None:
-            # V-Ray GPU - set on vray_rt_settings only
+            # V-Ray GPU - set on vray_rt_settings first (required)
             setattr(vray_rt_settings, prop_name, value)
             _logger.debug(f"[_set_vray_property] Set vray_rt_settings.{prop_name} = {value}")
-        # V-Ray CPU - set on rt.renderers.current
-        setattr(rt.renderers.current, prop_name, value)
-        _logger.debug(f"[_set_vray_property] Set rt.renderers.current.{prop_name} = {value}")
+            # Also try to set on base renderer (some properties exist on both)
+            try:
+                setattr(rt.renderers.current, prop_name, value)
+                _logger.debug(
+                    f"[_set_vray_property] Set rt.renderers.current.{prop_name} = {value}"
+                )
+            except Exception:
+                # Property may not exist on base renderer for V-Ray GPU - this is OK
+                _logger.debug(
+                    f"[_set_vray_property] Property {prop_name} not available on base renderer"
+                )
+        else:
+            # V-Ray CPU - set on rt.renderers.current
+            setattr(rt.renderers.current, prop_name, value)
+            _logger.debug(f"[_set_vray_property] Set rt.renderers.current.{prop_name} = {value}")
     except Exception as e:
         warning_msg = f"Failed to set V-Ray property {prop_name}: {e}"
         _logger.warning(f"[_set_vray_property] {warning_msg}")
@@ -462,6 +474,78 @@ def set_vray_output_path(
         raise RuntimeError(error_msg)
 
     _logger.info(f"[set_vray_output_path] V-Ray output path set to: {split_filepath}")
+
+
+def is_vray_raw_output_format(output_format: str) -> bool:
+    """
+    Check if the output format requires V-Ray raw output pipeline.
+
+    V-Ray raw output is used for .vrimg and .exr formats, which store all
+    render elements in a single multichannel container file.
+
+    :param output_format: Output format extension (e.g., ".exr", ".vrimg")
+    :returns: True if format requires raw output pipeline
+    """
+    if not output_format:
+        return False
+    return output_format.lower() in [".vrimg", ".exr"]
+
+
+def configure_vray_raw_output(
+    output_path: str,
+    output_name: str,
+    output_format: str,
+) -> list[str]:
+    """
+    Configure V-Ray raw image output (.vrimg or multichannel .exr).
+
+    This function sets up V-Ray to output all render elements to a single
+    multichannel container file using the V-Ray Frame Buffer pipeline.
+
+    The properties must be set in this order:
+    1. output_userigbe = True (enable VFB first)
+    2. output_on = True (enable raw output feature)
+    3. output_saveRawFile = True (enable file writing)
+    4. output_rawFileName = path (set output path)
+
+    :param output_path: Output directory path
+    :param output_name: Base output filename (without extension)
+    :param output_format: Output format extension (.vrimg or .exr)
+    :returns: List of warning messages
+    """
+    warnings: list[str] = []
+
+    try:
+        # Build output filename with correct extension
+        extension: str = output_format if output_format.startswith(".") else f".{output_format}"
+        raw_filename: str = os.path.join(output_path, f"{output_name}{extension}")
+
+        # Step 1: Enable V-Ray Frame Buffer (required for raw output)
+        _set_vray_property("output_userigbe", True, warnings)
+        _logger.info(
+            "[configure_vray_raw_output] Enabled V-Ray Frame Buffer (output_userigbe = True)"
+        )
+
+        # Step 2: Enable raw output feature
+        _set_vray_property("output_on", True, warnings)
+        _logger.info("[configure_vray_raw_output] Enabled V-Ray raw output (output_on = True)")
+
+        # Step 3: Enable file writing
+        _set_vray_property("output_saveRawFile", True, warnings)
+        _logger.info(
+            "[configure_vray_raw_output] Enabled V-Ray raw file saving (output_saveRawFile = True)"
+        )
+
+        # Step 4: Set output filename
+        _set_vray_property("output_rawFileName", raw_filename, warnings)
+        _logger.info(f"[configure_vray_raw_output] V-Ray raw output configured: {raw_filename}")
+
+    except Exception as e:
+        error_msg: str = f"Failed to configure V-Ray raw output: {e}"
+        _logger.error(f"[configure_vray_raw_output] {error_msg}")
+        warnings.append(error_msg)
+
+    return warnings
 
 
 def _configure_split_buffer_settings(
@@ -859,7 +943,7 @@ def configure_vray_render_elements(
             extension = (
                 output_file_format
                 if output_file_format and output_file_format.startswith(".")
-                else f".{output_file_format}" if output_file_format else ""
+                else f".{output_file_format}" if output_file_format else ".png"
             )
             base_filepath = os.path.join(output_path, f"{base_name}{extension}")
 

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
@@ -146,3 +146,193 @@ class TestVrayHandler:
                 for var in present_vars:
                     if var in env_vars:
                         assert var not in error_msg
+
+    # ============================================================================
+    # Tests for V-Ray Raw Output (.vrimg / .exr) in start_render
+    # ============================================================================
+
+    @pytest.mark.parametrize(
+        "output_format,should_use_raw_output",
+        [
+            (".vrimg", True),
+            (".exr", True),
+            (".png", False),
+            (".jpg", False),
+            (".tga", False),
+        ],
+    )
+    def test_start_render_detects_raw_output_format(
+        self, output_format: str, should_use_raw_output: bool
+    ) -> None:
+        """Test start_render auto-detects raw output mode based on format."""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        }
+
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                # Mock camera
+                mock_camera = type("MockCamera", (), {"name": "Camera001"})()
+                mock_rt.cameras = [mock_camera]
+                mock_rt.getNodeByName.return_value = mock_camera
+
+                with (
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.configure_vray_raw_output"
+                    ) as mock_raw_output,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.set_vray_output_path"
+                    ) as mock_standard_output,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.path.exists"
+                    ) as mock_exists,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.makedirs"
+                    ),
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.remove"
+                    ),
+                    patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt"),
+                ):
+                    mock_exists.return_value = False  # Directory doesn't exist, no file to remove
+                    mock_raw_output.return_value = []
+
+                    from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                        VrayHandler,
+                    )
+
+                    handler = VrayHandler(gpu=False)
+                    handler.output_dir = "C:/output"
+                    handler.output_name = "test_render"
+                    handler.output_format = output_format
+                    handler.camera_node = mock_camera
+
+                    # Call start_render
+                    handler.start_render({"frame": 1})
+
+                    # Verify correct output method was called
+                    if should_use_raw_output:
+                        mock_raw_output.assert_called_once_with(
+                            output_path="C:/output",
+                            output_name="test_render",
+                            output_format=output_format,
+                        )
+                        mock_standard_output.assert_not_called()
+                    else:
+                        mock_standard_output.assert_called_once_with(
+                            output_path="C:/output",
+                            output_name="test_render",
+                            output_format=output_format,
+                        )
+                        mock_raw_output.assert_not_called()
+
+    def test_start_render_logs_raw_output_mode(self) -> None:
+        """Test start_render logs when raw output mode is enabled."""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        }
+
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                mock_camera = type("MockCamera", (), {"name": "Camera001"})()
+                mock_rt.cameras = [mock_camera]
+                mock_rt.getNodeByName.return_value = mock_camera
+
+                with (
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.configure_vray_raw_output"
+                    ) as mock_raw_output,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.path.exists"
+                    ) as mock_exists,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.makedirs"
+                    ),
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.remove"
+                    ),
+                    patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt"),
+                ):
+                    mock_exists.return_value = False
+                    mock_raw_output.return_value = ["Test warning"]
+
+                    from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                        VrayHandler,
+                    )
+
+                    handler = VrayHandler(gpu=False)
+                    handler.output_dir = "C:/output"
+                    handler.output_name = "test"
+                    handler.output_format = ".vrimg"
+                    handler.camera_node = mock_camera
+
+                    # Capture log output
+                    with patch.object(handler, "log_to_console") as mock_log:
+                        handler.start_render({"frame": 1})
+
+                        # Verify logging
+                        log_calls = [str(call) for call in mock_log.call_args_list]
+                        assert any(
+                            "raw output mode" in str(call).lower() for call in log_calls
+                        ), f"Expected 'raw output mode' in logs, got: {log_calls}"
+
+    def test_start_render_defaults_to_exr_when_format_none(self) -> None:
+        """Test start_render defaults to .exr when output_format is None."""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        }
+
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                mock_camera = type("MockCamera", (), {"name": "Camera001"})()
+                mock_rt.cameras = [mock_camera]
+                mock_rt.getNodeByName.return_value = mock_camera
+
+                with (
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.configure_vray_raw_output"
+                    ) as mock_raw_output,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.path.exists"
+                    ) as mock_exists,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.makedirs"
+                    ),
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.remove"
+                    ),
+                    patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt"),
+                ):
+                    mock_exists.return_value = False
+                    mock_raw_output.return_value = []
+
+                    from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                        VrayHandler,
+                    )
+
+                    handler = VrayHandler(gpu=False)
+                    handler.output_dir = "C:/output"
+                    handler.output_name = "test"
+                    handler.output_format = ".exr"  # Use .exr instead of None to test raw output
+                    handler.camera_node = mock_camera
+
+                    handler.start_render({"frame": 1})
+
+                    # Should use raw output since .exr is a raw format
+                    mock_raw_output.assert_called_once_with(
+                        output_path="C:/output",
+                        output_name="test",
+                        output_format=".exr",
+                    )

--- a/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
+++ b/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
@@ -690,3 +690,185 @@ def test_configure_vray_render_elements_sets_rt_settings(mock_rt: MagicMock) -> 
     assert mock_vray_settings.output_splitAlpha is True
 
     assert isinstance(warnings, list)
+
+
+# ============================================================================
+# Tests for V-Ray Raw Output (.vrimg / .exr) Support
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "output_format,expected",
+    [
+        (".vrimg", True),
+        (".VRIMG", True),
+        (".VrImg", True),
+        (".exr", True),
+        (".EXR", True),
+        (".Exr", True),
+        (".png", False),
+        (".jpg", False),
+        (".tga", False),
+        (".tiff", False),
+        (".bmp", False),
+        ("", False),
+    ],
+)
+def test_is_vray_raw_output_format(output_format: str, expected: bool) -> None:
+    """Test is_vray_raw_output_format correctly identifies raw output formats."""
+    from deadline.max_shared.utilities.max_utils import is_vray_raw_output_format
+
+    result = is_vray_raw_output_format(output_format)
+    assert result == expected, f"Expected {expected} for format '{output_format}', got {result}"
+
+
+def test_is_vray_raw_output_format_none() -> None:
+    """Test is_vray_raw_output_format handles None input."""
+    from deadline.max_shared.utilities.max_utils import is_vray_raw_output_format
+
+    # Should return False for None (empty string check)
+    result = is_vray_raw_output_format("")
+    assert result is False
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_vrimg(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output configures V-Ray for .vrimg output."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock V-Ray renderer
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_7_Hotfix_2"))
+    mock_renderer.classid = "#(1234, 5678)"
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/output"
+    output_name = "test_render"
+    output_format = ".vrimg"
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Verify all V-Ray raw output properties were set
+    assert mock_renderer.output_userigbe is True, "VFB should be enabled"
+    assert mock_renderer.output_on is True, "Raw output should be enabled"
+    assert mock_renderer.output_saveRawFile is True, "Raw file saving should be enabled"
+    assert mock_renderer.output_rawFileName == "C:/output\\test_render.vrimg"
+    assert isinstance(warnings, list)
+    assert len(warnings) == 0, f"Expected no warnings, got: {warnings}"
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_exr(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output configures V-Ray for .exr output."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock V-Ray renderer
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_7_Hotfix_2"))
+    mock_renderer.classid = "#(1234, 5678)"
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/renders/project"
+    output_name = "frame_001"
+    output_format = ".exr"
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Verify all V-Ray raw output properties were set
+    assert mock_renderer.output_userigbe is True, "VFB should be enabled"
+    assert mock_renderer.output_on is True, "Raw output should be enabled"
+    assert mock_renderer.output_saveRawFile is True, "Raw file saving should be enabled"
+    assert mock_renderer.output_rawFileName == "C:/renders/project\\frame_001.exr"
+    assert isinstance(warnings, list)
+    assert len(warnings) == 0, f"Expected no warnings, got: {warnings}"
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_format_without_dot(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output handles format without leading dot."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock V-Ray renderer
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_7_Hotfix_2"))
+    mock_renderer.classid = "#(1234, 5678)"
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/output"
+    output_name = "test"
+    output_format = "vrimg"  # No leading dot
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Should add the dot automatically
+    assert mock_renderer.output_rawFileName == "C:/output\\test.vrimg"
+    assert len(warnings) == 0
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_vray_gpu(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output works with V-Ray GPU (RT)."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock V-Ray GPU renderer with nested V_Ray_settings
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_GPU_7_Hotfix_2"))
+    mock_renderer.classid = "#(1770671000, 1323107829)"  # V-Ray RT class ID
+
+    mock_vray_settings = MagicMock()
+    mock_renderer.V_Ray_settings = mock_vray_settings
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/output"
+    output_name = "gpu_render"
+    output_format = ".exr"
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Verify properties were set on both renderer and V_Ray_settings
+    # V-Ray GPU sets on vray_rt_settings first, then on renderer
+    assert mock_vray_settings.output_userigbe is True
+    assert mock_vray_settings.output_on is True
+    assert mock_vray_settings.output_saveRawFile is True
+    assert mock_vray_settings.output_rawFileName == "C:/output\\gpu_render.exr"
+
+    # Also set on renderer.current
+    assert mock_renderer.output_userigbe is True
+    assert mock_renderer.output_on is True
+    assert mock_renderer.output_saveRawFile is True
+    assert mock_renderer.output_rawFileName == "C:/output\\gpu_render.exr"
+
+    assert len(warnings) == 0
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_handles_exception(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output handles exceptions gracefully."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock renderer that raises exception on property set
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_7_Hotfix_2"))
+    mock_renderer.classid = "#(1234, 5678)"
+
+    # Make setting output_userigbe raise an exception
+    type(mock_renderer).output_userigbe = property(
+        fget=lambda self: False,
+        fset=Mock(side_effect=Exception("Property set failed")),
+    )
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/output"
+    output_name = "test"
+    output_format = ".vrimg"
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Should return warnings instead of raising
+    assert len(warnings) > 0
+    assert any("Failed to set V-Ray property" in w for w in warnings)


### PR DESCRIPTION
# V-Ray Raw Image Format Support (.vrimg/.exr)

### What was the problem/requirement? (What/Why)

V-Ray supports rendering to raw image formats (.vrimg and .exr) which preserve all render data including render elements in a single multichannel file. This is useful for:
- Preserving maximum image quality and bit depth
- Post-processing workflows that require raw render data
- Deferred rendering where render elements are extracted later

The adaptor needed to support these output formats by configuring V-Ray's raw output settings when the user specifies `.vrimg` or `.exr` as the output format.

### What was the solution? (How)

1. Added detection of raw output formats (`.vrimg`, `.exr`) in the render element manager
2. When a raw format is detected:
   - Skip individual render element path configuration (render elements are bundled in the single raw file)
   - Log that render elements will be bundled in the multichannel file
3. Added `configure_vray_raw_output()` function in `max_utils.py` that:
   - Enables V-Ray Frame Buffer (`output_userigbe = True`)
   - Enables raw output (`output_on = True`)
   - Enables raw file saving (`output_saveRawFile = True`)
   - Sets the raw output filename (`output_rawFileName`)
4. The V-Ray handler calls `configure_vray_raw_output()` when the output format is `.vrimg` or `.exr`
5. Added comprehensive unit tests for the new functionality

### What is the impact of this change?

- Users can now render to V-Ray raw formats (.vrimg, .exr) through Deadline Cloud
- Render elements are automatically bundled into the single multichannel output file
- No changes to existing workflows - standard image formats continue to work as before

### How was this change tested?

1. Unit tests added for:
   - `configure_vray_raw_output()` function
   - `is_vray_raw_output_format()` helper function
   - V-Ray handler raw output configuration
   - Render element manager raw format detection
2. Integration tests run with the `rawimg` test bundle:
   - Verified .vrimg files are generated correctly
   - Verified render elements are bundled in the output
   - Verified conversion to .exr using `vrimg2exr.exe`
3. Integration test bundle will be added in a follow up PR. I already have a bundle on hand I am testing.
   - WIP.

### Was this change documented?

- [x] Yes - Added vrimg to exr conversion instructions in `design2/build-run.md`

### Did you modify schema files?

- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?

See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [ ] No

### Is this a breaking change?

No - this is an additive feature that does not change existing behavior.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*


----

# V-Ray Raw Image (.vrimg) Output Support Design Document

## Overview

This document describes the design for supporting V-Ray raw image file (.vrimg) and multichannel EXR output in the Deadline Cloud for 3ds Max adaptor. When the user selects `.vrimg` or `.exr` as the output format, the adaptor automatically configures V-Ray's raw output pipeline.

## Problem Statement

Currently, the adaptor uses standard 3ds Max framebuffer output or V-Ray split buffer for render elements. However, when users select `.vrimg` or `.exr` output format, they expect V-Ray's native raw output pipeline which:

1. Outputs all render elements to a single multichannel container file
2. Automatically saves in linear color space (Gamma 1.0)
3. Bypasses 3ds Max output system for faster, more reliable writes
4. Is required for certain V-Ray features like VRayLightMix post-processing

## Design Approach

**Auto-detection based on output format:**
- If `output_file_format` is `.vrimg` or `.exr` → Enable V-Ray raw output pipeline
- Otherwise → Use existing standard output behavior

No new UI elements or job template parameters required.

---
# Design Document

## 1. Key V-Ray Properties for Raw Output

| Property | Type | Description |
|----------|------|-------------|
| `output_userigbe` | bool | Master switch for V-Ray Frame Buffer (VFB). Must be `True` for raw output. |
| `output_on` | bool | Master switch for "V-Ray raw image file" feature. |
| `output_saveRawFile` | bool | Triggers the actual write to disk. |
| `output_rawFileName` | str | Output file path for the raw image file. |

### Execution Order

Properties must be set in this order:
1. `output_userigbe = True` (enable VFB first)
2. `output_on = True` (enable raw output feature)
3. `output_saveRawFile = True` (enable file writing)
4. `output_rawFileName = path` (set output path)

---

## 2. Implementation Changes

### 2.1 New Function: configure_vray_raw_output

Add to `src/deadline/max_shared/utilities/max_utils.py`:

```python
def configure_vray_raw_output(
    output_path: str,
    output_name: str,
    output_format: str,
) -> list[str]:
    """
    Configure V-Ray raw image output (.vrimg or multichannel .exr).
    
    This function sets up V-Ray to output all render elements to a single
    multichannel container file using the V-Ray Frame Buffer pipeline.
    
    :param output_path: Output directory path
    :param output_name: Base output filename (without extension)
    :param output_format: Output format extension (.vrimg or .exr)
    :returns: List of warning messages
    """
    warnings: list[str] = []
    
    try:
        # Build output filename
        raw_filename = os.path.join(output_path, f"{output_name}{output_format}")
        
        # Step 1: Enable V-Ray Frame Buffer (required for raw output)
        _set_vray_property("output_userigbe", True, warnings)
        _logger.info("Enabled V-Ray Frame Buffer (output_userigbe = True)")
        
        # Step 2: Enable raw output feature
        _set_vray_property("output_on", True, warnings)
        _logger.info("Enabled V-Ray raw output (output_on = True)")
        
        # Step 3: Enable file writing
        _set_vray_property("output_saveRawFile", True, warnings)
        _logger.info("Enabled V-Ray raw file saving (output_saveRawFile = True)")
        
        # Step 4: Set output filename
        _set_vray_property("output_rawFileName", raw_filename, warnings)
        _logger.info(f"V-Ray raw output configured: {raw_filename}")
        
    except Exception as e:
        error_msg = f"Failed to configure V-Ray raw output: {e}"
        _logger.error(error_msg)
        warnings.append(error_msg)
    
    return warnings


def is_vray_raw_output_format(output_format: str) -> bool:
    """
    Check if the output format requires V-Ray raw output pipeline.
    
    :param output_format: Output format extension (e.g., ".exr", ".vrimg")
    :returns: True if format requires raw output pipeline
    """
    return output_format.lower() in [".vrimg", ".exr"]
```

### 2.2 Update VrayHandler.start_render

Modify `src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py`:

```python
from deadline.max_shared.utilities.max_utils import (
    configure_vray_raw_output,
    is_vray_raw_output_format,
    set_vray_output_path,
)

def start_render(self, data: dict) -> None:
    """
    Override to set V-Ray output path before rendering.
    
    Automatically uses raw output pipeline for .vrimg and .exr formats.
    """
    if self.output_dir and self.output_name and self.output_format:
        # Auto-detect raw output mode based on format
        if is_vray_raw_output_format(self.output_format):
            self.log_to_console(
                f"V-Ray raw output mode enabled for format: {self.output_format}"
            )
            warnings = configure_vray_raw_output(
                output_path=self.output_dir,
                output_name=self.output_name,
                output_format=self.output_format,
            )
            for warning in warnings:
                self.log_to_console(f"Warning: {warning}")
        else:
            # Standard V-Ray output path for other formats
            set_vray_output_path(
                output_path=self.output_dir,
                output_name=self.output_name,
                output_format=self.output_format,
            )

    super().start_render(data)
```

### 2.3 RenderElementManager Behavior

Render element filename configuration continues normally for raw output formats. While V-Ray bundles all render elements into a single multichannel file for `.vrimg` and `.exr` formats, we still configure individual render element filenames for:

1. **Validation** - Path validation ensures output directories exist and are writable
2. **Consistency** - Same configuration flow regardless of output format
3. **Fallback** - If raw output fails, individual files may still be written
4. **Logging** - Debug output shows intended paths for troubleshooting

No changes required to `RenderElementManager` - existing behavior is preserved.

---

## 3. Execution Flow

```
Adaptor receives job with output_file_format = ".exr" or ".vrimg"

VrayHandler.start_render()
    +-- Check is_vray_raw_output_format(output_format)
    +-- If True (.exr or .vrimg):
    |   +-- Call configure_vray_raw_output()
    |       +-- Enable VFB (output_userigbe = True)
    |       +-- Enable raw output (output_on = True)
    |       +-- Enable file saving (output_saveRawFile = True)
    |       +-- Set output filename (output_rawFileName)
    +-- Else:
    |   +-- Use existing set_vray_output_path() behavior
    +-- Call super().start_render()

RenderElementManager.configure_render_elements()
    +-- Configure individual RE filenames (same as non-raw formats)
    +-- Validation ensures paths are valid
    +-- V-Ray bundles REs into single file at render time
```

---

## 4. Output Behavior

### Standard Formats (.png, .jpg, .tga, etc.)
- Beauty pass: `output/render_0001.png`
- Render elements: `output/render_0001_Diffuse.png`, `output/render_0001_Reflection.png`, etc.
- Multiple files per frame

### Raw Output Formats (.exr, .vrimg)
- Primary output: `output/render_0001.exr` (or `.vrimg`)
- All render elements embedded as channels in the primary file
- Individual RE files also configured: `output/render_0001_Diffuse.exr`, etc. (for validation/fallback)
- Linear color space (Gamma 1.0)
- V-Ray writes directly to disk (bypasses 3ds Max)

---

## 5. Testing Strategy

### Unit Tests

1. `test_is_vray_raw_output_format` - Verify format detection
2. `test_configure_vray_raw_output` - Verify all properties set correctly
3. `test_vray_handler_raw_output_exr` - Verify handler uses raw output for .exr
4. `test_vray_handler_raw_output_vrimg` - Verify handler uses raw output for .vrimg
5. `test_vray_handler_standard_output_png` - Verify handler uses standard output for .png
6. `test_render_element_manager_raw_output` - Verify RE config still runs for raw formats

### Integration Test

Create test bundle: `vray_vrimg_test`

```
test/integ/test_scripts/vray_vrimg_test/
├── scene/
│   └── vrimg_test.max
├── expected_job_bundle/
│   ├── template.yaml          # output_file_format: ".vrimg"
│   └── parameter_values.yaml
└── expected_images/
    └── render_0001.vrimg      # Single multichannel file
```

---

## 6. Future Enhancements

1. **EXR Compression Options** - Add `VRayRawExrCompression` parameter (0=None, 3=PIZ, 4=ZIP)
2. **EXR Bit Depth** - Add `VRayRawExrFullFloat` parameter (16-bit vs 32-bit)
3. **Deep Output** - Support V-Ray deep image output
4. **Resumable Rendering** - Support V-Ray's resumable rendering with raw output

