### PR TITLE
fix: output extension override from submitter

### DIFF
--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -98,7 +98,10 @@ def on_create_job_bundle_callback(
                 output_dir = os.path.split(rt.rendOutputFilename)[0]
                 output_file = os.path.split(rt.rendOutputFilename)[1]
                 output_file_name = Path(output_file).stem
-                output_file_format = os.path.splitext(output_file)[1]
+                # Use UI override if provided, otherwise fall back to render setup extension
+                output_file_format = (
+                    settings.output_ext if settings.output_ext else os.path.splitext(output_file)[1]
+                )
             # If it isn't, use the UI fields data
             else:
                 output_dir = settings.output_path
@@ -137,7 +140,10 @@ def on_create_job_bundle_callback(
             output_dir = os.path.split(rt.rendOutputFilename)[0]
             output_file = os.path.split(rt.rendOutputFilename)[1]
             output_file_name = Path(output_file).stem
-            output_file_format = os.path.splitext(output_file)[1]
+            # Use UI override if provided, otherwise fall back to render setup extension
+            output_file_format = (
+                settings.output_ext if settings.output_ext else os.path.splitext(output_file)[1]
+            )
         # If it isn't, use the UI fields data
         else:
             output_dir = settings.output_path


### PR DESCRIPTION
When users override the output extension in the submitter UI, the override was being ignored if `rt.rendOutputFilename` was set in the render setup. The code always extracted the extension from the render setup path.

This fix ensures that settings.output_ext (UI override) takes precedence when provided, and only falls back to the render setup extension when no override is specified.

Tested by exporting job bundle and verifying parameter.yaml contains the correct overridden output extension.

### What was the problem/requirement? (What/Why)

When users attempted to override the output file extension in the Deadline Cloud submitter UI (e.g., changing from `.exr` to `.jpeg`), the override was being ignored if `rt.rendOutputFilename` was set in the 3ds Max render setup. The code always extracted and used the extension from the render setup path, completely bypassing the user's explicit override value in `settings.output_ext`.

This prevented users from changing output formats at submission time without modifying their scene's render setup, which is a common workflow requirement.

Here's the Github issue link: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/184

### What was the solution? (How)

Modified `src/deadline/max_submitter/max_render_submitter.py` at lines 101 and 140 to prioritize the UI override value over the render setup extension. The fix uses a conditional expression to check if `settings.output_ext` is provided, and only falls back to extracting the extension from `rt.rendOutputFilename` when no override is specified.

**Changes:**
- Line 101: Added conditional to check UI override first (for "all state sets" mode)
- Line 140: Added conditional to check UI override first (for "single state set" mode)

Both locations now use: `settings.output_ext if settings.output_ext else os.path.splitext(output_file)[1]`

### What is the impact of this change?

Users can now successfully override the output file extension in the submitter UI, regardless of what extension is configured in the render setup. This provides greater flexibility in submission workflows without requiring scene modifications.

**Impact:**
- Positive: Users gain the ability to change output formats at submission time
- No breaking changes: When no override is provided, behavior remains unchanged (uses render setup extension)
- Backward compatible: Existing workflows without overrides continue to work as before

### How was this change tested?

1. Set up a 3ds Max scene with `.exr` output extension in the render setup
<img width="1084" height="869" alt="Screenshot 2026-01-23 at 8 34 01 AM" src="https://github.com/user-attachments/assets/c69c7d0a-f76f-42c1-a76a-1016c62fd134" />
3. Opened the Deadline Cloud submitter UI
4. Overrode the output extension to `.jpeg` in the submitter
5. Exported the job bundle instead of submitting
6. Verified that `parameter_values.yaml` contained the correct overridden extension (`.jpeg`) instead of the render setup default (`.exr`) which previously did not happen. 
check the parameter.yaml files before [parameter_values_fixed.yaml](https://github.com/user-attachments/files/24823286/parameter_values_fixed.yaml) and after the change [parameter_values_with_bug.yaml](https://github.com/user-attachments/files/24823287/parameter_values_with_bug.yaml)


### Was this change documented?

- [x] No

This is a bug fix that restores expected behavior. No additional documentation is needed as the UI already indicates that the output extension field is an override.

### Did you modify schema files?

- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [ ] No

### Is this a breaking change?

- [x] No

This change is backward compatible. When no override is provided, the behavior remains unchanged (uses render setup extension). When an override is provided, it now correctly takes precedence as originally intended.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
