### PR TITLE
fix: skip output assets from asset introspection

### DIFF
--- a/docs/design/filter-output-assets.md
+++ b/docs/design/filter-output-assets.md
@@ -1,0 +1,186 @@
+# Filter Output Assets from get_referenced_files()
+
+## Problem
+
+The `get_referenced_files()` function currently uses `ATSOps.GetFiles()` which returns all tracked assets, including render outputs (main render output path, Render Elements like AO/Z-depth, and Bake-to-Texture paths). These output files should not be included in the referenced files list since they are destinations, not source dependencies.
+
+## Current Implementation
+
+```python
+def get_referenced_files() -> list:
+    rt.ATSOps.Refresh()
+    maps = rt.ATSOps.GetFiles(pymxs.byref(None))
+    maps_in_scene = [str(x.replace("\\", "/")) for x in list(maps)[1]]
+    # ... nested file handling ...
+    return maps_in_scene
+```
+
+## Proposed Change (Minimal)
+
+Use `AssetManager.getAssetId()` and `AssetManager.getAsset()` to check each file's asset type and filter out `#RenderOutput` and `#VideoPost` types.
+
+```python
+def get_referenced_files() -> list:
+    """
+    Finds all referenced files (bitmap textures, xrefs).
+    Excludes render output files (render outputs, render elements, video post).
+
+    :returns: list with paths to all referenced files
+    :return_type: list
+    """
+    # Refresh Asset Tracking to make sure we have the latest version
+    rt.ATSOps.Refresh()
+
+    # Convert result from usedMaps MAXScript function into a python list
+    maps = rt.ATSOps.GetFiles(pymxs.byref(None))
+    # Note: ATSOps returns list[int, [file paths]]
+    all_files = list(maps)[1]
+
+    # Filter out output assets (RenderOutput, VideoPost)
+    maps_in_scene = []
+    for f in all_files:
+        try:
+            asset_id = rt.AssetManager.getAssetId(f)
+            asset_obj = rt.AssetManager.getAsset(asset_id)
+            asset_type = str(asset_obj.getType())
+            if asset_type in ("#RenderOutput", "#VideoPost"):
+                continue
+        except Exception:
+            # If we can't determine the asset type, include the file
+            pass
+        maps_in_scene.append(str(f.replace("\\", "/")))
+
+    # Check for nested files to make sure the path correctly gets converted when it's relative
+    nested_files: list[list] = []
+    for i, map_ in enumerate(maps_in_scene):
+        if os.path.normpath(map_) == get_scene_path():
+            continue
+        nested = rt.ATSOps.GetDependentFiles(map_, False, pymxs.byref(None))[1]
+        if not nested:
+            continue
+        for item in nested:
+            try:
+                index = maps_in_scene.index(item.replace("\\", "/"))
+            except ValueError:
+                # Item may have been filtered out as an output asset
+                continue
+            # Pass along the nested file, the index of that nested file and the index of the parent
+            # in maps_in_scene
+            nested_files += [[item, index, i]]
+
+    # Update the path in the maps_in_scene
+    for file in nested_files:
+        relative_dir = os.path.split(maps_in_scene[file[2]])[0]
+        maps_in_scene[file[1]] = os.path.join(relative_dir, file[0])
+
+    return maps_in_scene
+```
+
+## Key Changes
+
+1. Added filtering loop that checks each file's asset type via `AssetManager`
+2. Skip files with type `#RenderOutput` or `#VideoPost`
+3. Added try/except in nested file handling to handle cases where a nested file was filtered out
+4. Wrapped asset type check in try/except to gracefully handle edge cases
+
+## Asset Types Reference
+
+| Type | Description | Include? |
+|------|-------------|----------|
+| `#Bitmap` | Texture files | Yes |
+| `#XRef` | External references | Yes |
+| `#Photometric` | IES light files | Yes |
+| `#ExternalLink` | External links | Yes |
+| `#RenderOutput` | Main render output, render elements | No |
+| `#VideoPost` | Video post output paths | No |
+
+## Proposed Tests
+
+### Unit Tests (with mocked pymxs)
+
+```python
+import pytest
+from unittest.mock import MagicMock, patch
+
+@pytest.fixture
+def mock_pymxs():
+    """Mock pymxs module for testing."""
+    with patch.dict('sys.modules', {'pymxs': MagicMock()}):
+        yield
+
+class TestGetReferencedFilesFiltering:
+    """Tests for output asset filtering in get_referenced_files()."""
+
+    def test_excludes_render_output_assets(self, mock_pymxs):
+        """Verify that #RenderOutput type assets are excluded."""
+        # Setup: ATSOps returns mix of input and output files
+        # Assert: Only input files are returned
+
+    def test_excludes_video_post_assets(self, mock_pymxs):
+        """Verify that #VideoPost type assets are excluded."""
+        # Setup: ATSOps returns VideoPost output path
+        # Assert: VideoPost path is not in result
+
+    def test_includes_bitmap_assets(self, mock_pymxs):
+        """Verify that #Bitmap type assets are included."""
+        # Setup: ATSOps returns bitmap texture paths
+        # Assert: All bitmap paths are in result
+
+    def test_includes_xref_assets(self, mock_pymxs):
+        """Verify that #XRef type assets are included."""
+        # Setup: ATSOps returns XRef paths
+        # Assert: All XRef paths are in result
+
+    def test_handles_asset_manager_exception(self, mock_pymxs):
+        """Verify graceful handling when AssetManager fails."""
+        # Setup: AssetManager.getAssetId raises exception
+        # Assert: File is still included (fail-open behavior)
+
+    def test_nested_files_with_filtered_parent(self, mock_pymxs):
+        """Verify nested file handling when parent is filtered out."""
+        # Setup: Parent file is RenderOutput, has nested dependencies
+        # Assert: No crash, nested files handled correctly
+```
+
+### Integration Tests (requires 3ds Max)
+
+```python
+class TestGetReferencedFilesIntegration:
+    """Integration tests requiring 3ds Max environment."""
+
+    def test_scene_with_render_output_set(self):
+        """Test scene that has render output path configured."""
+        # Setup: Create scene with render output path
+        # Call: get_referenced_files()
+        # Assert: Render output path not in result
+
+    def test_scene_with_render_elements(self):
+        """Test scene with render elements (AO, Z-depth, etc.)."""
+        # Setup: Create scene with render elements
+        # Call: get_referenced_files()
+        # Assert: Render element paths not in result
+
+    def test_scene_with_mixed_assets(self):
+        """Test scene with textures, xrefs, and render outputs."""
+        # Setup: Create scene with various asset types
+        # Call: get_referenced_files()
+        # Assert: Only input assets returned
+```
+
+## Alternative Approaches Considered
+
+### 1. Using ATSOps.GetFileSystemStatus with bitmask
+- Pros: Uses same API as current implementation
+- Cons: Requires understanding undocumented bitmask values, less readable
+
+### 2. Full migration to AssetManager.getAssets()
+- Pros: Cleaner API, no ATSOps dependency
+- Cons: Larger change, may miss "stale" references that ATS holds onto
+
+## Recommendation
+
+The proposed change is minimal and targeted:
+- Adds ~15 lines of filtering logic
+- Preserves existing ATSOps-based enumeration
+- Uses well-documented AssetManager type checking
+- Fails open (includes file if type check fails)

--- a/src/deadline/max_submitter/utilities/max_utils.py
+++ b/src/deadline/max_submitter/utilities/max_utils.py
@@ -17,6 +17,7 @@ _logger = logging.getLogger(__name__)
 def get_referenced_files() -> list:
     """
     Finds all referenced files (bitmap textures, xrefs).
+    Excludes render output files (render outputs, render elements, video post).
 
     :returns: list with paths to all referenced files
     :return_type: list
@@ -27,7 +28,21 @@ def get_referenced_files() -> list:
     # Convert result from usedMaps MAXScript function into a python list
     maps = rt.ATSOps.GetFiles(pymxs.byref(None))
     # Note: ATSOps returns list[int, [file paths]]
-    maps_in_scene = [str(x.replace("\\", "/")) for x in list(maps)[1]]
+    all_files = list(maps)[1]
+
+    # Filter out output assets (RenderOutput, VideoPost)
+    maps_in_scene = []
+    for f in all_files:
+        try:
+            asset_id = rt.AssetManager.getAssetId(f)
+            asset_obj = rt.AssetManager.getAsset(asset_id)
+            asset_type = str(asset_obj.getType())
+            if asset_type in ("#RenderOutput", "#VideoPost"):
+                continue
+        except Exception:
+            # If we can't determine the asset type, include the file
+            pass
+        maps_in_scene.append(str(f.replace("\\", "/")))
 
     # Check for nested files to make sure the path correctly gets converted when it's relative
     nested_files: list[list] = []
@@ -38,7 +53,11 @@ def get_referenced_files() -> list:
         if not nested:
             continue
         for item in nested:
-            index = maps_in_scene.index(item.replace("\\", "/"))
+            try:
+                index = maps_in_scene.index(item.replace("\\", "/"))
+            except ValueError:
+                # Item may have been filtered out as an output asset
+                continue
             # Pass along the nested file, the index of that nested file and the index of the parent
             # in maps_in_scene
             nested_files += [[item, index, i]]

--- a/test/unit/deadline_submitter_for_3ds_max/test_max_utils.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_max_utils.py
@@ -1,0 +1,186 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from typing import Any
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+class TestGetReferencedFilesFiltering:
+    """Tests for output asset filtering in get_referenced_files()."""
+
+    @pytest.fixture
+    def mock_pymxs(self):
+        """Mock pymxs module and runtime."""
+        with patch.dict("sys.modules", {"pymxs": MagicMock()}):
+            import sys
+
+            mock_pymxs = sys.modules["pymxs"]
+            mock_pymxs.byref = MagicMock(return_value=None)  # type: ignore[attr-defined]
+            yield mock_pymxs
+
+    @pytest.fixture
+    def mock_rt(self, mock_pymxs):
+        """Mock the pymxs runtime."""
+        with patch("deadline.max_submitter.utilities.max_utils.rt") as mock_rt:
+            # Default: no nested files
+            mock_rt.ATSOps.GetDependentFiles.return_value = (0, None)
+            mock_rt.maxFilePath = "C:/scenes/"
+            mock_rt.maxFileName = "test.max"
+            yield mock_rt
+
+    @pytest.fixture
+    def mock_asset_manager(self, mock_rt):
+        """Setup AssetManager mock with configurable asset types."""
+
+        def create_asset(asset_type: str) -> MagicMock:
+            asset = MagicMock()
+            asset.getType.return_value = asset_type
+            return asset
+
+        asset_map: dict[str, Any] = {}
+
+        def get_asset_id(path):
+            return path
+
+        def get_asset(asset_id):
+            return asset_map.get(asset_id, create_asset("#Bitmap"))
+
+        mock_rt.AssetManager.getAssetId = get_asset_id
+        mock_rt.AssetManager.getAsset = get_asset
+
+        return asset_map, create_asset
+
+    def test_excludes_render_output_assets(self, mock_pymxs, mock_rt, mock_asset_manager):
+        """Verify that #RenderOutput type assets are excluded."""
+        asset_map, create_asset = mock_asset_manager
+
+        # Setup files: one texture, one render output
+        files = ["C:\\textures\\diffuse.jpg", "C:\\output\\render.png"]
+        mock_rt.ATSOps.GetFiles.return_value = (2, files)
+
+        asset_map["C:\\textures\\diffuse.jpg"] = create_asset("#Bitmap")
+        asset_map["C:\\output\\render.png"] = create_asset("#RenderOutput")
+
+        from deadline.max_submitter.utilities.max_utils import get_referenced_files
+
+        result = get_referenced_files()
+
+        assert "C:/textures/diffuse.jpg" in result
+        assert "C:/output/render.png" not in result
+
+    def test_excludes_video_post_assets(self, mock_pymxs, mock_rt, mock_asset_manager):
+        """Verify that #VideoPost type assets are excluded."""
+        asset_map, create_asset = mock_asset_manager
+
+        files = ["C:\\textures\\diffuse.jpg", "C:\\videopost\\output.avi"]
+        mock_rt.ATSOps.GetFiles.return_value = (2, files)
+
+        asset_map["C:\\textures\\diffuse.jpg"] = create_asset("#Bitmap")
+        asset_map["C:\\videopost\\output.avi"] = create_asset("#VideoPost")
+
+        from deadline.max_submitter.utilities.max_utils import get_referenced_files
+
+        result = get_referenced_files()
+
+        assert "C:/textures/diffuse.jpg" in result
+        assert "C:/videopost/output.avi" not in result
+
+    def test_includes_bitmap_assets(self, mock_pymxs, mock_rt, mock_asset_manager):
+        """Verify that #Bitmap type assets are included."""
+        asset_map, create_asset = mock_asset_manager
+
+        files = ["C:\\textures\\diffuse.jpg", "C:\\textures\\normal.png", "C:\\textures\\spec.exr"]
+        mock_rt.ATSOps.GetFiles.return_value = (3, files)
+
+        for f in files:
+            asset_map[f] = create_asset("#Bitmap")
+
+        from deadline.max_submitter.utilities.max_utils import get_referenced_files
+
+        result = get_referenced_files()
+
+        assert len(result) == 3
+        assert "C:/textures/diffuse.jpg" in result
+        assert "C:/textures/normal.png" in result
+        assert "C:/textures/spec.exr" in result
+
+    def test_includes_xref_assets(self, mock_pymxs, mock_rt, mock_asset_manager):
+        """Verify that #XRef type assets are included."""
+        asset_map, create_asset = mock_asset_manager
+
+        files = ["C:\\xrefs\\model.max", "C:\\xrefs\\scene.max"]
+        mock_rt.ATSOps.GetFiles.return_value = (2, files)
+
+        for f in files:
+            asset_map[f] = create_asset("#XRef")
+
+        from deadline.max_submitter.utilities.max_utils import get_referenced_files
+
+        result = get_referenced_files()
+
+        assert len(result) == 2
+        assert "C:/xrefs/model.max" in result
+        assert "C:/xrefs/scene.max" in result
+
+    def test_includes_photometric_assets(self, mock_pymxs, mock_rt, mock_asset_manager):
+        """Verify that #Photometric (IES) type assets are included."""
+        asset_map, create_asset = mock_asset_manager
+
+        files = ["C:\\lights\\spot.ies"]
+        mock_rt.ATSOps.GetFiles.return_value = (1, files)
+
+        asset_map["C:\\lights\\spot.ies"] = create_asset("#Photometric")
+
+        from deadline.max_submitter.utilities.max_utils import get_referenced_files
+
+        result = get_referenced_files()
+
+        assert "C:/lights/spot.ies" in result
+
+    def test_handles_asset_manager_exception(self, mock_pymxs, mock_rt):
+        """Verify graceful handling when AssetManager fails - file should be included."""
+        files = ["C:\\textures\\diffuse.jpg"]
+        mock_rt.ATSOps.GetFiles.return_value = (1, files)
+
+        # Make AssetManager raise an exception
+        mock_rt.AssetManager.getAssetId.side_effect = Exception("Asset not found")
+
+        from deadline.max_submitter.utilities.max_utils import get_referenced_files
+
+        result = get_referenced_files()
+
+        # File should still be included (fail-open behavior)
+        assert "C:/textures/diffuse.jpg" in result
+
+    def test_mixed_asset_types(self, mock_pymxs, mock_rt, mock_asset_manager):
+        """Verify correct filtering with mixed input and output asset types."""
+        asset_map, create_asset = mock_asset_manager
+
+        files = [
+            "C:\\textures\\diffuse.jpg",  # Bitmap - include
+            "C:\\output\\render.png",  # RenderOutput - exclude
+            "C:\\xrefs\\model.max",  # XRef - include
+            "C:\\videopost\\out.avi",  # VideoPost - exclude
+            "C:\\lights\\spot.ies",  # Photometric - include
+            "C:\\output\\element_ao.exr",  # RenderOutput - exclude
+        ]
+        mock_rt.ATSOps.GetFiles.return_value = (6, files)
+
+        asset_map["C:\\textures\\diffuse.jpg"] = create_asset("#Bitmap")
+        asset_map["C:\\output\\render.png"] = create_asset("#RenderOutput")
+        asset_map["C:\\xrefs\\model.max"] = create_asset("#XRef")
+        asset_map["C:\\videopost\\out.avi"] = create_asset("#VideoPost")
+        asset_map["C:\\lights\\spot.ies"] = create_asset("#Photometric")
+        asset_map["C:\\output\\element_ao.exr"] = create_asset("#RenderOutput")
+
+        from deadline.max_submitter.utilities.max_utils import get_referenced_files
+
+        result = get_referenced_files()
+
+        assert len(result) == 3
+        assert "C:/textures/diffuse.jpg" in result
+        assert "C:/xrefs/model.max" in result
+        assert "C:/lights/spot.ies" in result
+        assert "C:/output/render.png" not in result
+        assert "C:/videopost/out.avi" not in result
+        assert "C:/output/element_ao.exr" not in result


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `get_referenced_files()` function was returning all assets tracked by the 3ds Max Asset Tracking System (ATS), including render output paths (main render output, render elements, Video Post outputs). These output destinations should not be included in the referenced input files list since they are destinations, not source dependencies.

### What was the solution? (How)

Added filtering logic using `AssetManager.getAssetId()` and `AssetManager.getAsset().getType()` to check each file's asset type and exclude `#RenderOutput` and `#VideoPost` types. The implementation fails open (includes the file if type check fails) to avoid accidentally excluding valid input assets.

### What is the impact of this change?

Job submissions will no longer incorrectly include render output paths in the asset references, resulting in cleaner job bundles that only contain actual input dependencies.

### How was this change tested?

- 7 new unit tests added covering: exclusion of RenderOutput assets, exclusion of VideoPost assets, inclusion of Bitmap/XRef/Photometric assets, graceful exception handling, and mixed asset type scenarios
- All 154 existing tests pass
- hatch build, fmt, lint all pass

### Tested with 3dsmax
- from the asset tracker I can see an output file 
<img width="780" height="257" alt="Screenshot 2026-02-10 at 1 52 42 PM" src="https://github.com/user-attachments/assets/c9c6abcb-cdbb-4690-883a-f6a2fdb7be89" />

- After the fix, this output file is no longer in the asset file:
```
assetReferences:
  inputs:
    directories: []
    filenames:
    - C:\Users\RDP\Users\RDP\Desktop\lightmix\MyProject_$render_element.png
    - C:\Users\RDP\deadline-cloud-for-3ds-max\test\integ\test_scripts\lightmix\scene\Grycon3.tx
    - C:\Users\RDP\deadline-cloud-for-3ds-max\test\integ\test_scripts\lightmix\scene\scene.max
  outputs:
    directories:
    - C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/lightmix/scene/
  referencedPaths: []
```

### Was this change documented?

Yes, design document added at `docs/design/filter-output-assets.md`

### Did you modify schema files?

- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?

See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [ ] No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
