### PR TITLE
doc: 3dsmax development setup Kiro power

### DIFF
--- a/.kiro/powers/3dsmax-dev-setup/POWER.md
+++ b/.kiro/powers/3dsmax-dev-setup/POWER.md
@@ -1,0 +1,146 @@
+---
+name: 3dsmax-dev-setup
+version: 1.0.0
+displayName: 3ds Max Dev Setup
+description: Automated development environment setup for deadline-cloud-for-3ds-max - builds packages, installs dependencies, and configures environment variables
+keywords:
+  - 3dsmax
+  - deadline
+  - setup
+  - build
+  - install
+  - environment
+  - development
+  - hatch
+  - openjd
+author: AWS Deadline Cloud
+---
+
+# 3ds Max Dev Setup Power
+
+Automated development environment setup for deadline-cloud-for-3ds-max project.
+
+## What This Power Does
+
+This power automates the complete development environment setup for working on the deadline-cloud-for-3ds-max project. It handles everything from reading documentation to building packages, installing dependencies, and configuring environment variables.
+
+## Setup Steps Performed
+
+1. **Documentation Review** - Reads README.md and DEVELOPMENT.md to understand project requirements
+2. **Hatch Installation** - Installs and configures Hatch build tool
+3. **Package Build** - Builds wheel and source distributions
+4. **Installer Build** - Builds the Windows installer (if InstallBuilder is available)
+5. **3ds Max Detection** - Verifies 3ds Max installation
+6. **Wheel Installation** - Installs the built wheel to 3ds Max Python
+7. **OpenJD CLI Installation** - Installs openjd-cli for running integration tests
+8. **Test Packages Installation** - Installs pytest, coverage, pillow, flaky, numpy
+9. **PowerShell YAML Module** - Installs powershell-yaml for test scripts
+10. **Environment Configuration** - Sets up required environment variables
+
+## Prerequisites
+
+- Python 3.9+ installed on system
+- 3ds Max 2024, 2025, or 2026 installed
+- Windows operating system
+- (Optional) InstallBuilder for building installers
+
+## Usage
+
+The power will prompt you for:
+- **3ds Max Version** (default: 2026)
+
+If 3ds Max is not found at the expected location, the setup will abort with instructions to install 3ds Max first.
+
+## What Gets Installed
+
+### System Python Packages
+- `hatch` - Build tool and environment manager
+
+### 3ds Max Python Packages
+- `deadline-cloud-for-3ds-max` - The built wheel from dist/
+- `deadline` - AWS Deadline Cloud client library
+- `openjd-adaptor-runtime` - OpenJD adaptor runtime
+- `openjd-cli` - OpenJD command-line interface
+- `pytest` - Test framework
+- `pytest-cov` - Coverage plugin for pytest
+- `pytest-xdist` - Parallel test execution
+- `coverage` - Code coverage measurement
+- `pillow` - Image processing for render output comparison
+- `flaky` - Retry flaky tests
+- `numpy<2` - Numerical operations (version <2 for 3ds Max compatibility)
+- All required dependencies
+
+### PowerShell Modules
+- `powershell-yaml` - YAML parsing for test scripts
+
+### Environment Variables (Machine-level)
+- `PATH` - Adds 3ds Max and Python directories
+- `3DSMAX_EXECUTABLE` - Points to 3dsmaxbatch.exe
+- `PYTHONPATH` - Configures Python module search paths
+- `VRAY_FOR_3DSMAX{VERSION}_*` - V-Ray configuration (if installed)
+
+## Output Files
+
+The power creates several reference documents:
+- `HATCH_SETUP.md` - Hatch usage guide
+- `configure_3dsmax_{version}_env.ps1` - Environment configuration script
+- `verify_3dsmax_{version}_paths.ps1` - Path verification script
+- `INSTALLATION_SUMMARY.md` - Complete installation summary
+- `OPENJD_SETUP_COMPLETE.md` - OpenJD usage guide
+
+## After Setup
+
+Once setup is complete, you can:
+
+### Run Unit Tests
+```powershell
+hatch run test
+```
+
+### Run Integration Tests
+```powershell
+.\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/vray_re_test/expected_job_bundle" -SkipInstall
+```
+
+### Build Package
+```powershell
+hatch build
+```
+
+### Format and Lint Code
+```powershell
+hatch run fmt
+hatch run lint
+```
+
+## Troubleshooting
+
+### Hatch Not Found
+If hatch is not found after installation, restart your terminal or add to PATH:
+```powershell
+$env:PATH = "C:\Users\$env:USERNAME\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+```
+
+### 3ds Max Python Issues
+Verify the correct Python is being used:
+```powershell
+& "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe" --version
+```
+
+### Environment Variables Not Applied
+Environment variables are set at machine level. You may need to:
+1. Restart your terminal
+2. Or run the generated `configure_3dsmax_{version}_env.ps1` script as Administrator
+
+### Integration Tests Failing
+Check 3ds Max logs:
+```powershell
+Get-Content "C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\{VERSION} - 64bit\ENU\Network\Max.log" -Tail 100
+```
+
+## Notes
+
+- Setup requires Administrator privileges for setting machine-level environment variables
+- The power skips S3 upload steps (those are for release workflows)
+- InstallBuilder is optional - installer build will be skipped if not found
+- V-Ray configuration is automatic if V-Ray is detected

--- a/.kiro/powers/3dsmax-dev-setup/steering/setup-guide.md
+++ b/.kiro/powers/3dsmax-dev-setup/steering/setup-guide.md
@@ -1,0 +1,266 @@
+# 3ds Max Dev Setup Guide
+
+Complete automated setup workflow for deadline-cloud-for-3ds-max development environment.
+
+## Setup Workflow
+
+### Step 1: Prompt for 3ds Max Version
+Ask the user which version of 3ds Max to set up for:
+- Default: 2026
+- Supported: 2024, 2025, 2026
+
+Example prompt:
+```
+Which version of 3ds Max would you like to set up for? (default: 2026)
+```
+
+### Step 2: Verify 3ds Max Installation
+Check if 3ds Max is installed at the expected location:
+```powershell
+Test-Path "C:\Program Files\Autodesk\3ds Max {VERSION}"
+Test-Path "C:\Program Files\Autodesk\3ds Max {VERSION}\3dsmax.exe"
+Test-Path "C:\Program Files\Autodesk\3ds Max {VERSION}\3dsmaxbatch.exe"
+Test-Path "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe"
+```
+
+**If 3ds Max is NOT found:**
+- Abort the setup
+- Display error message: "3ds Max {VERSION} is not installed at the expected location. Please install 3ds Max {VERSION} first."
+- Provide installation link or instructions
+
+**If 3ds Max IS found:**
+- Display confirmation: "Found 3ds Max {VERSION} at C:\Program Files\Autodesk\3ds Max {VERSION}"
+- Check Python version
+- Continue with setup
+
+### Step 3: Read Project Documentation
+Read and summarize key information from:
+1. `README.md` - Project overview, compatibility, requirements
+2. `DEVELOPMENT.md` - Development workflow, build instructions
+
+Extract important details:
+- Python version requirements
+- 3ds Max version compatibility
+- Required dependencies
+- Build commands
+
+### Step 4: Install Hatch
+Check if hatch is already installed:
+```powershell
+hatch --version
+```
+
+If not installed:
+```powershell
+python -m pip install hatch
+```
+
+Add hatch to PATH:
+```powershell
+$scriptsPath = "C:\Users\$env:USERNAME\AppData\Roaming\Python\Python311\Scripts"
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$scriptsPath", [EnvironmentVariableTarget]::User)
+```
+
+Verify installation:
+```powershell
+hatch --version
+hatch env show
+```
+
+### Step 5: Build the Package
+Build wheel and source distributions:
+```powershell
+hatch build
+```
+
+Expected output:
+- `dist/deadline_cloud_for_3ds_max-{VERSION}-py3-none-any.whl`
+- `dist/deadline_cloud_for_3ds_max-{VERSION}.tar.gz`
+
+Verify build artifacts exist.
+
+### Step 6: Build the Installer (Optional)
+Check if InstallBuilder is available:
+```powershell
+Test-Path "C:\Program Files\InstallBuilder*"
+```
+
+If available, build installer:
+```powershell
+hatch run installer:build-installer --local-dev
+```
+
+Expected output:
+- `DeadlineCloudFor3dsMaxSubmitter-windows-x64-installer.exe`
+
+If InstallBuilder is not found, skip this step and note it in the summary.
+
+### Step 7: Install pip to 3ds Max Python
+Ensure pip is installed in 3ds Max Python:
+```powershell
+& "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe" -m ensurepip
+```
+
+### Step 8: Install the Wheel to 3ds Max Python
+Install the built wheel:
+```powershell
+$wheelFile = Get-ChildItem "dist\deadline_cloud_for_3ds_max-*.whl" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+& "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe" -m pip install --force-reinstall $wheelFile.FullName
+```
+
+Verify installation:
+```powershell
+& "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe" -m pip show deadline-cloud-for-3ds-max
+```
+
+### Step 9: Install OpenJD CLI
+Install openjd-cli for running integration tests:
+```powershell
+& "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe" -m pip install openjd-cli
+```
+
+Verify installation:
+```powershell
+& "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe" -m openjd run --help
+```
+
+### Step 10: Install Test Packages
+Install pytest and related test packages required for running tests:
+```powershell
+& "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe" -m pip install pytest pytest-cov pytest-xdist coverage pillow flaky "numpy<2"
+```
+
+**Important:** Use `numpy<2` to avoid compatibility issues with 3ds Max.
+
+Verify pytest installation:
+```powershell
+& "C:\Program Files\Autodesk\3ds Max {VERSION}\Python\python.exe" -m pytest --version
+```
+
+**Installed Test Packages:**
+- `pytest` - Test framework
+- `pytest-cov` - Coverage plugin for pytest
+- `pytest-xdist` - Parallel test execution
+- `coverage` - Code coverage measurement
+- `pillow` - Image processing (for comparing render outputs)
+- `flaky` - Retry flaky tests
+- `numpy<2` - Numerical operations (version <2 for 3ds Max compatibility)
+
+### Step 11: Install PowerShell YAML Module
+Install the PowerShell YAML module required by test scripts:
+```powershell
+Install-Module powershell-yaml -Force -Scope CurrentUser
+```
+
+This module is required for parsing YAML job bundle files in the test scripts.
+
+### Step 12: Configure Environment Variables
+Create and run environment configuration script.
+
+**Create verification script:**
+`verify_3dsmax_{VERSION}_paths.ps1` - Checks all required paths
+
+**Create configuration script:**
+`configure_3dsmax_{VERSION}_env.ps1` - Sets environment variables
+
+Environment variables to set (Machine level):
+1. **PATH** - Add 3ds Max and Python directories
+   ```powershell
+   [Environment]::SetEnvironmentVariable('Path', 'C:\Program Files\Autodesk\3ds Max {VERSION};' + [Environment]::GetEnvironmentVariable('Path', 'Machine'), 'Machine')
+   [Environment]::SetEnvironmentVariable('Path', 'C:\Program Files\Autodesk\3ds Max {VERSION}\Python;' + [Environment]::GetEnvironmentVariable('Path', 'Machine'), 'Machine')
+   ```
+
+2. **3DSMAX_EXECUTABLE**
+   ```powershell
+   [Environment]::SetEnvironmentVariable('3DSMAX_EXECUTABLE', 'C:\Program Files\Autodesk\3ds Max {VERSION}\3dsmaxbatch.exe', 'Machine')
+   ```
+
+3. **PYTHONPATH**
+   ```powershell
+   [Environment]::SetEnvironmentVariable('PYTHONPATH', 'C:\Program Files\Autodesk\3ds Max {VERSION}\Python', 'Machine')
+   ```
+
+4. **V-Ray Variables (if V-Ray is detected)**
+   Check for V-Ray:
+   ```powershell
+   Test-Path "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax{VERSION}"
+   ```
+   
+   If found, set:
+   ```powershell
+   [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX{VERSION}_MAIN', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax{VERSION}\bin\', 'Machine')
+   [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX{VERSION}_PLUGINS', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax{VERSION}\bin\plugins\', 'Machine')
+   ```
+
+**Note:** Setting machine-level environment variables requires Administrator privileges.
+
+### Step 13: Create Documentation Files
+Generate reference documentation:
+
+1. **HATCH_SETUP.md** - Hatch commands and usage
+2. **INSTALLATION_SUMMARY.md** - Complete setup summary with versions
+3. **OPENJD_SETUP_COMPLETE.md** - OpenJD usage guide with examples
+
+### Step 14: Display Setup Summary
+Show a summary of what was installed and configured:
+- Hatch version
+- Built packages (wheel, installer)
+- Installed Python packages and versions
+- Environment variables set
+- Next steps for the user
+
+## Example Summary Output
+
+```
+=== 3ds Max 2026 Dev Setup Complete ===
+
+✅ Hatch 1.16.3 installed
+✅ Package built: deadline_cloud_for_3ds_max-0.1.7.post18+g04b6260de
+✅ Wheel installed to 3ds Max 2026 Python
+✅ OpenJD CLI 0.7.4 installed
+✅ Test packages installed (pytest, coverage, pillow, etc.)
+✅ PowerShell YAML module installed
+✅ Environment variables configured
+
+Installed Packages:
+- deadline-cloud-for-3ds-max 0.1.7.post18+g04b6260de
+- deadline 0.52.1
+- openjd-adaptor-runtime 0.9.3
+- openjd-cli 0.7.4
+- pytest 9.0.2
+- pytest-cov 7.0.0
+- pytest-xdist 3.8.0
+- coverage 7.13.2
+- pillow 12.1.0
+- flaky 3.8.1
+- numpy 1.26.4
+
+Environment Variables Set:
+- PATH (added 3ds Max and Python)
+- 3DSMAX_EXECUTABLE
+- PYTHONPATH
+- VRAY_FOR_3DSMAX2026_* (V-Ray detected)
+
+Documentation Created:
+- HATCH_SETUP.md
+- INSTALLATION_SUMMARY.md
+- OPENJD_SETUP_COMPLETE.md
+- configure_3dsmax_2026_env.ps1
+- verify_3dsmax_2026_paths.ps1
+
+Next Steps:
+1. Restart your terminal for environment variables to take effect
+2. Run unit tests: hatch run test
+3. Run integration test: .\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/re_disabled_test/expected_job_bundle" -SkipInstall
+
+For more information, see INSTALLATION_SUMMARY.md
+```
+
+## Important Notes
+
+- Always verify 3ds Max installation before proceeding
+- Use the correct Python executable for the 3ds Max version
+- Environment variables require terminal restart to take effect
+- Administrator privileges needed for machine-level environment variables
+- V-Ray configuration is automatic if detected
+- InstallBuilder is optional - setup continues without it

--- a/.kiro/powers/3dsmax-dev-setup/steering/troubleshooting.md
+++ b/.kiro/powers/3dsmax-dev-setup/steering/troubleshooting.md
@@ -1,0 +1,288 @@
+# Troubleshooting Guide
+
+Common issues and solutions for 3ds Max dev setup.
+
+## 3ds Max Not Found
+
+**Problem:** Setup aborts with "3ds Max {VERSION} is not installed"
+
+**Solutions:**
+1. Verify 3ds Max is installed at the standard location:
+   ```
+   C:\Program Files\Autodesk\3ds Max {VERSION}
+   ```
+
+2. If installed at a different location, create a symbolic link:
+   ```powershell
+   New-Item -ItemType SymbolicLink -Path "C:\Program Files\Autodesk\3ds Max 2026" -Target "D:\Your\Custom\Path\3dsMax2026"
+   ```
+
+3. Install 3ds Max from Autodesk website
+
+4. Check if you have the correct version installed (2024, 2025, or 2026)
+
+## Hatch Installation Issues
+
+**Problem:** `hatch: The term 'hatch' is not recognized`
+
+**Solutions:**
+1. Verify hatch is installed:
+   ```powershell
+   python -m pip list | Select-String "hatch"
+   ```
+
+2. Add Scripts directory to PATH:
+   ```powershell
+   $env:PATH = "C:\Users\$env:USERNAME\AppData\Roaming\Python\Python311\Scripts;$env:PATH"
+   ```
+
+3. Restart terminal after installation
+
+4. Set PATH permanently:
+   ```powershell
+   [Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\Users\$env:USERNAME\AppData\Roaming\Python\Python311\Scripts", [EnvironmentVariableTarget]::User)
+   ```
+
+## Build Failures
+
+**Problem:** `hatch build` fails
+
+**Solutions:**
+1. Ensure you're in the repository root directory
+
+2. Check if git is initialized (hatch-vcs requires git):
+   ```powershell
+   git status
+   ```
+
+3. Verify Python version:
+   ```powershell
+   python --version  # Should be 3.9+
+   ```
+
+4. Clean build artifacts and retry:
+   ```powershell
+   Remove-Item -Recurse -Force dist, build, *.egg-info -ErrorAction SilentlyContinue
+   hatch build
+   ```
+
+## Wheel Installation Issues
+
+**Problem:** Wheel installation fails or wrong packages installed
+
+**Solutions:**
+1. Verify using correct Python:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" --version
+   ```
+
+2. Check if pip is installed:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m ensurepip
+   ```
+
+3. Install with --force-reinstall:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip install --force-reinstall dist\deadline_cloud_for_3ds_max-*.whl
+   ```
+
+4. Check for conflicting packages:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip list | Select-String "deadline|openjd"
+   ```
+
+## OpenJD CLI Issues
+
+**Problem:** `openjd run` command not found or fails
+
+**Solutions:**
+1. Verify openjd-cli is installed:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip show openjd-cli
+   ```
+
+2. Install if missing:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip install openjd-cli
+   ```
+
+3. Test with module syntax:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m openjd run --help
+   ```
+
+4. Check for dependency conflicts:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip check
+   ```
+
+## Environment Variables Not Applied
+
+**Problem:** Environment variables not recognized after setup
+
+**Solutions:**
+1. Restart terminal/PowerShell session
+
+2. Check if variables are set:
+   ```powershell
+   [Environment]::GetEnvironmentVariable('3DSMAX_EXECUTABLE', 'Machine')
+   [Environment]::GetEnvironmentVariable('PYTHONPATH', 'Machine')
+   ```
+
+3. Run configuration script as Administrator:
+   ```powershell
+   # Right-click PowerShell -> Run as Administrator
+   .\configure_3dsmax_2026_env.ps1
+   ```
+
+4. Set manually if needed:
+   ```powershell
+   [Environment]::SetEnvironmentVariable('3DSMAX_EXECUTABLE', 'C:\Program Files\Autodesk\3ds Max 2026\3dsmaxbatch.exe', 'Machine')
+   ```
+
+5. Restart computer for system-wide changes
+
+## Integration Test Failures
+
+**Problem:** Integration tests fail to run
+
+**Solutions:**
+1. Check 3ds Max logs:
+   ```powershell
+   Get-Content "C:\Users\$env:USERNAME\AppData\Local\Autodesk\3dsMax\2026 - 64bit\ENU\Network\Max.log" -Tail 100
+   ```
+
+2. Verify 3DSMAX_EXECUTABLE is set:
+   ```powershell
+   $env:3DSMAX_EXECUTABLE
+   ```
+
+3. Check if scene files exist:
+   ```powershell
+   Test-Path "test/integ/test_scripts/*/scene/*.max"
+   ```
+
+4. Run with verbose output:
+   ```powershell
+   .\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/re_disabled_test/expected_job_bundle" -ShowOutput
+   ```
+
+5. Verify Python environment:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -c "import deadline.max_adaptor; print('OK')"
+   ```
+
+## V-Ray Not Detected
+
+**Problem:** V-Ray environment variables not set
+
+**Solutions:**
+1. Check if V-Ray is installed:
+   ```powershell
+   Test-Path "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2026"
+   ```
+
+2. Install V-Ray for 3ds Max if needed
+
+3. Manually set V-Ray variables:
+   ```powershell
+   [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2026_MAIN', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2026\bin\', 'Machine')
+   ```
+
+4. Verify V-Ray version matches 3ds Max version
+
+## Permission Denied Errors
+
+**Problem:** Access denied when setting environment variables
+
+**Solutions:**
+1. Run PowerShell as Administrator:
+   - Right-click PowerShell
+   - Select "Run as Administrator"
+
+2. Check user permissions:
+   ```powershell
+   whoami /groups | Select-String "Administrators"
+   ```
+
+3. Use User-level variables instead of Machine-level:
+   ```powershell
+   [Environment]::SetEnvironmentVariable('3DSMAX_EXECUTABLE', 'C:\Program Files\Autodesk\3ds Max 2026\3dsmaxbatch.exe', 'User')
+   ```
+
+## Python Version Mismatch
+
+**Problem:** Wrong Python version being used
+
+**Solutions:**
+1. Always use full path to 3ds Max Python:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe"
+   ```
+
+2. Check Python version:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" --version
+   ```
+
+3. Verify PATH priority:
+   ```powershell
+   (Get-Command python).Source
+   ```
+
+4. Update PATH to prioritize 3ds Max Python:
+   ```powershell
+   $env:PATH = "C:\Program Files\Autodesk\3ds Max 2026\Python;$env:PATH"
+   ```
+
+## Module Import Errors
+
+**Problem:** `ModuleNotFoundError` when running tests
+
+**Solutions:**
+1. Verify package is installed:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip list | Select-String "deadline"
+   ```
+
+2. Check PYTHONPATH:
+   ```powershell
+   $env:PYTHONPATH
+   ```
+
+3. Reinstall the wheel:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip uninstall deadline-cloud-for-3ds-max -y
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -m pip install dist\deadline_cloud_for_3ds_max-*.whl
+   ```
+
+4. Check for conflicting installations:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max 2026\Python\python.exe" -c "import deadline; print(deadline.__file__)"
+   ```
+
+## Getting Help
+
+If issues persist:
+
+1. Check the project documentation:
+   - README.md
+   - DEVELOPMENT.md
+   - INSTALLATION_SUMMARY.md
+
+2. Review generated documentation:
+   - HATCH_SETUP.md
+   - OPENJD_SETUP_COMPLETE.md
+
+3. Check 3ds Max logs for detailed error messages
+
+4. Verify all prerequisites are met:
+   - Python 3.9+
+   - 3ds Max 2024/2025/2026
+   - Windows OS
+   - Administrator privileges
+
+5. Try a clean setup:
+   - Uninstall all packages
+   - Delete dist/ directory
+   - Run setup again


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Developers setting up the deadline-cloud-for-3ds-max project for local development had to manually follow multiple steps across different documentation files, install various dependencies, configure environment variables, and ensure the correct Python environment was being used. This manual process was error-prone and time-consuming.

### What was the solution? (How)

Created a new Kiro power called `3dsmax-dev-setup` that automates the complete development environment setup workflow. The power includes:

1. **POWER.md** - Overview documentation explaining what the power does
2. **power.json** - Power configuration with keywords and metadata
3. **steering/setup-guide.md** - Step-by-step automated setup workflow including:
   - Prompting for 3ds Max version (default: 2026, supports 2024/2025/2026)
   - Verifying 3ds Max installation (aborts if not found)
   - Reading project documentation (README.md, DEVELOPMENT.md)
   - Installing Hatch build tool
   - Building wheel and installer packages
   - Installing pip to 3ds Max Python
   - Installing the built wheel to 3ds Max Python
   - Installing OpenJD CLI for integration tests
   - Installing test packages (pytest, pytest-cov, pytest-xdist, coverage, pillow, flaky, numpy<2)
   - Installing PowerShell YAML module for test scripts
   - Configuring environment variables (PATH, 3DSMAX_EXECUTABLE, PYTHONPATH, V-Ray vars)
   - Creating documentation files
4. **steering/troubleshooting.md** - Common issues and solutions

### What is the impact of this change?

- **Improved Developer Experience**: New contributors can set up their development environment with guided automation instead of manually following documentation
- **Reduced Setup Errors**: The power validates 3ds Max installation before proceeding and uses correct Python paths
- **Consistent Environment**: All developers get the same packages and configuration
- **Self-Documenting**: The power serves as living documentation for the setup process

### How was this change tested?

- Manually executed each step of the setup workflow on a Windows machine with 3ds Max 2026
- Verified Hatch installation and package building
- Confirmed wheel installation to 3ds Max Python
- Verified OpenJD CLI and test packages installation
- Ran `pytest --collect-only` to confirm 122 unit tests are discoverable
- Tested PowerShell YAML module installation

### Was this change documented?

Yes. The power itself is documentation:
- `POWER.md` provides overview and usage instructions
- `steering/setup-guide.md` contains detailed step-by-step workflow
- `steering/troubleshooting.md` covers common issues and solutions

### Did you modify schema files?

- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?

See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [x] No (N/A - no schema files modified)

### Is this a breaking change?

No. This is a new additive feature (Kiro power) that does not modify any existing code or behavior.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
