### PR TITLE
test: fix invalid escape sequence in test_executable_handler

### DIFF
--- a/test/unit/deadline_adaptor_for_3ds_max/test_executable_handler.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/test_executable_handler.py
@@ -4,6 +4,7 @@ from deadline.max_adaptor.executable_handler import (
     SupportedMaxExecutable,
 )
 from unittest.mock import patch, Mock
+import os
 import pytest
 from typing import List
 
@@ -15,13 +16,13 @@ class TestMaxExecutableHandler:
         [
             ("3dsmax", "3dsmax"),
             ("3dsmax.exe", "3dsmax"),
-            ("C:\\Users\\user1\\somedir\\3dsmax", "3dsmax"),
-            ("C:\\Users\\user1\somedir\\3dsmax.exe", "3dsmax"),
+            (os.sep.join(["C:", "Users", "user1", "somedir", "3dsmax"]), "3dsmax"),
+            (os.sep.join(["C:", "Users", "user1", "somedir", "3dsmax.exe"]), "3dsmax"),
             ("/users/user1/somedir/3dsmax.exe", "3dsmax"),
             ("3dsmaxbatch", "3dsmaxbatch"),
             ("3dsmaxbatch.exe", "3dsmaxbatch"),
-            ("C:\\Users\\user1\\somedir\\3dsmaxbatch", "3dsmaxbatch"),
-            ("C:\\Users\\user1\\somedir\\3dsmaxbatch.exe", "3dsmaxbatch"),
+            (os.sep.join(["C:", "Users", "user1", "somedir", "3dsmaxbatch"]), "3dsmaxbatch"),
+            (os.sep.join(["C:", "Users", "user1", "somedir", "3dsmaxbatch.exe"]), "3dsmaxbatch"),
             ("/users/user1/somedir/3dsmaxbatch.exe", "3dsmaxbatch"),
         ],
     )

--- a/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
+++ b/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
@@ -753,7 +753,7 @@ def test_configure_vray_raw_output_vrimg(mock_rt: MagicMock) -> None:
     assert mock_renderer.output_userigbe is True, "VFB should be enabled"
     assert mock_renderer.output_on is True, "Raw output should be enabled"
     assert mock_renderer.output_saveRawFile is True, "Raw file saving should be enabled"
-    assert mock_renderer.output_rawFileName == "C:/output\\test_render.vrimg"
+    assert mock_renderer.output_rawFileName == os.path.join("C:/output", "test_render.vrimg")
     assert isinstance(warnings, list)
     assert len(warnings) == 0, f"Expected no warnings, got: {warnings}"
 
@@ -780,7 +780,7 @@ def test_configure_vray_raw_output_exr(mock_rt: MagicMock) -> None:
     assert mock_renderer.output_userigbe is True, "VFB should be enabled"
     assert mock_renderer.output_on is True, "Raw output should be enabled"
     assert mock_renderer.output_saveRawFile is True, "Raw file saving should be enabled"
-    assert mock_renderer.output_rawFileName == "C:/renders/project\\frame_001.exr"
+    assert mock_renderer.output_rawFileName == os.path.join("C:/renders/project", "frame_001.exr")
     assert isinstance(warnings, list)
     assert len(warnings) == 0, f"Expected no warnings, got: {warnings}"
 
@@ -804,7 +804,7 @@ def test_configure_vray_raw_output_format_without_dot(mock_rt: MagicMock) -> Non
     warnings = configure_vray_raw_output(output_path, output_name, output_format)
 
     # THEN - Should add the dot automatically
-    assert mock_renderer.output_rawFileName == "C:/output\\test.vrimg"
+    assert mock_renderer.output_rawFileName == os.path.join("C:/output", "test.vrimg")
     assert len(warnings) == 0
 
 
@@ -834,13 +834,13 @@ def test_configure_vray_raw_output_vray_gpu(mock_rt: MagicMock) -> None:
     assert mock_vray_settings.output_userigbe is True
     assert mock_vray_settings.output_on is True
     assert mock_vray_settings.output_saveRawFile is True
-    assert mock_vray_settings.output_rawFileName == "C:/output\\gpu_render.exr"
+    assert mock_vray_settings.output_rawFileName == os.path.join("C:/output", "gpu_render.exr")
 
     # Also set on renderer.current
     assert mock_renderer.output_userigbe is True
     assert mock_renderer.output_on is True
     assert mock_renderer.output_saveRawFile is True
-    assert mock_renderer.output_rawFileName == "C:/output\\gpu_render.exr"
+    assert mock_renderer.output_rawFileName == os.path.join("C:/output", "gpu_render.exr")
 
     assert len(warnings) == 0
 


### PR DESCRIPTION

Replace hardcoded Windows paths with os.sep.join() and os.path.join() to create cross-platform compatible paths in test parametrization 
and assertions. This eliminates SyntaxWarning for invalid escape sequences and ensures tests pass on both Windows and Linux/macOS.

### What was the problem/requirement? (What/Why)

Test files contained hardcoded Windows-style paths with backslashes that caused two issues:
1. test_executable_handler.py - Parametrized test data used raw backslash strings (e.g., "C:\\Users\\user1\\somedir\\3dsmax") triggering 
SyntaxWarning for invalid escape sequences
2. test_shared_max_utils.py - Test assertions used hardcoded backslash paths (e.g., "C:/output\\test.vrimg") that failed on macOS/Linux 
where os.path.join() produces forward slashes

These platform-specific paths made tests fail on non-Windows systems.

### What was the solution? (How)

test_executable_handler.py:
- Replaced hardcoded Windows path strings with os.sep.join() to dynamically construct paths
- Example: "C:\\Users\\user1\\somedir\\3dsmax" → os.sep.join(["C:", "Users", "user1", "somedir", "3dsmax"])
- Added import os to support the change

test_shared_max_utils.py:
- Replaced hardcoded path assertions with os.path.join() to match the implementation's behavior
- Fixed 5 test assertions across 4 test functions:
  - test_configure_vray_raw_output_vrimg
  - test_configure_vray_raw_output_exr
  - test_configure_vray_raw_output_format_without_dot
  - test_configure_vray_raw_output_vray_gpu (2 assertions)
- Example: "C:/output\\test.vrimg" → os.path.join("C:/output", "test.vrimg")

### What is the impact of this change?

- Eliminates SyntaxWarning during test execution
- Makes tests cross-platform compatible (Windows, Linux, macOS)
- Improves code quality and test reliability
- Ensures CI/CD pipelines work correctly across all platforms

### How was this change tested?

Ran the affected unit tests on macOS to verify all assertions pass:
- test_executable_handler.py - All parametrized test cases pass without warnings
- test_shared_max_utils.py - All 42 tests pass including the 4 fixed V-Ray raw output tests

### Was this change documented?

No documentation needed - this is an internal test improvement with no user-facing changes.

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No - this is a test-only change with no impact on production code or public APIs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your 
choice.