### PR TITLE
feat: add developer option to override adaptor with local wheels

### DIFF
--- a/.kiro/powers/3dsmax-dev-power/steering/build-and-test.md
+++ b/.kiro/powers/3dsmax-dev-power/steering/build-and-test.md
@@ -74,7 +74,62 @@ Integration tests require 3ds Max to be installed.
 .\scripts\test-3dsmax-openjd-run.ps1 -JobBundleDir "test/integ/test_scripts/vray_simple_test/expected_job_bundle" -SkipInstall
 ```
 
-## Step 5: Check Logs
+## Step 5: Build Adaptor Wheels (Developer Option)
+
+For testing adaptor changes on a live Deadline Cloud farm, build wheels for all dependencies:
+
+```powershell
+# Build wheels for openjd-adaptor-runtime, deadline, and deadline-cloud-for-3ds-max
+.\scripts\build_wheels.ps1
+
+# Or clean and rebuild
+.\scripts\build_wheels.ps1 -Clean
+```
+
+This creates wheels in the `wheels/` directory:
+- `openjd_adaptor_runtime-*.whl`
+- `deadline-*.whl`
+- `deadline_cloud_for_3ds_max-*.whl`
+
+### Testing Adaptor Wheels on Workers
+
+1. **Enable developer options** before launching 3ds Max:
+   ```powershell
+   $env:DEADLINE_ENABLE_DEVELOPER_OPTIONS = "true"
+   & "D:\ProgramFiles\Autodesk\3ds Max 2025\3dsmax.exe"
+   ```
+
+2. **Open the submitter** and go to Scene Settings tab
+
+3. **Enable "Override Adaptor Wheels"** checkbox (only visible with developer options)
+
+4. **Add wheels directory** to Job Attachments tab:
+   - Click "Add Directory"
+   - Browse to `D:\workspace\3dsmax\deadline-cloud-for-3ds-max\wheels`
+
+5. **Submit the job** - The worker will:
+   - Create a Python virtual environment
+   - Install your development wheels
+   - Use your modified adaptor to run the job
+
+### Prerequisites for Building Wheels
+
+The sibling repositories must be cloned:
+```
+workspace/
+├── openjd-adaptor-runtime-for-python/
+├── deadline-cloud/
+└── deadline-cloud-for-3ds-max/
+```
+
+Clone missing repositories:
+```powershell
+cd D:\workspace\3dsmax
+git clone https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python.git
+git clone https://github.com/aws-deadline/deadline-cloud.git
+```
+
+## Step 6: Check Logs
 
 After running integration tests:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,13 +81,51 @@ After installation a "Deadline Cloud" menu is available the menu bar. Run "Submi
 
 ### Application Interface Adaptor Development Workflow
 
-You can work on the adaptor alongside your submitter development workflow using a Deadline Cloud
-farm that uses a service-managed fleet. You'll need to perform the following steps to substitute
-your build of the adaptor for the one in the service.
+#### Running the Adaptor on a Farm
 
-1. Use the development location from the Submitter Development Workflow. Make sure you're running 3ds Max with `set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` enabled.
-2. Build wheels for `openjd_adaptor_runtime`, `deadline` and `deadline_cloud_for_3ds_max`, place them in a "wheels" folder in `deadline-cloud-for-3ds-max`. A script is provided to do this, just execute from `deadline-cloud-for-3ds-max`:
+If you have made modifications to the adaptor and wish to test your modifications on a live Deadline Cloud Farm
+with real jobs, then we recommend using a [Service Managed Fleet](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html)
+for your testing. We recommend performing this style of test if you have made any modifications that might interact with Deadline Cloud's
+job attachments feature, or that could interact with path mapping in any way. We have implemented a developer feature in the 3ds Max submitter
+plug-in that submits the Python wheel files for your modified adaptor along with your job submission and uses the modified adaptor to
+run the submitted job.
 
+You'll need to perform the following steps to substitute your build of the adaptor for the one in the service.
+
+1. Using the submitter development workflow (See [Submitter Development Workflow](#submitter-development-workflow)), make sure that you are
+   running 3ds Max with `DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` enabled.
+   
+   **Windows (PowerShell):**
+   ```powershell
+   $env:DEADLINE_ENABLE_DEVELOPER_OPTIONS = "true"
+   & $env:3DSMAX_EXECUTABLE
+   ```
+   
+   **Windows (CMD):**
+   ```cmd
+   set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true
+   "%3DSMAX_EXECUTABLE%"
+   ```
+
+2. Clone the [deadline-cloud](https://github.com/aws-deadline/deadline-cloud) and
+   [openjd-adaptor-runtime-for-python](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python) repositories beside
+   this one, and ensure that you `git checkout release` in each to checkout the latest `release` branch.
+
+3. Build wheels for `openjd_adaptor_runtime`, `deadline` and `deadline_cloud_for_3ds_max`, place them in the `wheels/` folder in `deadline-cloud-for-3ds-max`.
+   
+   **Windows (PowerShell):**
+   ```powershell
+   # If you don't have the build package installed already
+   pip install build
+   
+   # Use the provided script to build all wheels
+   .\scripts\build_wheels.ps1
+   
+   # Or to clean and rebuild:
+   .\scripts\build_wheels.ps1 -Clean
+   ```
+   
+   **Linux/Mac:**
    ```bash
    # If you don't have the build package installed already
    $ pip install build
@@ -95,7 +133,7 @@ your build of the adaptor for the one in the service.
    $ ./scripts/build_wheels.sh
    ```
 
-   Wheels should have been generated in the "wheels" folder:
+   Wheels should have been generated in the `wheels/` folder:
 
    ```bash
    $ ls ./wheels
@@ -104,7 +142,11 @@ your build of the adaptor for the one in the service.
    openjd_adaptor_runtime-<version>-py3-none-any.whl
    ```
 
-3. Open the 3ds Max integrated submitter, and in the Job-Specific Settings tab, enable the option 'Include Adaptor Wheels'. This option is only visible when the environment variable `DEADLINE_ENABLE_DEVELOPER_OPTIONS` is set to `true`. Then submit your test job.
+4. Open the 3ds Max integrated submitter, and in the Scene Settings tab, enable the option 'Override Adaptor Wheels'. This option is only visible when the environment variable `DEADLINE_ENABLE_DEVELOPER_OPTIONS` is set to `true`.
+
+5. Go to the Job Attachments tab and manually add the `wheels` directory as an input directory.
+
+6. Submit your test job. The worker will create a Python virtual environment, install your development wheels, and use your modified adaptor to run the job.
 
 #### Adaptor Schema Files
 

--- a/scripts/build_wheels.ps1
+++ b/scripts/build_wheels.ps1
@@ -1,0 +1,22 @@
+#!/usr/bin/env pwsh
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path "wheels")) {
+    New-Item -ItemType Directory -Path "wheels" | Out-Null
+}
+Remove-Item "wheels\*.whl" -Force -ErrorAction SilentlyContinue
+
+$repos = @("../openjd-adaptor-runtime-for-python", "../deadline-cloud", "../deadline-cloud-for-3ds-max")
+
+foreach ($dir in $repos) {
+    Write-Host "Building $dir..."
+    Push-Location $dir
+    try {
+        hatch build
+        Move-Item "dist\*.whl" "../deadline-cloud-for-3ds-max/wheels/" -Force
+    } finally {
+        Pop-Location
+    }
+}

--- a/src/deadline/max_submitter/adaptor_override_environment.yaml
+++ b/src/deadline/max_submitter/adaptor_override_environment.yaml
@@ -16,69 +16,17 @@ environment:
   script:
     actions:
       onEnter:
-        command: '{{Env.File.Enter}}'
+        command: python3
+        args:
+          - '{{Env.File.SetupAdaptor}}'
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
     embeddedFiles:
-    - name: Enter
-      filename: override-adaptor-enter.sh
+    - name: SetupAdaptor
+      filename: setup-adaptor.py
       type: TEXT
       runnable: true
       data: |
-        #!/bin/env bash
-
-        set -euo pipefail
-
-        echo "The adaptor wheels that are attached to the job:"
-        ls '{{Param.OverrideAdaptorWheels}}'
-        echo ""
-
-        # Create a venv and activate it in this environment
-        echo "Creating Python venv for the {{Param.OverrideAdaptorName}} command"
-        /usr/local/bin/python3 -m venv '{{Session.WorkingDirectory}}/venv'
-        {{Env.File.InitialVars}}
-        . '{{Session.WorkingDirectory}}/venv/bin/activate'
-        {{Env.File.CaptureVars}}
-        echo ""
-
-        echo "Installing adaptor into the venv"
-        pip install '{{Param.OverrideAdaptorWheels}}'/openjd*.whl
-        pip install '{{Param.OverrideAdaptorWheels}}'/deadline*.whl
-        echo ""
-
-        if [ ! -f '{{Session.WorkingDirectory}}/venv/bin/{{Param.OverrideAdaptorName}}' ]; then
-          echo "The Override Adaptor {{Param.OverrideAdaptorName}} was not installed as expected."
-          exit 1
-        fi
-    - name: InitialVars
-      filename: initial-vars
-      type: TEXT
-      runnable: true
-      data: |
-        #!/usr/bin/env python3
-        import os, json
-        envfile = "{{Session.WorkingDirectory}}/.envInitial"
-        with open(envfile, "w", encoding="utf8") as f:
-            json.dump(dict(os.environ), f)
-    - name: CaptureVars
-      filename: capture-vars
-      type: TEXT
-      runnable: true
-      data: |
-        #!/usr/bin/env python3
-        import os, json, sys
-        envfile = "{{Session.WorkingDirectory}}/.envInitial"
-        if os.path.isfile(envfile):
-            with open(envfile, "r", encoding="utf8") as f:
-                before = json.load(f)
-        else:
-            print("No initial environment found, must run Env.File.CaptureVars script first")
-            sys.exit(1)
-        after = dict(os.environ)
-
-        put = {k: v for k, v in after.items() if v != before.get(k)}
-        delete = {k for k in before if k not in after}
-
-        for k, v in put.items():
-            print(f"updating {k}={v}")
-            print(f"openjd_env: {k}={v}")
-        for k in delete:
-            print(f"openjd_unset_env: {k}")
+        # This content will be replaced by the external setup_adaptor_wheels.py file
+        # during job bundle creation in create_job_bundle.py
+        pass

--- a/src/deadline/max_submitter/create_job_bundle.py
+++ b/src/deadline/max_submitter/create_job_bundle.py
@@ -413,7 +413,7 @@ def _create_step_definitions(
     return job_template
 
 
-def _merge_adaptor_override_environment():
+def _merge_adaptor_override_environment() -> dict[str, Any]:
     """
     Create template for the adaptor override environment.
 
@@ -450,7 +450,7 @@ def _merge_adaptor_override_environment():
     wheels_path_package_names = {path.split("-", 1)[0] for path in wheel_files}
 
     # Check for duplicate packages (multiple versions of the same package)
-    package_counts = {}
+    package_counts: dict[str, int] = {}
     for wheel_file in wheel_files:
         package_name = wheel_file.split("-", 1)[0]
         package_counts[package_name] = package_counts.get(package_name, 0) + 1

--- a/src/deadline/max_submitter/create_job_bundle.py
+++ b/src/deadline/max_submitter/create_job_bundle.py
@@ -415,46 +415,119 @@ def _create_step_definitions(
 
 def _merge_adaptor_override_environment():
     """
-    Create template for the adaptor override environment
+    Create template for the adaptor override environment.
+
+    Loads the adaptor_override_environment.yaml file, validates the wheels directory,
+    and configures the OverrideAdaptorName parameter with the default value.
+
+    :return: The override environment dictionary loaded from YAML
+    :raises RuntimeError: If the YAML file is invalid or wheels directory is missing/incorrect
     """
-    # TODO see if changes to adaptor_override_environment.yaml need to be made to work on windows worker
     with open(Path(__file__).parent / "adaptor_override_environment.yaml") as f:
         override_environment = yaml.safe_load(f)
 
-    # Read DEVELOPMENT.md for instructions to create the wheels directory.
+    if override_environment is None:
+        raise RuntimeError(
+            "Failed to load adaptor_override_environment.yaml - file is empty or invalid"
+        )
+
+    if "parameterDefinitions" not in override_environment:
+        raise RuntimeError(
+            f"adaptor_override_environment.yaml is missing 'parameterDefinitions'. Keys found: {list(override_environment.keys())}"
+        )
+
+    # Validate wheels directory exists and contains the correct packages
     wheels_path = Path(__file__).parent.parent.parent.parent / "wheels"
-    if not wheels_path.exists() and wheels_path.is_dir():
+    _logger.info(f"Validating wheels directory: {wheels_path}")
+
+    if not wheels_path.exists() or not wheels_path.is_dir():
         raise RuntimeError(
             "The Developer Option 'Include Adaptor Wheels' is enabled, "
-            "but the wheels directory does not exist:\n" + str(wheels_path)
+            f"but the wheels directory does not exist: {wheels_path}"
         )
-    wheels_path_package_names = {
-        path.split("-", 1)[0] for path in os.listdir(wheels_path) if path.endswith(".whl")
-    }
-    if wheels_path_package_names != {
-        "openjd_adaptor_runtime",
-        "deadline",
-        "deadline_cloud_for_3ds_max",
-    }:
+
+    wheel_files = [f for f in os.listdir(wheels_path) if f.endswith(".whl")]
+    wheels_path_package_names = {path.split("-", 1)[0] for path in wheel_files}
+
+    # Check for duplicate packages (multiple versions of the same package)
+    package_counts = {}
+    for wheel_file in wheel_files:
+        package_name = wheel_file.split("-", 1)[0]
+        package_counts[package_name] = package_counts.get(package_name, 0) + 1
+
+    duplicates = {pkg: count for pkg, count in package_counts.items() if count > 1}
+    if duplicates:
+        duplicate_details = []
+        for pkg in duplicates:
+            matching_wheels = [f for f in wheel_files if f.startswith(pkg + "-")]
+            duplicate_details.append(f"  {pkg}: {len(matching_wheels)} versions found")
+            for wheel in matching_wheels:
+                duplicate_details.append(f"    - {wheel}")
+        raise RuntimeError(
+            "The Developer Option 'Include Adaptor Wheels' is enabled, but the wheels directory contains "
+            "multiple versions of the same package(s):\n"
+            + "\n".join(duplicate_details)
+            + "\n\nPlease ensure only one version of each package is present. "
+            + "Run 'scripts/build_wheels.ps1 -Clean' to rebuild with a clean directory."
+        )
+
+    expected_packages = {"openjd_adaptor_runtime", "deadline", "deadline_cloud_for_3ds_max"}
+    if wheels_path_package_names != expected_packages:
         raise RuntimeError(
             "The Developer Option 'Include Adaptor Wheels' is enabled, but the wheels directory contains the "
             "wrong wheels:\n"
-            + "Expected: openjd_adaptor_runtime, deadline, and deadline_cloud_for_3ds_max\n"
-            + f"Actual: {wheels_path_package_names}"
+            + f"Expected: {', '.join(sorted(expected_packages))}\n"
+            + f"Actual: {', '.join(sorted(wheels_path_package_names))}"
         )
 
-    override_adaptor_wheels_param = [
+    _logger.info(f"Found required wheel packages: {', '.join(sorted(wheels_path_package_names))}")
+
+    # Find and validate OverrideAdaptorWheels parameter
+    override_adaptor_wheels_params = [
         param
         for param in override_environment["parameterDefinitions"]
-        if param["name"] == "OverrideAdaptorWheels"
-    ][0]
-    override_adaptor_wheels_param["default"] = str(wheels_path)
-    override_adaptor_name_param = [
+        if param and param.get("name") == "OverrideAdaptorWheels"
+    ]
+
+    if not override_adaptor_wheels_params:
+        raise RuntimeError(
+            "Could not find 'OverrideAdaptorWheels' parameter in adaptor_override_environment.yaml"
+        )
+
+    # Find and configure OverrideAdaptorName parameter
+    override_adaptor_name_params = [
         param
         for param in override_environment["parameterDefinitions"]
-        if param["name"] == "OverrideAdaptorName"
-    ][0]
+        if param and param.get("name") == "OverrideAdaptorName"
+    ]
+
+    if not override_adaptor_name_params:
+        raise RuntimeError(
+            "Could not find 'OverrideAdaptorName' parameter in adaptor_override_environment.yaml"
+        )
+
+    override_adaptor_name_param = override_adaptor_name_params[0]
     override_adaptor_name_param["default"] = "3dsmax-openjd"
+    _logger.info("Configured adaptor override environment with adaptor name: 3dsmax-openjd")
+
+    # Load the setup script from external file and inject it into the embedded files
+    setup_script_path = Path(__file__).parent / "setup_adaptor_wheels.py"
+    with open(setup_script_path, "r", encoding="utf8") as f:
+        setup_script_content = f.read()
+
+    # Find the SetupAdaptor embedded file and update its data
+    embedded_files = override_environment["environment"]["script"]["embeddedFiles"]
+    for embedded_file in embedded_files:
+        if embedded_file.get("name") == "SetupAdaptor":
+            embedded_file["data"] = setup_script_content
+            _logger.info(f"Loaded setup script from {setup_script_path}")
+            break
+    else:
+        raise RuntimeError(
+            "Could not find 'SetupAdaptor' embedded file in adaptor_override_environment.yaml"
+        )
+
+    return override_environment
 
 
 def get_parameters_values(
@@ -639,6 +712,11 @@ def _get_job_parameters(
         elif any(elem.name for elem in render_elements):
             # Add empty parameter if render elements exist but none are ignored
             parameter_values.append({"name": "IgnoreRenderElementsByName", "value": ""})
+
+    # If we're overriding the adaptor with wheels, set the OverrideAdaptorWheels parameter
+    if settings.include_adaptor_wheels:
+        wheels_path = str(Path(__file__).parent.parent.parent.parent / "wheels")
+        parameter_values.append({"name": "OverrideAdaptorWheels", "value": wheels_path})
 
     return parameter_values
 

--- a/src/deadline/max_submitter/setup_adaptor_wheels.py
+++ b/src/deadline/max_submitter/setup_adaptor_wheels.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Cross-platform script to set up adaptor wheels in a virtual environment."""
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    system = platform.system()
+    working_dir = Path(r"{{Session.WorkingDirectory}}")
+    wheels_dir = Path(r"{{Param.OverrideAdaptorWheels}}")
+    adaptor_name = r"{{Param.OverrideAdaptorName}}"
+
+    print(f"Platform: {system}")
+    print(f"Working directory: {working_dir}")
+    print(f"Wheels directory: {wheels_dir}")
+    print(f"Adaptor name: {adaptor_name}")
+    print()
+
+    # Show available wheels
+    print("The adaptor wheels that are attached to the job:")
+    for wheel in sorted(wheels_dir.glob("*.whl")):
+        print(f"  {wheel.name}")
+    print()
+
+    # Create venv
+    venv_dir = working_dir / "venv"
+    print(f"Creating Python venv for the {adaptor_name} command")
+    python_cmd = "python" if system == "Windows" else "/usr/local/bin/python3"
+    subprocess.run([python_cmd, "-m", "venv", str(venv_dir)], check=True)
+    print()
+
+    # Save initial environment
+    env_file = working_dir / ".envInitial"
+    with open(env_file, "w", encoding="utf8") as f:
+        json.dump(dict(os.environ), f)
+
+    # Determine venv paths based on platform
+    if system == "Windows":
+        venv_pip = venv_dir / "Scripts" / "pip.exe"
+        adaptor_exe = venv_dir / "Scripts" / f"{adaptor_name}.exe"
+    else:
+        venv_pip = venv_dir / "bin" / "pip"
+        adaptor_exe = venv_dir / "bin" / adaptor_name
+
+    # Install wheels
+    print("Installing adaptor into the venv")
+    openjd_wheels = list(wheels_dir.glob("openjd*.whl"))
+    deadline_wheels = list(wheels_dir.glob("deadline*.whl"))
+
+    for wheel in openjd_wheels + deadline_wheels:
+        print(f"  Installing {wheel.name}")
+        subprocess.run([str(venv_pip), "install", str(wheel)], check=True)
+    print()
+
+    # Verify adaptor was installed
+    if not adaptor_exe.exists():
+        print(f"ERROR: The Override Adaptor {adaptor_name} was not installed as expected.")
+        print(f"Expected location: {adaptor_exe}")
+        sys.exit(1)
+
+    print(f"Successfully installed {adaptor_name}")
+
+    # Capture environment changes
+    after_env = dict(os.environ)
+
+    # Update PATH to include venv
+    if system == "Windows":
+        venv_bin = str(venv_dir / "Scripts")
+    else:
+        venv_bin = str(venv_dir / "bin")
+
+    if "PATH" in after_env:
+        after_env["PATH"] = f"{venv_bin}{os.pathsep}{after_env['PATH']}"
+    else:
+        after_env["PATH"] = venv_bin
+
+    # Load initial environment
+    with open(env_file, "r", encoding="utf8") as f:
+        before_env = json.load(f)
+
+    # Output environment changes for OpenJD
+    for key, value in after_env.items():
+        if value != before_env.get(key):
+            print(f"updating {key}={value}")
+            print(f"openjd_env: {key}={value}")
+
+    for key in before_env:
+        if key not in after_env:
+            print(f"openjd_unset_env: {key}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -242,7 +242,8 @@ class SceneSettingsWidget(QWidget):
 
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
-                "Developer Option: Include Adaptor Wheels", self
+                "Developer Option: Include Adaptor Wheels. Add the 'wheels' directory from Job Attachments Tab.",
+                self,
             )
             lyt.addWidget(self.include_adaptor_wheels, 17, 0)
 

--- a/test/unit/deadline_submitter_for_3ds_max/test_adaptor_override.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_adaptor_override.py
@@ -89,7 +89,7 @@ class TestAdaptorWheelsValidation:
         ]
 
         # Count packages
-        package_counts = {}
+        package_counts: dict[str, int] = {}
         for wheel_file in wheel_files:
             package_name = wheel_file.split("-", 1)[0]
             package_counts[package_name] = package_counts.get(package_name, 0) + 1
@@ -111,7 +111,7 @@ class TestAdaptorWheelsValidation:
         ]
 
         # Count packages
-        package_counts = {}
+        package_counts: dict[str, int] = {}
         for wheel_file in wheel_files:
             package_name = wheel_file.split("-", 1)[0]
             package_counts[package_name] = package_counts.get(package_name, 0) + 1

--- a/test/unit/deadline_submitter_for_3ds_max/test_adaptor_override.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_adaptor_override.py
@@ -1,0 +1,196 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Unit tests for adaptor wheels override functionality.
+
+Note: These tests focus on validation logic. Full integration testing
+of _merge_adaptor_override_environment() is done in integration tests
+due to complex module dependencies.
+"""
+
+from pathlib import Path
+
+
+class TestAdaptorWheelsValidation:
+    """Tests for wheel package validation logic."""
+
+    def test_wheel_package_name_extraction(self):
+        """Test that wheel package names are correctly extracted from filenames."""
+        # Simulate the logic from _merge_adaptor_override_environment
+        wheel_files = [
+            "openjd_adaptor_runtime-0.9.3.post8+gfffbe2a9f-py3-none-any.whl",
+            "deadline-0.52.1-py3-none-any.whl",
+            "deadline_cloud_for_3ds_max-0.1.9.post1+geaf1ba928.d20260210-py3-none-any.whl",
+        ]
+
+        # Extract package names (split on first '-')
+        package_names = {path.split("-", 1)[0] for path in wheel_files if path.endswith(".whl")}
+
+        expected_packages = {"openjd_adaptor_runtime", "deadline", "deadline_cloud_for_3ds_max"}
+        assert package_names == expected_packages
+
+    def test_wheel_package_name_extraction_with_different_versions(self):
+        """Test package name extraction works with various version formats."""
+        test_cases = [
+            ("openjd_adaptor_runtime-0.9.3-py3-none-any.whl", "openjd_adaptor_runtime"),
+            ("deadline-0.52.1-py3-none-any.whl", "deadline"),
+            ("deadline_cloud_for_3ds_max-0.1.9-py3-none-any.whl", "deadline_cloud_for_3ds_max"),
+            ("openjd_adaptor_runtime-1.0.0.post1-py3-none-any.whl", "openjd_adaptor_runtime"),
+            ("deadline-0.50.0+local-py3-none-any.whl", "deadline"),
+        ]
+
+        for wheel_file, expected_name in test_cases:
+            package_name = wheel_file.split("-", 1)[0]
+            assert package_name == expected_name, f"Failed for {wheel_file}"
+
+    def test_wheel_package_validation_missing_package(self):
+        """Test that missing required packages are detected."""
+        wheel_files = [
+            "openjd_adaptor_runtime-0.9.3-py3-none-any.whl",
+            "deadline-0.52.1-py3-none-any.whl",
+            # Missing: deadline_cloud_for_3ds_max
+        ]
+
+        package_names = {path.split("-", 1)[0] for path in wheel_files if path.endswith(".whl")}
+
+        expected_packages = {"openjd_adaptor_runtime", "deadline", "deadline_cloud_for_3ds_max"}
+        assert package_names != expected_packages
+        assert "deadline_cloud_for_3ds_max" not in package_names
+
+    def test_wheel_package_validation_wrong_package(self):
+        """Test that incorrect packages are detected."""
+        wheel_files = [
+            "wrong_package-1.0.0-py3-none-any.whl",
+            "another_wrong-2.0.0-py3-none-any.whl",
+            "deadline-0.52.1-py3-none-any.whl",
+        ]
+
+        package_names = {path.split("-", 1)[0] for path in wheel_files if path.endswith(".whl")}
+
+        expected_packages = {"openjd_adaptor_runtime", "deadline", "deadline_cloud_for_3ds_max"}
+        assert package_names != expected_packages
+
+    def test_adaptor_name_default_value(self):
+        """Test that the adaptor name is set correctly."""
+        # This simulates the logic in _merge_adaptor_override_environment
+        adaptor_name_param = {"name": "OverrideAdaptorName", "type": "STRING"}
+        adaptor_name_param["default"] = "3dsmax-openjd"
+
+        assert adaptor_name_param["default"] == "3dsmax-openjd"
+        assert adaptor_name_param["name"] == "OverrideAdaptorName"
+
+    def test_duplicate_package_detection(self):
+        """Test that duplicate packages are detected correctly."""
+        wheel_files = [
+            "deadline-0.52.1-py3-none-any.whl",
+            "deadline-0.50.0+local-py3-none-any.whl",
+            "openjd_adaptor_runtime-0.9.3-py3-none-any.whl",
+            "deadline_cloud_for_3ds_max-0.1.9-py3-none-any.whl",
+        ]
+
+        # Count packages
+        package_counts = {}
+        for wheel_file in wheel_files:
+            package_name = wheel_file.split("-", 1)[0]
+            package_counts[package_name] = package_counts.get(package_name, 0) + 1
+
+        # Check for duplicates
+        duplicates = {pkg: count for pkg, count in package_counts.items() if count > 1}
+
+        assert "deadline" in duplicates
+        assert duplicates["deadline"] == 2
+        assert "openjd_adaptor_runtime" not in duplicates
+        assert "deadline_cloud_for_3ds_max" not in duplicates
+
+    def test_no_duplicate_packages(self):
+        """Test that validation passes when there are no duplicates."""
+        wheel_files = [
+            "deadline-0.52.1-py3-none-any.whl",
+            "openjd_adaptor_runtime-0.9.3-py3-none-any.whl",
+            "deadline_cloud_for_3ds_max-0.1.9-py3-none-any.whl",
+        ]
+
+        # Count packages
+        package_counts = {}
+        for wheel_file in wheel_files:
+            package_name = wheel_file.split("-", 1)[0]
+            package_counts[package_name] = package_counts.get(package_name, 0) + 1
+
+        # Check for duplicates
+        duplicates = {pkg: count for pkg, count in package_counts.items() if count > 1}
+
+        assert len(duplicates) == 0
+
+
+class TestSetupAdaptorWheelsScript:
+    """Tests for the setup_adaptor_wheels.py script structure."""
+
+    def test_setup_script_exists(self):
+        """Test that the setup_adaptor_wheels.py file exists."""
+        script_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "src"
+            / "deadline"
+            / "max_submitter"
+            / "setup_adaptor_wheels.py"
+        )
+        assert script_path.exists(), f"Setup script not found at {script_path}"
+
+    def test_setup_script_has_main_function(self):
+        """Test that the setup script has a main() function."""
+        script_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "src"
+            / "deadline"
+            / "max_submitter"
+            / "setup_adaptor_wheels.py"
+        )
+
+        with open(script_path, "r", encoding="utf8") as f:
+            content = f.read()
+
+        assert "def main():" in content
+        assert 'if __name__ == "__main__":' in content
+
+    def test_setup_script_has_required_imports(self):
+        """Test that the setup script imports required modules."""
+        script_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "src"
+            / "deadline"
+            / "max_submitter"
+            / "setup_adaptor_wheels.py"
+        )
+
+        with open(script_path, "r", encoding="utf8") as f:
+            content = f.read()
+
+        required_imports = [
+            "import json",
+            "import os",
+            "import platform",
+            "import subprocess",
+            "import sys",
+            "from pathlib import Path",
+        ]
+
+        for required_import in required_imports:
+            assert required_import in content, f"Missing import: {required_import}"
+
+    def test_setup_script_has_openjd_template_variables(self):
+        """Test that the setup script contains OpenJD template variable placeholders."""
+        script_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "src"
+            / "deadline"
+            / "max_submitter"
+            / "setup_adaptor_wheels.py"
+        )
+
+        with open(script_path, "r", encoding="utf8") as f:
+            content = f.read()
+
+        # These will be substituted by OpenJD at runtime
+        assert "{{Session.WorkingDirectory}}" in content
+        assert "{{Param.OverrideAdaptorWheels}}" in content
+        assert "{{Param.OverrideAdaptorName}}" in content


### PR DESCRIPTION
https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/76

### What was the problem/requirement? (What/Why)

Developers working on the 3ds Max adaptor needed a way to test local adaptor changes on workers without having to publish and install new versions. This is essential for rapid iteration during development and debugging of adaptor-specific issues.

### What was the solution? (How)

Added a developer-only "Include Adaptor Wheels" checkbox in the Scene Settings tab that:
- Only appears when `DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` environment variable is set
- Allows developers to attach a `wheels/` directory containing local builds of `openjd-adaptor-runtime`, `deadline`, and `deadline-cloud-for-3ds-max` packages
- Creates a Python virtual environment on the worker and installs the custom wheels before running the adaptor
- Uses a single cross-platform Python script (`setup_adaptor_wheels.py`) that automatically handles platform differences (Windows vs Linux)

### What is the impact of this change?

- Developers can now test local adaptor changes on workers without modifying installed packages
- Full cross-platform support for both Windows and Linux workers using a single Python script
- Cleaner, more maintainable implementation with the setup logic in a separate Python file
- No impact on production users (feature is hidden behind developer environment variable)

### How was this change tested?

- Unit tests added and passing
- Manually tested on Windows worker with local adaptor wheels
- Verified checkbox only appears when `DEADLINE_ENABLE_DEVELOPER_OPTIONS=true`
- Confirmed worker creates venv, installs wheels (including dev versions with git hashes), and runs custom adaptor successfully
- Verified cross-platform Python script handles platform detection correctly

### Was this change documented?

- [x] Yes

Added comprehensive documentation in `DEVELOPMENT.md` under "Running the Adaptor on a Farm" section with:
- Step-by-step instructions for building and using adaptor wheels
- Platform-specific commands for Windows (PowerShell/CMD) using environment variables
- Updated `.kiro/powers/3dsmax-dev-power/steering/build-and-test.md` with adaptor wheels workflow
- Generic path references using `$env:3DSMAX_EXECUTABLE` instead of hardcoded paths

### Did you modify schema files?

- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [ ] No

### Is this a breaking change?

- [ ] Yes
- [x] No

This is a purely additive feature that only affects developers who explicitly enable it via environment variable.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
