### PR TITLE
feat: output filenames customizability with tokens

### DIFF
--- a/docs/design/output-filename-with-tokens.md
+++ b/docs/design/output-filename-with-tokens.md
@@ -1,0 +1,614 @@
+# Output Filename Token Pattern System — Design Document
+
+## Overview
+
+This feature adds a Deadline 10-style output filename token pattern system to the Deadline Cloud for 3ds Max submitter. The pattern field replaces the existing "Output Filename" field — users type the full filename directly, with optional tokens that get resolved by the adaptor at render time.
+
+**Supported tokens:**
+- `<camera>` — Scene camera name (e.g., "Camera001", "RenderCam")
+- `<stateset>` — State Set name (e.g., "DayLight", "NightTime")
+- `<scene>` — Scene file name without extension (e.g., "myScene")
+
+Everything else in the pattern is literal text (the base name, frame padding, delimiters).
+
+**All tokens are resolved by the adaptor at render time.** The submitter passes the raw pattern through to init-data. The adaptor already has all the data it needs: camera from run-data/init-data, state set from init-data, scene name from the scene file path in init-data.
+
+**Example patterns and results:**
+
+| Pattern | Camera=RenderCam, StateSet=DayLight, Scene=myScene |
+|---------|-----------------------------------------------------|
+| `<camera>_<stateset>_<scene>_###` | `RenderCam_DayLight_myScene_###` |
+| `<camera>_<stateset>_myRender_###` | `RenderCam_DayLight_myRender_###` |
+| `<stateset>_<scene>_###` | `DayLight_myScene_###` |
+| `<scene>_###` | `myScene_###` |
+| `myRender_###` | `myRender_###` |
+
+**Default pattern initialization:**
+1. If `rt.rendOutputFilename` is set in 3ds Max Render Setup → pattern is built as `<camera>_<stateset>_{stem from rendOutputFilename}`
+2. If not set → pattern is built as `<camera>_<stateset>_<scene>_###`
+3. Sticky settings always take precedence over both — if the user previously saved a pattern, that's what loads
+
+**Delimiter:** Hardcoded as `_` in a single constant (`OUTPUT_FILENAME_DELIMITER` in `data_const.py`). Used for cleanup of double delimiters after token resolution.
+
+---
+
+## 1. Data Structures to Change or Add
+
+### 1.1 New field on `RenderSubmitterUISettings`
+
+**File:** `src/deadline/max_submitter/data_classes.py`
+
+```python
+@dataclass
+class RenderSubmitterUISettings:
+    ...existing fields...
+
+    # Output Filename Pattern (replaces output_name for filename composition)
+    # The full output filename with optional <camera>, <stateset>, and <scene> tokens.
+    # Everything else is literal text (base name, frame padding, delimiters).
+    output_filename_pattern: str = field(
+        default="<camera>_<stateset>_<scene>_###", metadata={"sticky": True}
+    )
+```
+
+The existing `output_name` field is kept for backward compatibility with sticky settings files but is no longer used for filename composition.
+
+### 1.2 No changes to `StateSetData`
+
+The `output_file_name` field on `StateSetData` now carries the raw pattern string (with unresolved tokens). The adaptor resolves all tokens at render time.
+
+### 1.3 New utility function (shared, used by both adaptor and UI preview)
+
+**File:** `src/deadline/max_shared/utilities/filename_utils.py` (new file)
+
+```python
+def format_output_filename(
+    pattern: str,
+    camera_name: str = "",
+    state_set_name: str = "",
+    scene_name: str = "",
+    delimiter: str = "_",
+) -> str:
+    """
+    Resolve an output filename from a token pattern.
+
+    Replaces <camera>, <stateset>, and <scene> tokens with actual values,
+    then cleans up double delimiters and leading/trailing delimiters
+    that result from empty token values.
+    """
+    ...
+```
+
+See Appendix A.1 for full implementation.
+
+---
+
+## 2. UX Changes (Submitter Dialog)
+
+### 2.1 Replace "Output Filename" with pattern-based fields
+
+**File:** `src/deadline/max_submitter/ui/scene_settings_tab.py`
+
+The existing "Output Filename" `QLineEdit` (row 2) is replaced by an "Output Filename Settings" group box containing the pattern and live preview:
+
+```
+Row 0: Project Path       [C:/Projects/MyProject        ] (read-only)
+Row 1: Output Path        [C:/Output                    ] [...]
+Row 2: ┌─ Output Filename Settings ──────────────────────────────────┐
+       │  Filename Pattern    [<camera>_<stateset>_<scene>_###    ]  │
+       │  Filename Preview    RenderCam_DayLight_myScene_###         │
+       └─────────────────────────────────────────────────────────────┘
+Row 3: Output File Ext    [OpenEXR Image File (*.exr)   ▼]
+Row 4: State Sets          [All State Sets               ▼]
+...
+```
+
+The group box replaces the old "Output Filename" QLineEdit at Row 2. The Output File Extension dropdown stays at Row 3 (unchanged position). All rows below remain at their current indices.
+
+**Controls:**
+
+| Control | Type | Default | Sticky | Notes |
+|---------|------|---------|--------|-------|
+| Filename Pattern | `QLineEdit` | (built from render settings, see below) | Yes | Tooltip lists available tokens |
+| Filename Preview | `QLabel` | (computed) | No | Read-only, updates live |
+
+**Tooltip for Filename Pattern:**
+```
+Available tokens:
+  <camera>   — Scene camera name (e.g., Camera001, RenderCam)
+  <stateset> — State set name
+  <scene>    — Scene file name (without extension)
+
+Everything else is literal text.
+Remove a token to exclude it from the filename.
+Examples:
+  <camera>_<stateset>_<scene>_###
+  <camera>_<stateset>_myRender_###
+  <scene>_###
+  myScene_###
+```
+
+### 2.2 Default pattern initialization
+
+**File:** `src/deadline/max_submitter/max_render_submitter.py` — in `show_job_bundle_submitter()`
+
+The default pattern is built before sticky settings load:
+
+```python
+# Build default pattern from render settings
+output_path, output_name, output_ext = max_utils.get_render_output_info()
+render_settings.output_path = output_path
+render_settings.output_filename_pattern = f"<camera>_<stateset>_{output_name}"
+if output_ext:
+    render_settings.output_ext = output_ext
+
+# Sticky settings override the pattern if previously saved
+render_settings.load_sticky_settings()
+```
+
+This means:
+- If `rendOutputFilename` = `C:\output\myScene_###.exr` → pattern = `<camera>_<stateset>_myScene_###`
+- If `rendOutputFilename` is empty → pattern = `<camera>_<stateset>_<scene>_###`
+- If sticky settings exist → pattern = whatever the user last saved
+
+### 2.3 Preview update logic
+
+The preview label updates whenever any of these change:
+- `output_filename_pattern_txt` (pattern)
+- `state_sets_box` (state set selection)
+- `cameras_box` (camera selection)
+
+The preview calls `format_output_filename()` with current UI values. For "All State Sets", the preview uses the first state set name as example. For "All Cameras", the preview uses the first camera name as example. For `<scene>`, the preview uses the current scene name.
+
+### 2.4 `_configure_settings()` additions
+
+```python
+def _configure_settings(self, settings):
+    ...existing settings...
+
+    self.output_filename_pattern_txt.setText(settings.output_filename_pattern)
+    self._update_filename_preview()
+```
+
+### 2.5 `update_settings()` additions
+
+```python
+def update_settings(self, settings):
+    ...existing settings...
+
+    settings.output_filename_pattern = self.output_filename_pattern_txt.text()
+```
+
+### 2.6 Removal of old "Output Filename" field
+
+The existing `output_name_txt` QLineEdit and its label are removed from the UI. The `output_name` field on `RenderSubmitterUISettings` is kept for backward compatibility but no longer drives filename composition.
+
+---
+
+## 3. Job Template and Bundle Changes
+
+### 3.1 No changes to `default_max_job_template.yaml`
+
+The template stays as-is. The `OutputFileName` parameter now carries the raw pattern with unresolved tokens.
+
+### 3.2 No changes to `init_data.schema.json`
+
+No new fields. The existing `output_file_name` field carries the raw pattern string.
+
+### 3.3 Changes to `max_render_submitter.py` — pass raw pattern through
+
+**File:** `src/deadline/max_submitter/max_render_submitter.py`
+
+In `on_create_job_bundle_callback()`, the ad-hoc filename logic is replaced in **both** code paths (all state sets and single state set). The raw pattern is passed as `output_file_name` for all cases:
+
+```python
+# ALL STATE SETS path — currently does: output_file_name = state_set[0] + "_" + settings.output_name
+# SINGLE STATE SET path — currently does: output_file_name = settings.output_name
+#
+# Both are replaced with:
+output_file_name = settings.output_filename_pattern
+```
+
+The output directory and extension logic stays the same (from `rendOutputFilename` or UI fields).
+
+---
+
+## 4. Adapter Changes
+
+### 4.1 Changes to `DefaultMaxHandler.start_render()`
+
+**File:** `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py`
+
+**Breaking change:** The current code appends the camera name with `_` when the camera comes from run-data (`output_name = self.output_name + "_" + camera`). This ad-hoc logic is removed — camera naming is now controlled entirely by the `<camera>` token in the pattern. Users who relied on the old implicit camera-appending behavior will need to include `<camera>` in their pattern.
+
+The adaptor resolves all tokens in `start_render()` before building the output path:
+
+```python
+from deadline.max_shared.utilities.filename_utils import format_output_filename
+
+def start_render(self, data: dict) -> None:
+    ...existing frame/output validation...
+
+    camera = data.get("camera")
+    if camera is not None:
+        logger.debug("Setting camera with run data")
+        camera = self.get_camera_to_render(camera)
+        self.camera_node = rt.getNodeByName(camera)
+
+    ...existing camera_node None check...
+
+    # Resolve all tokens in the output filename
+    scene_name = Path(rt.maxFileName).stem if rt.maxFileName else ""
+    state_set_name = self.state_set_name or ""
+    camera_name = camera or ""
+
+    output_name = format_output_filename(
+        pattern=self.output_name,
+        camera_name=camera_name,
+        state_set_name=state_set_name,
+        scene_name=scene_name,
+    )
+
+    output_name = self.reformat_framenumber_padding(output_name, frame)
+    output_file = output_name + self.output_format
+    output_path = os.path.join(self.output_dir, output_file)
+
+    ...rest of function unchanged...
+```
+
+### 4.2 New instance variable for state set name
+
+The adaptor needs to store the state set name from init-data so it's available in `start_render()`.
+
+**File:** `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py` — in `__init__()`
+
+```python
+class DefaultMaxHandler:
+    def __init__(self):
+        ...existing action_dict, camera_node, output_dir, etc...
+
+        # NEW: Store state set name for token resolution in start_render()
+        self.state_set_name: str = ""
+```
+
+**File:** `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py` — in `set_state_set()`
+
+In `set_state_set()`, store the name before the existing state set switching logic:
+
+```python
+def set_state_set(self, data: dict) -> None:
+    state_set_name = data.get("state_set")
+    self.state_set_name = state_set_name or ""
+    ...existing state set logic...
+```
+
+### 4.3 No changes to `MaxAdaptor._populate_action_queue()`
+
+No new init-data keys needed. The adaptor already receives `state_set`, `scene_file`, and `camera` — all the data needed to resolve every token.
+
+---
+
+---
+
+## 5. Render Settings Override & Smart Sticky Settings
+
+### 5.1 Focus-change detection (mid-session render settings updates)
+
+**File:** `src/deadline/max_submitter/ui/scene_settings_tab.py`
+
+When the user switches focus back to the submitter dialog after changing `rt.rendOutputFilename` in 3ds Max Render Setup, the submitter detects the change and updates the pattern accordingly.
+
+The `SceneSettingsWidget` tracks `_last_rend_output_filename` and hooks into `QApplication.instance().focusChanged`. On focus change, `on_focus_changed()` compares the current `rt.rendOutputFilename` to the tracked value. If different, it:
+1. Extracts the new stem, output path, and extension
+2. Rebuilds the pattern as `<camera>_<stateset>_{new_stem}`
+3. Updates the pattern field, output path, and extension in the UI
+4. Updates `_last_rend_output_filename` to the new value
+
+### 5.2 Smart sticky override on submitter open
+
+**File:** `src/deadline/max_submitter/max_render_submitter.py` — in `show_job_bundle_submitter()`
+
+After `load_sticky_settings()`, the submitter compares the current `rt.rendOutputFilename` to `last_rend_output_filename` (a sticky field). If they differ, the render settings have changed since the last submission, so the pattern is rebuilt from the current render settings — overriding the sticky pattern.
+
+```python
+# Only override sticky pattern if render output changed since last save
+current_rend_output = str(rt.rendOutputFilename or "")
+if current_rend_output and current_rend_output != render_settings.last_rend_output_filename:
+    output_path, output_name, output_ext = max_utils.get_render_output_info()
+    render_settings.output_path = output_path
+    render_settings.output_filename_pattern = f"<camera>_<stateset>_{output_name}"
+    if output_ext:
+        render_settings.output_ext = output_ext
+```
+
+### 5.3 Save tracking on submission
+
+**File:** `src/deadline/max_submitter/max_render_submitter.py` — in `on_create_job_bundle_callback()`
+
+Before `save_sticky_settings()`, the current `rt.rendOutputFilename` is stored into `settings.last_rend_output_filename`. This becomes the baseline for the next smart sticky override check.
+
+```python
+settings.last_rend_output_filename = str(rt.rendOutputFilename or "")
+settings.save_sticky_settings()
+```
+
+### 5.4 New sticky field: `last_rend_output_filename`
+
+**File:** `src/deadline/max_submitter/data_classes.py`
+
+```python
+# Tracks rt.rendOutputFilename at last save, used to detect external changes
+last_rend_output_filename: str = field(default="", metadata={"sticky": True})
+```
+
+---
+
+## 6. Automatic Frame Padding
+
+### 6.1 Submitter-side frame padding adjustment
+
+**File:** `src/deadline/max_shared/utilities/filename_utils.py`
+
+Two utility functions handle automatic frame padding:
+
+- `is_single_frame(frame_range)` — returns `True` if the frame range string has no `-` or `,` (i.e., a single frame like `"5"`)
+- `ensure_frame_padding(pattern, frame_range)` — adjusts the pattern based on frame count:
+  - Single frame: strips any existing `#` padding and trailing delimiter
+  - Multi-frame: appends `_####` if no `#` padding exists
+
+```python
+def ensure_frame_padding(pattern: str, frame_range: str) -> str:
+    has_padding = "#" in pattern
+    if is_single_frame(frame_range):
+        if has_padding:
+            pattern = pattern.rstrip("#").rstrip(_DELIMITER)
+        return pattern
+    else:
+        if not has_padding:
+            return f"{pattern}{_DELIMITER}{_DEFAULT_FRAME_PADDING}"
+        return pattern
+```
+
+### 6.2 Applied at submission time
+
+**File:** `src/deadline/max_submitter/max_render_submitter.py` — in `on_create_job_bundle_callback()`
+
+After frame override is applied, the submitter loops over all state sets and adjusts `output_file_name`:
+
+```python
+# Auto-adjust frame padding: strip for single frame, add for multi-frame
+for state_set in state_sets_to_submit:
+    state_set.output_file_name = ensure_frame_padding(
+        state_set.output_file_name, state_set.frame_range
+    )
+```
+
+The pattern field in the UI stays untouched — padding adjustment only happens on the submitted data.
+
+### 6.3 Adaptor-side: no frame number appended when no padding
+
+**File:** `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py`
+
+The `reformat_framenumber_padding()` method was updated: when there are no `#` characters in the filename (because the submitter stripped them for a single-frame render), it returns the name as-is instead of appending the raw frame number.
+
+```python
+def reformat_framenumber_padding(self, name: str, number: int) -> str:
+    padding_amount = name.count("#")
+    # If there are no hashes, the submitter decided no frame numbering is needed
+    if not padding_amount:
+        return name
+    ...
+```
+
+This ensures single-frame renders produce clean filenames like `RenderCam_myScene_State01_KIRBY.png` without a trailing `0`.
+
+---
+
+## 7. Integration Test Updates
+
+### 7.1 Multi-camera support in openjd test script
+
+**File:** `scripts/test-3dsmax-openjd-run.ps1`
+
+The integration test script was updated to run all cameras × all frames instead of just the first camera. It:
+1. Extracts all cameras from `taskParameterDefinitions` in the template
+2. Expands the frame range into individual frame numbers
+3. Builds camera × frame task parameter combinations
+4. Passes all tasks to `openjd run` via `--tasks file://` JSON
+
+### 7.2 Console output cleanup in both test scripts
+
+**Files:** `scripts/test-3dsmax-openjd-run.ps1`, `scripts/test-3dsmax-adapter-run.ps1`
+
+Updated console output to show cameras, frames, and total task count instead of referencing removed variables.
+
+---
+
+## Files to Modify Summary
+
+| File | Changes |
+|------|---------|
+| `src/deadline/max_shared/utilities/filename_utils.py` | **New file** — `format_output_filename()`, `ensure_frame_padding()`, `is_single_frame()` utilities |
+| `src/deadline/max_submitter/data_classes.py` | Add `output_filename_pattern` and `last_rend_output_filename` sticky fields |
+| `src/deadline/max_submitter/data_const.py` | No changes needed |
+| `src/deadline/max_submitter/ui/scene_settings_tab.py` | Replace "Output Filename" with "Output Filename Settings" group box (pattern + preview); focus-change detection for render settings updates |
+| `src/deadline/max_submitter/max_render_submitter.py` | Build default pattern from render settings; pass raw pattern as `output_file_name`; smart sticky override; frame padding adjustment at submission; save `last_rend_output_filename` |
+| `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py` | Resolve all tokens in `start_render()`, store `state_set_name`, no-padding = no frame number appended |
+| `scripts/test-3dsmax-openjd-run.ps1` | Multi-camera × multi-frame task execution |
+| `scripts/test-3dsmax-adapter-run.ps1` | Console output cleanup |
+| `test/unit/...` | Unit tests for `format_output_filename()`, `ensure_frame_padding()`, `is_single_frame()` |
+
+
+
+---
+
+## Appendix: Full Code Implementations
+
+### A.1 `format_output_filename()` — Full Implementation
+
+**File:** `src/deadline/max_shared/utilities/filename_utils.py` (new file)
+
+```python
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Shared output filename utilities for Deadline Cloud 3ds Max integration.
+
+Provides token-based output filename formatting.
+
+Supported tokens:
+    <camera>   — Scene camera name (e.g., "Camera001", "RenderCam")
+    <stateset> — State Set name (e.g., "DayLight", "NightTime")
+    <scene>    — Scene file name without extension (e.g., "myScene")
+
+Everything else in the pattern is literal text (base name, frame padding, delimiters).
+"""
+
+# Hardcoded delimiter for cleanup
+_DELIMITER = "_"
+
+
+def format_output_filename(
+    pattern: str,
+    camera_name: str = "",
+    state_set_name: str = "",
+    scene_name: str = "",
+) -> str:
+    """
+    Resolve an output filename from a token pattern.
+
+    Replaces <camera>, <stateset>, and <scene> tokens with actual values,
+    then cleans up double underscores and leading/trailing underscores
+    that result from empty token values.
+
+    Examples:
+        >>> format_output_filename(
+        ...     "<camera>_<stateset>_<scene>_###",
+        ...     camera_name="RenderCam", state_set_name="DayLight", scene_name="myScene")
+        'RenderCam_DayLight_myScene_###'
+
+        >>> format_output_filename(
+        ...     "<camera>_<stateset>_<scene>_###",
+        ...     camera_name="", state_set_name="", scene_name="myScene")
+        'myScene_###'
+
+        >>> format_output_filename(
+        ...     "<camera>_<stateset>_myRender_###",
+        ...     camera_name="RenderCam", state_set_name="DayLight")
+        'RenderCam_DayLight_myRender_###'
+
+        >>> format_output_filename("myRender_###")
+        'myRender_###'
+
+    :param pattern: the full filename pattern with optional tokens
+    :param camera_name: the scene camera name, or "" if not applicable
+    :param state_set_name: the state set name, or "" if not applicable
+    :param scene_name: the scene file name (no extension), or "" if not applicable
+    :returns: the resolved filename string
+    """
+    if not pattern:
+        return ""
+
+    result = pattern
+    result = result.replace("<camera>", camera_name)
+    result = result.replace("<stateset>", state_set_name)
+    result = result.replace("<scene>", scene_name)
+
+    # Collapse runs of the delimiter into a single delimiter
+    double = _DELIMITER + _DELIMITER
+    while double in result:
+        result = result.replace(double, _DELIMITER)
+
+    # Strip leading/trailing delimiters
+    result = result.strip(_DELIMITER)
+
+    return result
+```
+
+### A.2 `_build_output_filename_settings_ui()` — Full Implementation
+
+**File:** `src/deadline/max_submitter/ui/scene_settings_tab.py`
+
+```python
+def _build_output_filename_settings_ui(self):
+    """
+    Create a QGroupBox for the output filename pattern settings.
+    Replaces the old "Output Filename" QLineEdit.
+    """
+    self.output_filename_grp_box = QGroupBox()
+    self.output_filename_grp_box.setTitle("Output Filename Settings")
+    fn_lyt = QGridLayout(self)
+    self.output_filename_grp_box.setLayout(fn_lyt)
+
+    # Filename Pattern
+    self.output_filename_pattern_txt = QLineEdit(self)
+    self.output_filename_pattern_txt.setToolTip(
+        "Available tokens:\n"
+        "  <camera>   — Scene camera name (e.g., Camera001, RenderCam)\n"
+        "  <stateset> — State set name\n"
+        "  <scene>    — Scene file name (without extension)\n\n"
+        "Everything else is literal text.\n"
+        "Remove a token to exclude it from the filename.\n"
+        "Examples:\n"
+        "  <camera>_<stateset>_<scene>_###\n"
+        "  <camera>_<stateset>_myRender_###\n"
+        "  <scene>_###\n"
+        "  myScene_###"
+    )
+    fn_lyt.addWidget(QLabel("Filename Pattern"), 0, 0)
+    fn_lyt.addWidget(self.output_filename_pattern_txt, 0, 1)
+    self.output_filename_pattern_txt.textChanged.connect(self._update_filename_preview)
+
+    # Filename Preview
+    self.filename_preview_label = QLabel(self)
+    self.filename_preview_label.setStyleSheet("color: gray; font-style: italic;")
+    self.filename_preview_label.setToolTip("Preview of the resolved output filename")
+    fn_lyt.addWidget(QLabel("Filename Preview"), 1, 0)
+    fn_lyt.addWidget(self.filename_preview_label, 1, 1)
+```
+
+### A.3 `_update_filename_preview()` — Full Implementation
+
+**File:** `src/deadline/max_submitter/ui/scene_settings_tab.py`
+
+```python
+def _update_filename_preview(self):
+    """
+    Update the filename preview label based on current UI values.
+    """
+    from deadline.max_shared.utilities.filename_utils import format_output_filename
+    from data_const import ALL_CAMERAS_STR, ALL_STEREO_CAMERAS_STR
+
+    pattern = self.output_filename_pattern_txt.text()
+
+    # Get state set name from current selection
+    state_set_text = self.state_sets_box.currentText()
+    state_set_name = "" if state_set_text == "All State Sets" else state_set_text
+
+    # For "All State Sets", show first state set as example if available
+    if state_set_text == "All State Sets" and self.state_sets:
+        state_set_name = self.state_sets[0][0]
+
+    # Get camera name from current selection
+    camera_data = self.cameras_box.currentData()
+    is_all_cameras = camera_data in (ALL_CAMERAS_STR, ALL_STEREO_CAMERAS_STR)
+
+    if is_all_cameras and hasattr(self, "cameras") and self.cameras:
+        camera_name = self.cameras[0]
+    elif not is_all_cameras and camera_data:
+        camera_name = camera_data
+    else:
+        camera_name = ""
+
+    # Get scene name
+    scene_name = max_utils.get_scene_name()
+
+    preview = format_output_filename(
+        pattern=pattern,
+        camera_name=camera_name,
+        state_set_name=state_set_name,
+        scene_name=scene_name,
+    )
+
+    self.filename_preview_label.setText(preview)
+```

--- a/docs/design/output-filename-with-tokens.md
+++ b/docs/design/output-filename-with-tokens.md
@@ -1,13 +1,19 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+
 # Output Filename Token Pattern System — Design Document
 
 ## Overview
 
 This feature adds a Deadline 10-style output filename token pattern system to the Deadline Cloud for 3ds Max submitter. The pattern field replaces the existing "Output Filename" field — users type the full filename directly, with optional tokens that get resolved by the adaptor at render time.
 
+**WYSIWYG principle:** The pattern is passed through exactly as the user types it. No automatic cleanup of delimiters, no automatic frame padding adjustment. What you see is what you get.
+
 **Supported tokens:**
 - `<camera>` — Scene camera name (e.g., "Camera001", "RenderCam")
 - `<stateset>` — State Set name (e.g., "DayLight", "NightTime")
 - `<scene>` — Scene file name without extension (e.g., "myScene")
+
+Token definitions are maintained in a single source of truth: `SUPPORTED_TOKENS` dict in `filename_utils.py`. The UI tooltip is generated from this dict via `get_tokens_tooltip()`, so adding a new token only requires updating one place.
 
 Everything else in the pattern is literal text (the base name, frame padding, delimiters).
 
@@ -27,8 +33,6 @@ Everything else in the pattern is literal text (the base name, frame padding, de
 1. If `rt.rendOutputFilename` is set in 3ds Max Render Setup → pattern is built as `<camera>_<stateset>_{stem from rendOutputFilename}`
 2. If not set → pattern is built as `<camera>_<stateset>_<scene>_###`
 3. Sticky settings always take precedence over both — if the user previously saved a pattern, that's what loads
-
-**Delimiter:** Hardcoded as `_` in a single constant (`OUTPUT_FILENAME_DELIMITER` in `data_const.py`). Used for cleanup of double delimiters after token resolution.
 
 ---
 
@@ -57,29 +61,40 @@ The existing `output_name` field is kept for backward compatibility with sticky 
 
 The `output_file_name` field on `StateSetData` now carries the raw pattern string (with unresolved tokens). The adaptor resolves all tokens at render time.
 
-### 1.3 New utility function (shared, used by both adaptor and UI preview)
+### 1.3 Shared utility functions
 
-**File:** `src/deadline/max_shared/utilities/filename_utils.py` (new file)
+**File:** `src/deadline/max_shared/utilities/filename_utils.py`
+
+This file contains:
+- `SUPPORTED_TOKENS` — single source of truth dict mapping token strings to descriptions
+- `get_tokens_tooltip()` — builds the UI tooltip string from `SUPPORTED_TOKENS`
+- `format_output_filename()` — pure token replacement, no cleanup
 
 ```python
+SUPPORTED_TOKENS: dict[str, str] = {
+    "<camera>": "Scene camera name (e.g., Camera001, RenderCam)",
+    "<stateset>": "State set name",
+    "<scene>": "Scene file name (without extension)",
+}
+
 def format_output_filename(
     pattern: str,
     camera_name: str = "",
     state_set_name: str = "",
     scene_name: str = "",
-    delimiter: str = "_",
 ) -> str:
     """
     Resolve an output filename from a token pattern.
-
-    Replaces <camera>, <stateset>, and <scene> tokens with actual values,
-    then cleans up double delimiters and leading/trailing delimiters
-    that result from empty token values.
+    Pure token replacement — no delimiter cleanup, no padding adjustment.
     """
-    ...
+    if not pattern:
+        return ""
+    result = pattern
+    result = result.replace("<camera>", camera_name)
+    result = result.replace("<stateset>", state_set_name)
+    result = result.replace("<scene>", scene_name)
+    return result
 ```
-
-See Appendix A.1 for full implementation.
 
 ---
 
@@ -103,30 +118,14 @@ Row 4: State Sets          [All State Sets               ▼]
 ...
 ```
 
-The group box replaces the old "Output Filename" QLineEdit at Row 2. The Output File Extension dropdown stays at Row 3 (unchanged position). All rows below remain at their current indices.
-
 **Controls:**
 
 | Control | Type | Default | Sticky | Notes |
 |---------|------|---------|--------|-------|
-| Filename Pattern | `QLineEdit` | (built from render settings, see below) | Yes | Tooltip lists available tokens |
-| Filename Preview | `QLabel` | (computed) | No | Read-only, updates live |
+| Filename Pattern | `QLineEdit` | (built from render settings, see below) | Yes | Tooltip generated from `SUPPORTED_TOKENS` via `get_tokens_tooltip()` |
+| Filename Preview | `QLabel` | (computed) | No | Read-only, updates live. Tooltip says "Example preview of the resolved output filename" |
 
-**Tooltip for Filename Pattern:**
-```
-Available tokens:
-  <camera>   — Scene camera name (e.g., Camera001, RenderCam)
-  <stateset> — State set name
-  <scene>    — Scene file name (without extension)
-
-Everything else is literal text.
-Remove a token to exclude it from the filename.
-Examples:
-  <camera>_<stateset>_<scene>_###
-  <camera>_<stateset>_myRender_###
-  <scene>_###
-  myScene_###
-```
+**Tooltip for Filename Pattern** is generated dynamically from `get_tokens_tooltip()` in `filename_utils.py`. Adding a new token to `SUPPORTED_TOKENS` automatically updates the tooltip.
 
 ### 2.2 Default pattern initialization
 
@@ -151,6 +150,8 @@ This means:
 - If `rendOutputFilename` is empty → pattern = `<camera>_<stateset>_<scene>_###`
 - If sticky settings exist → pattern = whatever the user last saved
 
+**No automatic override of sticky settings.** Once the user has saved a pattern via submission, it is always respected on next open. There is no tracking of `rendOutputFilename` changes between sessions.
+
 ### 2.3 Preview update logic
 
 The preview label updates whenever any of these change:
@@ -160,28 +161,13 @@ The preview label updates whenever any of these change:
 
 The preview calls `format_output_filename()` with current UI values. For "All State Sets", the preview uses the first state set name as example. For "All Cameras", the preview uses the first camera name as example. For `<scene>`, the preview uses the current scene name.
 
-### 2.4 `_configure_settings()` additions
+### 2.4 No focus-change render settings sync
 
-```python
-def _configure_settings(self, settings):
-    ...existing settings...
+The submitter does **not** auto-detect changes to `rt.rendOutputFilename` while the dialog is open. If the user changes render output in 3ds Max Render Setup, they must manually update the pattern in the submitter. This avoids silently overriding user input or sticky settings.
 
-    self.output_filename_pattern_txt.setText(settings.output_filename_pattern)
-    self._update_filename_preview()
-```
+### 2.5 No automatic frame padding
 
-### 2.5 `update_settings()` additions
-
-```python
-def update_settings(self, settings):
-    ...existing settings...
-
-    settings.output_filename_pattern = self.output_filename_pattern_txt.text()
-```
-
-### 2.6 Removal of old "Output Filename" field
-
-The existing `output_name_txt` QLineEdit and its label are removed from the UI. The `output_name` field on `RenderSubmitterUISettings` is kept for backward compatibility but no longer drives filename composition.
+The submitter does **not** add or strip frame padding (`#` characters). If the user renders multiple frames without padding in the filename, the output images will overwrite each other — but that's the user's explicit choice. The WYSIWYG principle applies: the pattern is submitted exactly as typed.
 
 ---
 
@@ -199,17 +185,18 @@ No new fields. The existing `output_file_name` field carries the raw pattern str
 
 **File:** `src/deadline/max_submitter/max_render_submitter.py`
 
-In `on_create_job_bundle_callback()`, the ad-hoc filename logic is replaced in **both** code paths (all state sets and single state set). The raw pattern is passed as `output_file_name` for all cases:
+In `on_create_job_bundle_callback()`, the raw pattern is passed as `output_file_name` for all cases. Output directory and extension are resolved using `max_utils.get_render_output_info()`:
 
 ```python
-# ALL STATE SETS path — currently does: output_file_name = state_set[0] + "_" + settings.output_name
-# SINGLE STATE SET path — currently does: output_file_name = settings.output_name
-#
-# Both are replaced with:
-output_file_name = settings.output_filename_pattern
+if rt.rendOutputFilename:
+    output_dir, _, rend_ext = max_utils.get_render_output_info()
+    output_file_name = settings.output_filename_pattern
+    output_file_format = settings.output_ext if settings.output_ext else rend_ext
+else:
+    output_dir = settings.output_path
+    output_file_name = settings.output_filename_pattern
+    output_file_format = settings.output_ext
 ```
-
-The output directory and extension logic stays the same (from `rendOutputFilename` or UI fields).
 
 ---
 
@@ -219,8 +206,6 @@ The output directory and extension logic stays the same (from `rendOutputFilenam
 
 **File:** `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py`
 
-**Breaking change:** The current code appends the camera name with `_` when the camera comes from run-data (`output_name = self.output_name + "_" + camera`). This ad-hoc logic is removed — camera naming is now controlled entirely by the `<camera>` token in the pattern. Users who relied on the old implicit camera-appending behavior will need to include `<camera>` in their pattern.
-
 The adaptor resolves all tokens in `start_render()` before building the output path:
 
 ```python
@@ -228,14 +213,6 @@ from deadline.max_shared.utilities.filename_utils import format_output_filename
 
 def start_render(self, data: dict) -> None:
     ...existing frame/output validation...
-
-    camera = data.get("camera")
-    if camera is not None:
-        logger.debug("Setting camera with run data")
-        camera = self.get_camera_to_render(camera)
-        self.camera_node = rt.getNodeByName(camera)
-
-    ...existing camera_node None check...
 
     # Resolve all tokens in the output filename
     scene_name = Path(rt.maxFileName).stem if rt.maxFileName else ""
@@ -252,28 +229,12 @@ def start_render(self, data: dict) -> None:
     output_name = self.reformat_framenumber_padding(output_name, frame)
     output_file = output_name + self.output_format
     output_path = os.path.join(self.output_dir, output_file)
-
-    ...rest of function unchanged...
+    ...
 ```
 
-### 4.2 New instance variable for state set name
+### 4.2 State set name stored from init-data
 
-The adaptor needs to store the state set name from init-data so it's available in `start_render()`.
-
-**File:** `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py` — in `__init__()`
-
-```python
-class DefaultMaxHandler:
-    def __init__(self):
-        ...existing action_dict, camera_node, output_dir, etc...
-
-        # NEW: Store state set name for token resolution in start_render()
-        self.state_set_name: str = ""
-```
-
-**File:** `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py` — in `set_state_set()`
-
-In `set_state_set()`, store the name before the existing state set switching logic:
+The adaptor stores the state set name from init-data so it's available in `start_render()`:
 
 ```python
 def set_state_set(self, data: dict) -> None:
@@ -282,333 +243,33 @@ def set_state_set(self, data: dict) -> None:
     ...existing state set logic...
 ```
 
-### 4.3 No changes to `MaxAdaptor._populate_action_queue()`
-
-No new init-data keys needed. The adaptor already receives `state_set`, `scene_file`, and `camera` — all the data needed to resolve every token.
-
 ---
 
----
+## 5. Utility: `get_render_output_info()`
 
-## 5. Render Settings Override & Smart Sticky Settings
+**File:** `src/deadline/max_submitter/utilities/max_utils.py`
 
-### 5.1 Focus-change detection (mid-session render settings updates)
-
-**File:** `src/deadline/max_submitter/ui/scene_settings_tab.py`
-
-When the user switches focus back to the submitter dialog after changing `rt.rendOutputFilename` in 3ds Max Render Setup, the submitter detects the change and updates the pattern accordingly.
-
-The `SceneSettingsWidget` tracks `_last_rend_output_filename` and hooks into `QApplication.instance().focusChanged`. On focus change, `on_focus_changed()` compares the current `rt.rendOutputFilename` to the tracked value. If different, it:
-1. Extracts the new stem, output path, and extension
-2. Rebuilds the pattern as `<camera>_<stateset>_{new_stem}`
-3. Updates the pattern field, output path, and extension in the UI
-4. Updates `_last_rend_output_filename` to the new value
-
-### 5.2 Smart sticky override on submitter open
-
-**File:** `src/deadline/max_submitter/max_render_submitter.py` — in `show_job_bundle_submitter()`
-
-After `load_sticky_settings()`, the submitter compares the current `rt.rendOutputFilename` to `last_rend_output_filename` (a sticky field). If they differ, the render settings have changed since the last submission, so the pattern is rebuilt from the current render settings — overriding the sticky pattern.
+Uses `pathlib.Path` for clean path decomposition:
 
 ```python
-# Only override sticky pattern if render output changed since last save
-current_rend_output = str(rt.rendOutputFilename or "")
-if current_rend_output and current_rend_output != render_settings.last_rend_output_filename:
-    output_path, output_name, output_ext = max_utils.get_render_output_info()
-    render_settings.output_path = output_path
-    render_settings.output_filename_pattern = f"<camera>_<stateset>_{output_name}"
-    if output_ext:
-        render_settings.output_ext = output_ext
-```
-
-### 5.3 Save tracking on submission
-
-**File:** `src/deadline/max_submitter/max_render_submitter.py` — in `on_create_job_bundle_callback()`
-
-Before `save_sticky_settings()`, the current `rt.rendOutputFilename` is stored into `settings.last_rend_output_filename`. This becomes the baseline for the next smart sticky override check.
-
-```python
-settings.last_rend_output_filename = str(rt.rendOutputFilename or "")
-settings.save_sticky_settings()
-```
-
-### 5.4 New sticky field: `last_rend_output_filename`
-
-**File:** `src/deadline/max_submitter/data_classes.py`
-
-```python
-# Tracks rt.rendOutputFilename at last save, used to detect external changes
-last_rend_output_filename: str = field(default="", metadata={"sticky": True})
-```
-
----
-
-## 6. Automatic Frame Padding
-
-### 6.1 Submitter-side frame padding adjustment
-
-**File:** `src/deadline/max_shared/utilities/filename_utils.py`
-
-Two utility functions handle automatic frame padding:
-
-- `is_single_frame(frame_range)` — returns `True` if the frame range string has no `-` or `,` (i.e., a single frame like `"5"`)
-- `ensure_frame_padding(pattern, frame_range)` — adjusts the pattern based on frame count:
-  - Single frame: strips any existing `#` padding and trailing delimiter
-  - Multi-frame: appends `_####` if no `#` padding exists
-
-```python
-def ensure_frame_padding(pattern: str, frame_range: str) -> str:
-    has_padding = "#" in pattern
-    if is_single_frame(frame_range):
-        if has_padding:
-            pattern = pattern.rstrip("#").rstrip(_DELIMITER)
-        return pattern
+def get_render_output_info() -> tuple[str, str, str]:
+    if rt.rendOutputFilename:
+        output_path = Path(rt.rendOutputFilename)
+        return str(output_path.parent), output_path.stem, output_path.suffix
     else:
-        if not has_padding:
-            return f"{pattern}{_DELIMITER}{_DEFAULT_FRAME_PADDING}"
-        return pattern
+        return get_scene_dir(), get_scene_name() + "_###", ""
 ```
-
-### 6.2 Applied at submission time
-
-**File:** `src/deadline/max_submitter/max_render_submitter.py` — in `on_create_job_bundle_callback()`
-
-After frame override is applied, the submitter loops over all state sets and adjusts `output_file_name`:
-
-```python
-# Auto-adjust frame padding: strip for single frame, add for multi-frame
-for state_set in state_sets_to_submit:
-    state_set.output_file_name = ensure_frame_padding(
-        state_set.output_file_name, state_set.frame_range
-    )
-```
-
-The pattern field in the UI stays untouched — padding adjustment only happens on the submitted data.
-
-### 6.3 Adaptor-side: no frame number appended when no padding
-
-**File:** `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py`
-
-The `reformat_framenumber_padding()` method was updated: when there are no `#` characters in the filename (because the submitter stripped them for a single-frame render), it returns the name as-is instead of appending the raw frame number.
-
-```python
-def reformat_framenumber_padding(self, name: str, number: int) -> str:
-    padding_amount = name.count("#")
-    # If there are no hashes, the submitter decided no frame numbering is needed
-    if not padding_amount:
-        return name
-    ...
-```
-
-This ensures single-frame renders produce clean filenames like `RenderCam_myScene_State01_KIRBY.png` without a trailing `0`.
 
 ---
 
-## 7. Integration Test Updates
-
-### 7.1 Multi-camera support in openjd test script
-
-**File:** `scripts/test-3dsmax-openjd-run.ps1`
-
-The integration test script was updated to run all cameras × all frames instead of just the first camera. It:
-1. Extracts all cameras from `taskParameterDefinitions` in the template
-2. Expands the frame range into individual frame numbers
-3. Builds camera × frame task parameter combinations
-4. Passes all tasks to `openjd run` via `--tasks file://` JSON
-
-### 7.2 Console output cleanup in both test scripts
-
-**Files:** `scripts/test-3dsmax-openjd-run.ps1`, `scripts/test-3dsmax-adapter-run.ps1`
-
-Updated console output to show cameras, frames, and total task count instead of referencing removed variables.
-
----
-
-## Files to Modify Summary
+## Files Modified Summary
 
 | File | Changes |
 |------|---------|
-| `src/deadline/max_shared/utilities/filename_utils.py` | **New file** — `format_output_filename()`, `ensure_frame_padding()`, `is_single_frame()` utilities |
-| `src/deadline/max_submitter/data_classes.py` | Add `output_filename_pattern` and `last_rend_output_filename` sticky fields |
-| `src/deadline/max_submitter/data_const.py` | No changes needed |
-| `src/deadline/max_submitter/ui/scene_settings_tab.py` | Replace "Output Filename" with "Output Filename Settings" group box (pattern + preview); focus-change detection for render settings updates |
-| `src/deadline/max_submitter/max_render_submitter.py` | Build default pattern from render settings; pass raw pattern as `output_file_name`; smart sticky override; frame padding adjustment at submission; save `last_rend_output_filename` |
-| `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py` | Resolve all tokens in `start_render()`, store `state_set_name`, no-padding = no frame number appended |
-| `scripts/test-3dsmax-openjd-run.ps1` | Multi-camera × multi-frame task execution |
-| `scripts/test-3dsmax-adapter-run.ps1` | Console output cleanup |
-| `test/unit/...` | Unit tests for `format_output_filename()`, `ensure_frame_padding()`, `is_single_frame()` |
-
-
-
----
-
-## Appendix: Full Code Implementations
-
-### A.1 `format_output_filename()` — Full Implementation
-
-**File:** `src/deadline/max_shared/utilities/filename_utils.py` (new file)
-
-```python
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-"""
-Shared output filename utilities for Deadline Cloud 3ds Max integration.
-
-Provides token-based output filename formatting.
-
-Supported tokens:
-    <camera>   — Scene camera name (e.g., "Camera001", "RenderCam")
-    <stateset> — State Set name (e.g., "DayLight", "NightTime")
-    <scene>    — Scene file name without extension (e.g., "myScene")
-
-Everything else in the pattern is literal text (base name, frame padding, delimiters).
-"""
-
-# Hardcoded delimiter for cleanup
-_DELIMITER = "_"
-
-
-def format_output_filename(
-    pattern: str,
-    camera_name: str = "",
-    state_set_name: str = "",
-    scene_name: str = "",
-) -> str:
-    """
-    Resolve an output filename from a token pattern.
-
-    Replaces <camera>, <stateset>, and <scene> tokens with actual values,
-    then cleans up double underscores and leading/trailing underscores
-    that result from empty token values.
-
-    Examples:
-        >>> format_output_filename(
-        ...     "<camera>_<stateset>_<scene>_###",
-        ...     camera_name="RenderCam", state_set_name="DayLight", scene_name="myScene")
-        'RenderCam_DayLight_myScene_###'
-
-        >>> format_output_filename(
-        ...     "<camera>_<stateset>_<scene>_###",
-        ...     camera_name="", state_set_name="", scene_name="myScene")
-        'myScene_###'
-
-        >>> format_output_filename(
-        ...     "<camera>_<stateset>_myRender_###",
-        ...     camera_name="RenderCam", state_set_name="DayLight")
-        'RenderCam_DayLight_myRender_###'
-
-        >>> format_output_filename("myRender_###")
-        'myRender_###'
-
-    :param pattern: the full filename pattern with optional tokens
-    :param camera_name: the scene camera name, or "" if not applicable
-    :param state_set_name: the state set name, or "" if not applicable
-    :param scene_name: the scene file name (no extension), or "" if not applicable
-    :returns: the resolved filename string
-    """
-    if not pattern:
-        return ""
-
-    result = pattern
-    result = result.replace("<camera>", camera_name)
-    result = result.replace("<stateset>", state_set_name)
-    result = result.replace("<scene>", scene_name)
-
-    # Collapse runs of the delimiter into a single delimiter
-    double = _DELIMITER + _DELIMITER
-    while double in result:
-        result = result.replace(double, _DELIMITER)
-
-    # Strip leading/trailing delimiters
-    result = result.strip(_DELIMITER)
-
-    return result
-```
-
-### A.2 `_build_output_filename_settings_ui()` — Full Implementation
-
-**File:** `src/deadline/max_submitter/ui/scene_settings_tab.py`
-
-```python
-def _build_output_filename_settings_ui(self):
-    """
-    Create a QGroupBox for the output filename pattern settings.
-    Replaces the old "Output Filename" QLineEdit.
-    """
-    self.output_filename_grp_box = QGroupBox()
-    self.output_filename_grp_box.setTitle("Output Filename Settings")
-    fn_lyt = QGridLayout(self)
-    self.output_filename_grp_box.setLayout(fn_lyt)
-
-    # Filename Pattern
-    self.output_filename_pattern_txt = QLineEdit(self)
-    self.output_filename_pattern_txt.setToolTip(
-        "Available tokens:\n"
-        "  <camera>   — Scene camera name (e.g., Camera001, RenderCam)\n"
-        "  <stateset> — State set name\n"
-        "  <scene>    — Scene file name (without extension)\n\n"
-        "Everything else is literal text.\n"
-        "Remove a token to exclude it from the filename.\n"
-        "Examples:\n"
-        "  <camera>_<stateset>_<scene>_###\n"
-        "  <camera>_<stateset>_myRender_###\n"
-        "  <scene>_###\n"
-        "  myScene_###"
-    )
-    fn_lyt.addWidget(QLabel("Filename Pattern"), 0, 0)
-    fn_lyt.addWidget(self.output_filename_pattern_txt, 0, 1)
-    self.output_filename_pattern_txt.textChanged.connect(self._update_filename_preview)
-
-    # Filename Preview
-    self.filename_preview_label = QLabel(self)
-    self.filename_preview_label.setStyleSheet("color: gray; font-style: italic;")
-    self.filename_preview_label.setToolTip("Preview of the resolved output filename")
-    fn_lyt.addWidget(QLabel("Filename Preview"), 1, 0)
-    fn_lyt.addWidget(self.filename_preview_label, 1, 1)
-```
-
-### A.3 `_update_filename_preview()` — Full Implementation
-
-**File:** `src/deadline/max_submitter/ui/scene_settings_tab.py`
-
-```python
-def _update_filename_preview(self):
-    """
-    Update the filename preview label based on current UI values.
-    """
-    from deadline.max_shared.utilities.filename_utils import format_output_filename
-    from data_const import ALL_CAMERAS_STR, ALL_STEREO_CAMERAS_STR
-
-    pattern = self.output_filename_pattern_txt.text()
-
-    # Get state set name from current selection
-    state_set_text = self.state_sets_box.currentText()
-    state_set_name = "" if state_set_text == "All State Sets" else state_set_text
-
-    # For "All State Sets", show first state set as example if available
-    if state_set_text == "All State Sets" and self.state_sets:
-        state_set_name = self.state_sets[0][0]
-
-    # Get camera name from current selection
-    camera_data = self.cameras_box.currentData()
-    is_all_cameras = camera_data in (ALL_CAMERAS_STR, ALL_STEREO_CAMERAS_STR)
-
-    if is_all_cameras and hasattr(self, "cameras") and self.cameras:
-        camera_name = self.cameras[0]
-    elif not is_all_cameras and camera_data:
-        camera_name = camera_data
-    else:
-        camera_name = ""
-
-    # Get scene name
-    scene_name = max_utils.get_scene_name()
-
-    preview = format_output_filename(
-        pattern=pattern,
-        camera_name=camera_name,
-        state_set_name=state_set_name,
-        scene_name=scene_name,
-    )
-
-    self.filename_preview_label.setText(preview)
-```
+| `src/deadline/max_shared/utilities/filename_utils.py` | `SUPPORTED_TOKENS` dict, `get_tokens_tooltip()`, `format_output_filename()` (pure token replacement, no cleanup) |
+| `src/deadline/max_submitter/data_classes.py` | Add `output_filename_pattern` sticky field |
+| `src/deadline/max_submitter/ui/scene_settings_tab.py` | "Output Filename Settings" group box (pattern + preview); tooltip from `get_tokens_tooltip()`; imports moved to top-level |
+| `src/deadline/max_submitter/max_render_submitter.py` | Build default pattern; pass raw pattern as `output_file_name`; use `get_render_output_info()` helper |
+| `src/deadline/max_submitter/utilities/max_utils.py` | `get_render_output_info()` simplified with `pathlib.Path` |
+| `src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py` | Resolve all tokens in `start_render()`, store `state_set_name` |
+| `test/unit/...` | Unit tests for `format_output_filename()` |

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional
 
 import pymxs  # noqa
 from pymxs import runtime as rt
 
 from deadline.max_adaptor.executable_handler import MaxExecutableHandler
+from deadline.max_shared.utilities.filename_utils import format_output_filename
 
 if TYPE_CHECKING:
     from deadline.max_adaptor.MaxClient.render_element_manager import RenderElementManager
@@ -46,6 +48,7 @@ class DefaultMaxHandler:
         self.output_dir = None
         self.output_name = None
         self.output_format = None
+        self.state_set_name: str = ""
         self._executable_handler: MaxExecutableHandler = MaxExecutableHandler()
         # Initialize render element manager as private attribute
         self._render_element_manager: Optional["RenderElementManager"] = None
@@ -117,19 +120,25 @@ class DefaultMaxHandler:
                 logger.debug("Setting camera with run data")
                 camera = self.get_camera_to_render(camera)
                 self.camera_node = rt.getNodeByName(camera)
-                # If camera gets set by run data, add the camera to the output name
-                output_name = self.output_name + "_" + camera
 
             # Since camera can be set by both init and run data, this isn't a required parameter in either schema.
             if self.camera_node is None:
                 self.log_to_console("Error: MaxClient: start_render called without a camera.")
                 raise RuntimeError("MaxClient: start_render called without a camera.")
 
-            # Create output path to pass along with render
-            if not output_name:
-                output_name = self.reformat_framenumber_padding(self.output_name, frame)
-            else:
-                output_name = self.reformat_framenumber_padding(output_name, frame)
+            # Resolve all tokens in the output filename pattern
+            scene_name = Path(rt.maxFileName).stem if rt.maxFileName else ""
+            state_set_name = self.state_set_name or ""
+            camera_name = camera or ""
+
+            output_name = format_output_filename(
+                pattern=self.output_name,
+                camera_name=camera_name,
+                state_set_name=state_set_name,
+                scene_name=scene_name,
+            )
+
+            output_name = self.reformat_framenumber_padding(output_name, frame)
             output_file = output_name + self.output_format
             output_path = os.path.join(self.output_dir, output_file)
 
@@ -170,9 +179,10 @@ class DefaultMaxHandler:
         """
         padding_amount = name.count("#")
 
-        # If there are no hashes indicating the padding, just add the number
+        # If there are no hashes, the submitter decided no frame numbering is needed
+        # (e.g. single-frame render). Return the name as-is.
         if not padding_amount:
-            return name + str(number)
+            return name
 
         numbers_amount = len(str(number))
         # Calculate how many zeroes need to be added.
@@ -270,6 +280,7 @@ class DefaultMaxHandler:
         :raises: RuntimeError: if state set doesn't exist
         """
         state_set_name = data.get("state_set")
+        self.state_set_name = state_set_name or ""
 
         # Create necessary items to interact with state sets
         state_sets_dot_net_object = rt.dotNetObject("Autodesk.Max.StateSets.Plugin")

--- a/src/deadline/max_shared/utilities/filename_utils.py
+++ b/src/deadline/max_shared/utilities/filename_utils.py
@@ -4,55 +4,32 @@
 Shared output filename utilities for Deadline Cloud 3ds Max integration.
 
 Provides token-based output filename formatting.
-
-Supported tokens:
-    <camera>   — Scene camera name (e.g., "Camera001", "RenderCam")
-    <stateset> — State Set name (e.g., "DayLight", "NightTime")
-    <scene>    — Scene file name without extension (e.g., "myScene")
-
 Everything else in the pattern is literal text (base name, frame padding, delimiters).
 """
 
-# Hardcoded delimiter for cleanup
-_DELIMITER = "_"
-
-# Default frame padding when auto-added for multi-frame ranges
-_DEFAULT_FRAME_PADDING = "####"
-
-
-def is_single_frame(frame_range: str) -> bool:
-    """
-    Check if a frame range string represents a single frame.
-
-    :param frame_range: frame range string (e.g., "5", "1-10", "1,3,5")
-    :returns: True if the range is a single frame
-    """
-    return bool(frame_range) and "-" not in frame_range and "," not in frame_range
+# Single source of truth for supported tokens and their descriptions.
+# Add new tokens here — the UI tooltip and replacement logic both read from this.
+SUPPORTED_TOKENS: dict[str, str] = {
+    "<camera>": "Scene camera name (e.g., Camera001, RenderCam)",
+    "<stateset>": "State set name",
+    "<scene>": "Scene file name (without extension)",
+}
 
 
-def ensure_frame_padding(pattern: str, frame_range: str) -> str:
-    """
-    Ensure the output filename pattern has appropriate frame padding.
-
-    If the frame range is a single frame, any existing # padding is stripped.
-    If the frame range is multiple frames and no # padding exists, #### is appended.
-
-    :param pattern: the output filename pattern
-    :param frame_range: the frame range string (e.g., "0", "1-10", "1,3,5-12")
-    :returns: the pattern with appropriate frame padding
-    """
-    has_padding = "#" in pattern
-
-    if is_single_frame(frame_range):
-        # Single frame — strip any # padding
-        if has_padding:
-            pattern = pattern.rstrip("#").rstrip(_DELIMITER)
-        return pattern
-    else:
-        # Multi-frame — ensure padding exists
-        if not has_padding:
-            return f"{pattern}{_DELIMITER}{_DEFAULT_FRAME_PADDING}"
-        return pattern
+def get_tokens_tooltip() -> str:
+    """Build a tooltip string describing all supported tokens."""
+    lines = ["Available tokens:"]
+    for token, desc in SUPPORTED_TOKENS.items():
+        lines.append(f"  {token}  — {desc}")
+    lines.append("")
+    lines.append("Everything else is literal text.")
+    lines.append("Remove a token to exclude it from the filename.")
+    lines.append("Examples:")
+    lines.append("  <camera>_<stateset>_<scene>_###")
+    lines.append("  <camera>_<stateset>_myRender_###")
+    lines.append("  <scene>_###")
+    lines.append("  myScene_###")
+    return "\n".join(lines)
 
 
 def format_output_filename(
@@ -64,9 +41,8 @@ def format_output_filename(
     """
     Resolve an output filename from a token pattern.
 
-    Replaces <camera>, <stateset>, and <scene> tokens with actual values,
-    then cleans up double underscores and leading/trailing underscores
-    that result from empty token values.
+    Replaces <camera>, <stateset>, and <scene> tokens with their actual values.
+    No additional cleanup is performed — what you see is what you get.
 
     Examples:
         >>> format_output_filename(
@@ -77,12 +53,7 @@ def format_output_filename(
         >>> format_output_filename(
         ...     "<camera>_<stateset>_<scene>_###",
         ...     camera_name="", state_set_name="", scene_name="myScene")
-        'myScene_###'
-
-        >>> format_output_filename(
-        ...     "<camera>_<stateset>_myRender_###",
-        ...     camera_name="RenderCam", state_set_name="DayLight")
-        'RenderCam_DayLight_myRender_###'
+        '__myScene_###'
 
         >>> format_output_filename("myRender_###")
         'myRender_###'
@@ -100,13 +71,5 @@ def format_output_filename(
     result = result.replace("<camera>", camera_name)
     result = result.replace("<stateset>", state_set_name)
     result = result.replace("<scene>", scene_name)
-
-    # Collapse runs of the delimiter into a single delimiter
-    double = _DELIMITER + _DELIMITER
-    while double in result:
-        result = result.replace(double, _DELIMITER)
-
-    # Strip leading/trailing delimiters
-    result = result.strip(_DELIMITER)
 
     return result

--- a/src/deadline/max_shared/utilities/filename_utils.py
+++ b/src/deadline/max_shared/utilities/filename_utils.py
@@ -1,0 +1,112 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Shared output filename utilities for Deadline Cloud 3ds Max integration.
+
+Provides token-based output filename formatting.
+
+Supported tokens:
+    <camera>   — Scene camera name (e.g., "Camera001", "RenderCam")
+    <stateset> — State Set name (e.g., "DayLight", "NightTime")
+    <scene>    — Scene file name without extension (e.g., "myScene")
+
+Everything else in the pattern is literal text (base name, frame padding, delimiters).
+"""
+
+# Hardcoded delimiter for cleanup
+_DELIMITER = "_"
+
+# Default frame padding when auto-added for multi-frame ranges
+_DEFAULT_FRAME_PADDING = "####"
+
+
+def is_single_frame(frame_range: str) -> bool:
+    """
+    Check if a frame range string represents a single frame.
+
+    :param frame_range: frame range string (e.g., "5", "1-10", "1,3,5")
+    :returns: True if the range is a single frame
+    """
+    return bool(frame_range) and "-" not in frame_range and "," not in frame_range
+
+
+def ensure_frame_padding(pattern: str, frame_range: str) -> str:
+    """
+    Ensure the output filename pattern has appropriate frame padding.
+
+    If the frame range is a single frame, any existing # padding is stripped.
+    If the frame range is multiple frames and no # padding exists, #### is appended.
+
+    :param pattern: the output filename pattern
+    :param frame_range: the frame range string (e.g., "0", "1-10", "1,3,5-12")
+    :returns: the pattern with appropriate frame padding
+    """
+    has_padding = "#" in pattern
+
+    if is_single_frame(frame_range):
+        # Single frame — strip any # padding
+        if has_padding:
+            pattern = pattern.rstrip("#").rstrip(_DELIMITER)
+        return pattern
+    else:
+        # Multi-frame — ensure padding exists
+        if not has_padding:
+            return f"{pattern}{_DELIMITER}{_DEFAULT_FRAME_PADDING}"
+        return pattern
+
+
+def format_output_filename(
+    pattern: str,
+    camera_name: str = "",
+    state_set_name: str = "",
+    scene_name: str = "",
+) -> str:
+    """
+    Resolve an output filename from a token pattern.
+
+    Replaces <camera>, <stateset>, and <scene> tokens with actual values,
+    then cleans up double underscores and leading/trailing underscores
+    that result from empty token values.
+
+    Examples:
+        >>> format_output_filename(
+        ...     "<camera>_<stateset>_<scene>_###",
+        ...     camera_name="RenderCam", state_set_name="DayLight", scene_name="myScene")
+        'RenderCam_DayLight_myScene_###'
+
+        >>> format_output_filename(
+        ...     "<camera>_<stateset>_<scene>_###",
+        ...     camera_name="", state_set_name="", scene_name="myScene")
+        'myScene_###'
+
+        >>> format_output_filename(
+        ...     "<camera>_<stateset>_myRender_###",
+        ...     camera_name="RenderCam", state_set_name="DayLight")
+        'RenderCam_DayLight_myRender_###'
+
+        >>> format_output_filename("myRender_###")
+        'myRender_###'
+
+    :param pattern: the full filename pattern with optional tokens
+    :param camera_name: the scene camera name, or "" if not applicable
+    :param state_set_name: the state set name, or "" if not applicable
+    :param scene_name: the scene file name (no extension), or "" if not applicable
+    :returns: the resolved filename string
+    """
+    if not pattern:
+        return ""
+
+    result = pattern
+    result = result.replace("<camera>", camera_name)
+    result = result.replace("<stateset>", state_set_name)
+    result = result.replace("<scene>", scene_name)
+
+    # Collapse runs of the delimiter into a single delimiter
+    double = _DELIMITER + _DELIMITER
+    while double in result:
+        result = result.replace(double, _DELIMITER)
+
+    # Strip leading/trailing delimiters
+    result = result.strip(_DELIMITER)
+
+    return result

--- a/src/deadline/max_submitter/create_job_bundle.py
+++ b/src/deadline/max_submitter/create_job_bundle.py
@@ -573,6 +573,7 @@ def _get_job_parameters(
     possible_multiples = [
         ["frame_range", "Frames"],
         ["output_file_dir", "OutputFilePath"],
+        ["output_file_name", "OutputFileName"],
         ["output_file_format", "OutputFileFormat"],
     ]
     for possible_multiple in possible_multiples:

--- a/src/deadline/max_submitter/data_classes.py
+++ b/src/deadline/max_submitter/data_classes.py
@@ -90,6 +90,16 @@ class RenderSubmitterUISettings:
     output_ext_list: list[str] = field(default_factory=list)
     output_ext: str = field(default=".jpg", metadata={"sticky": True})
 
+    # Output Filename Pattern (replaces output_name for filename composition)
+    # The full output filename with optional <camera>, <stateset>, and <scene> tokens.
+    # Everything else is literal text (base name, frame padding, delimiters).
+    output_filename_pattern: str = field(
+        default="<camera>_<stateset>_<scene>_###", metadata={"sticky": True}
+    )
+
+    # Tracks rt.rendOutputFilename at last save, used to detect external changes
+    last_rend_output_filename: str = field(default="", metadata={"sticky": True})
+
     renderer: str = field(default="")
     state_set: str = field(default="")
     state_set_index: str = field(default="")

--- a/src/deadline/max_submitter/data_classes.py
+++ b/src/deadline/max_submitter/data_classes.py
@@ -90,15 +90,11 @@ class RenderSubmitterUISettings:
     output_ext_list: list[str] = field(default_factory=list)
     output_ext: str = field(default=".jpg", metadata={"sticky": True})
 
-    # Output Filename Pattern (replaces output_name for filename composition)
     # The full output filename with optional <camera>, <stateset>, and <scene> tokens.
     # Everything else is literal text (base name, frame padding, delimiters).
     output_filename_pattern: str = field(
         default="<camera>_<stateset>_<scene>_###", metadata={"sticky": True}
     )
-
-    # Tracks rt.rendOutputFilename at last save, used to detect external changes
-    last_rend_output_filename: str = field(default="", metadata={"sticky": True})
 
     renderer: str = field(default="")
     state_set: str = field(default="")

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -28,7 +28,6 @@ from deadline.client.ui.dialogs._types import JobBundlePurpose
 from pymxs import runtime as rt
 from qtpy.QtCore import Qt  # type: ignore
 from sanity_checks import check_sanity
-from deadline.max_shared.utilities.filename_utils import ensure_frame_padding
 from ui.scene_settings_tab import SceneSettingsWidget
 from ui.submit_dialog import SubmitMaxJobToDeadlineDialog
 from utilities import max_utils, submission_utils
@@ -94,20 +93,9 @@ def on_create_job_bundle_callback(
                 f"needState = masterState.Children.Item[{state_set[1]}] \n"
                 f"masterState.CurrentState = #(needState)"
             )
-            # Check if an output directory is set in render setup dialog
-            if rt.rendOutputFilename:
-                output_dir = os.path.split(rt.rendOutputFilename)[0]
-                output_file = os.path.split(rt.rendOutputFilename)[1]
-                output_file_name = settings.output_filename_pattern
-                # Use UI override if provided, otherwise fall back to render setup extension
-                output_file_format = (
-                    settings.output_ext if settings.output_ext else os.path.splitext(output_file)[1]
-                )
-            # If it isn't, use the UI fields data
-            else:
-                output_dir = settings.output_path
-                output_file_name = settings.output_filename_pattern
-                output_file_format = settings.output_ext
+            output_dir = settings.output_path
+            output_file_name = settings.output_filename_pattern
+            output_file_format = settings.output_ext
             image_resolution = (rt.renderWidth, rt.renderHeight)
 
             state_sets_to_submit.append(
@@ -136,20 +124,9 @@ def on_create_job_bundle_callback(
             f"needState = masterState.Children.Item[{need_state}]\n"
             f"masterState.CurrentState = #(needState)"
         )
-        # Check if an output directory is set in render setup dialog
-        if rt.rendOutputFilename:
-            output_dir = os.path.split(rt.rendOutputFilename)[0]
-            output_file = os.path.split(rt.rendOutputFilename)[1]
-            output_file_name = settings.output_filename_pattern
-            # Use UI override if provided, otherwise fall back to render setup extension
-            output_file_format = (
-                settings.output_ext if settings.output_ext else os.path.splitext(output_file)[1]
-            )
-        # If it isn't, use the UI fields data
-        else:
-            output_dir = settings.output_path
-            output_file_name = settings.output_filename_pattern
-            output_file_format = settings.output_ext
+        output_dir = settings.output_path
+        output_file_name = settings.output_filename_pattern
+        output_file_format = settings.output_ext
         image_resolution = (rt.renderWidth, rt.renderHeight)
 
         state_sets_to_submit.append(
@@ -170,12 +147,6 @@ def on_create_job_bundle_callback(
     if settings.override_frame_range:
         for state_set in state_sets_to_submit:
             state_set.frame_range = settings.frame_list
-
-    # Auto-adjust frame padding: strip for single frame, add for multi-frame
-    for state_set in state_sets_to_submit:
-        state_set.output_file_name = ensure_frame_padding(
-            state_set.output_file_name, state_set.frame_range
-        )
 
     # Add render element output directories to output_directories set
     if settings.render_elements and not settings.ignore_render_elements_by_name:
@@ -260,7 +231,6 @@ def on_create_job_bundle_callback(
     settings.input_filenames = sorted(attachments.input_filenames)
 
     # Save sticky settings
-    settings.last_rend_output_filename = str(rt.rendOutputFilename or "")
     settings.save_sticky_settings()
 
 
@@ -293,15 +263,6 @@ def show_job_bundle_submitter():
 
     render_settings.load_sticky_settings()
 
-    # Only override sticky pattern if render output changed since last save
-    current_rend_output = str(rt.rendOutputFilename or "")
-    if current_rend_output and current_rend_output != render_settings.last_rend_output_filename:
-        output_path, output_name, output_ext = max_utils.get_render_output_info()
-        render_settings.output_path = output_path
-        render_settings.output_filename_pattern = f"<camera>_<stateset>_{output_name}"
-        if output_ext:
-            render_settings.output_ext = output_ext
-
     output_directories: set[str] = set()
 
     # Add output dir from state set settings if one is set
@@ -317,8 +278,8 @@ def show_job_bundle_submitter():
             f"masterState.CurrentState = #(needState)"
         )
         if rt.rendOutputFilename:
-            output = os.path.split(rt.rendOutputFilename)
-            output_directories.update([output[0]])
+            output_dir, _, _ = max_utils.get_render_output_info()
+            output_directories.update([output_dir])
     output_directories.update([render_settings.output_path])
 
     # Add render element output directories if render elements are enabled

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -28,6 +28,7 @@ from deadline.client.ui.dialogs._types import JobBundlePurpose
 from pymxs import runtime as rt
 from qtpy.QtCore import Qt  # type: ignore
 from sanity_checks import check_sanity
+from deadline.max_shared.utilities.filename_utils import ensure_frame_padding
 from ui.scene_settings_tab import SceneSettingsWidget
 from ui.submit_dialog import SubmitMaxJobToDeadlineDialog
 from utilities import max_utils, submission_utils
@@ -97,7 +98,7 @@ def on_create_job_bundle_callback(
             if rt.rendOutputFilename:
                 output_dir = os.path.split(rt.rendOutputFilename)[0]
                 output_file = os.path.split(rt.rendOutputFilename)[1]
-                output_file_name = Path(output_file).stem
+                output_file_name = settings.output_filename_pattern
                 # Use UI override if provided, otherwise fall back to render setup extension
                 output_file_format = (
                     settings.output_ext if settings.output_ext else os.path.splitext(output_file)[1]
@@ -105,7 +106,7 @@ def on_create_job_bundle_callback(
             # If it isn't, use the UI fields data
             else:
                 output_dir = settings.output_path
-                output_file_name = state_set[0] + "_" + settings.output_name
+                output_file_name = settings.output_filename_pattern
                 output_file_format = settings.output_ext
             image_resolution = (rt.renderWidth, rt.renderHeight)
 
@@ -139,7 +140,7 @@ def on_create_job_bundle_callback(
         if rt.rendOutputFilename:
             output_dir = os.path.split(rt.rendOutputFilename)[0]
             output_file = os.path.split(rt.rendOutputFilename)[1]
-            output_file_name = Path(output_file).stem
+            output_file_name = settings.output_filename_pattern
             # Use UI override if provided, otherwise fall back to render setup extension
             output_file_format = (
                 settings.output_ext if settings.output_ext else os.path.splitext(output_file)[1]
@@ -147,7 +148,7 @@ def on_create_job_bundle_callback(
         # If it isn't, use the UI fields data
         else:
             output_dir = settings.output_path
-            output_file_name = settings.output_name
+            output_file_name = settings.output_filename_pattern
             output_file_format = settings.output_ext
         image_resolution = (rt.renderWidth, rt.renderHeight)
 
@@ -169,6 +170,12 @@ def on_create_job_bundle_callback(
     if settings.override_frame_range:
         for state_set in state_sets_to_submit:
             state_set.frame_range = settings.frame_list
+
+    # Auto-adjust frame padding: strip for single frame, add for multi-frame
+    for state_set in state_sets_to_submit:
+        state_set.output_file_name = ensure_frame_padding(
+            state_set.output_file_name, state_set.frame_range
+        )
 
     # Add render element output directories to output_directories set
     if settings.render_elements and not settings.ignore_render_elements_by_name:
@@ -253,6 +260,7 @@ def on_create_job_bundle_callback(
     settings.input_filenames = sorted(attachments.input_filenames)
 
     # Save sticky settings
+    settings.last_rend_output_filename = str(rt.rendOutputFilename or "")
     settings.save_sticky_settings()
 
 
@@ -270,12 +278,29 @@ def show_job_bundle_submitter():
     render_settings.name = max_utils.get_scene_name()
     render_settings.frame_list = max_utils.get_frames()
     render_settings.project_path = max_utils.get_scene_path()
-    render_settings.output_path = max_utils.get_scene_dir()
-    render_settings.output_name = max_utils.get_scene_name() + "_###"
+
+    # set output settings from renderer
+    output_path, output_name, output_ext = max_utils.get_render_output_info()
+    render_settings.output_path = output_path
+    render_settings.output_name = output_name
+    # Build default pattern from render settings
+    render_settings.output_filename_pattern = f"<camera>_<stateset>_{output_name}"
+    if output_ext:
+        render_settings.output_ext = output_ext
+
     render_settings.backup_file = rt.execute("GetDir #temp") + "\\" + TEMP_BACKUP_FILENAME
     render_settings.renderer = str(rt.renderers.current).split(":")[0]
 
     render_settings.load_sticky_settings()
+
+    # Only override sticky pattern if render output changed since last save
+    current_rend_output = str(rt.rendOutputFilename or "")
+    if current_rend_output and current_rend_output != render_settings.last_rend_output_filename:
+        output_path, output_name, output_ext = max_utils.get_render_output_info()
+        render_settings.output_path = output_path
+        render_settings.output_filename_pattern = f"<camera>_<stateset>_{output_name}"
+        if output_ext:
+            render_settings.output_ext = output_ext
 
     output_directories: set[str] = set()
 

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -122,6 +122,9 @@ class SceneSettingsWidget(QWidget):
         rt.callbacks.addScript(rt.Name("postRendererChange"), "pyCallback()")
         QApplication.instance().focusChanged.connect(self.on_focus_changed)
 
+        # Track render output filename to detect changes from Render Setup dialog
+        self._last_rend_output_filename = str(rt.rendOutputFilename or "")
+
     def _build_ui(self, settings):
         """
         Function that creates all the Qt UI elements for the job specific settings tab
@@ -139,10 +142,9 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(QLabel("Output Path"), 1, 0)
         lyt.addWidget(self.output_path_txt, 1, 1)
 
-        # Output filename
-        self.output_name_txt = QLineEdit(self)
-        lyt.addWidget(QLabel("Output Filename"), 2, 0)
-        lyt.addWidget(self.output_name_txt, 2, 1)
+        # Output filename settings (pattern + preview)
+        self._build_output_filename_settings_ui()
+        lyt.addWidget(self.output_filename_grp_box, 2, 0, 1, 2)
 
         # Output extension
         self.output_ext_box = QComboBox(self)
@@ -162,6 +164,7 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(QLabel("State Sets"), 4, 0)
         lyt.addWidget(self.state_sets_box, 4, 1)
         (self.state_sets_box.currentIndexChanged.connect(self._update_state_set))
+        self.state_sets_box.currentIndexChanged.connect(lambda _: self._update_filename_preview())
 
         # Renderer
         self.renderers_box = QComboBox(self)
@@ -205,6 +208,7 @@ class SceneSettingsWidget(QWidget):
         self.cameras_box = QComboBox(self)
         lyt.addWidget(QLabel("Cameras To Render"), 7, 0)
         lyt.addWidget(self.cameras_box, 7, 1)
+        self.cameras_box.currentIndexChanged.connect(lambda _: self._update_filename_preview())
 
         # Override frame range
         self.frame_override_chck = QCheckBox("Override Frame Range", self)
@@ -290,6 +294,82 @@ class SceneSettingsWidget(QWidget):
         for mat in SCENE_TWEAKS_MATS:
             self.custom_mat_box.addItem(mat, mat)
         scene_tweaks_lyt.addWidget(self.custom_mat_box, 3, 1)
+
+    def _build_output_filename_settings_ui(self):
+        """
+        Create a QGroupBox for the output filename pattern settings.
+        Replaces the old "Output Filename" QLineEdit.
+        """
+        self.output_filename_grp_box = QGroupBox()
+        self.output_filename_grp_box.setTitle("Output Filename Settings")
+        fn_lyt = QGridLayout(self)
+        self.output_filename_grp_box.setLayout(fn_lyt)
+
+        # Filename Pattern
+        self.output_filename_pattern_txt = QLineEdit(self)
+        self.output_filename_pattern_txt.setToolTip(
+            "Available tokens:\n"
+            "  <camera>   — Scene camera name (e.g., Camera001, RenderCam)\n"
+            "  <stateset> — State set name\n"
+            "  <scene>    — Scene file name (without extension)\n\n"
+            "Everything else is literal text.\n"
+            "Remove a token to exclude it from the filename.\n"
+            "Examples:\n"
+            "  <camera>_<stateset>_<scene>_###\n"
+            "  <camera>_<stateset>_myRender_###\n"
+            "  <scene>_###\n"
+            "  myScene_###"
+        )
+        fn_lyt.addWidget(QLabel("Filename Pattern"), 0, 0)
+        fn_lyt.addWidget(self.output_filename_pattern_txt, 0, 1)
+        self.output_filename_pattern_txt.textChanged.connect(self._update_filename_preview)
+
+        # Filename Preview
+        self.filename_preview_label = QLabel(self)
+        self.filename_preview_label.setStyleSheet("color: gray; font-style: italic;")
+        self.filename_preview_label.setToolTip("Preview of the resolved output filename")
+        fn_lyt.addWidget(QLabel("Filename Preview"), 1, 0)
+        fn_lyt.addWidget(self.filename_preview_label, 1, 1)
+
+    def _update_filename_preview(self):
+        """
+        Update the filename preview label based on current UI values.
+        """
+        from deadline.max_shared.utilities.filename_utils import format_output_filename
+        from deadline.max_submitter.data_const import ALL_CAMERAS_STR, ALL_STEREO_CAMERAS_STR
+
+        pattern = self.output_filename_pattern_txt.text()
+
+        # Get state set name from current selection
+        state_set_text = self.state_sets_box.currentText()
+        state_set_name = "" if state_set_text == "All State Sets" else state_set_text
+
+        # For "All State Sets", show first state set as example if available
+        if state_set_text == "All State Sets" and self.state_sets:
+            state_set_name = self.state_sets[0][0]
+
+        # Get camera name from current selection
+        camera_data = self.cameras_box.currentData()
+        is_all_cameras = camera_data in (ALL_CAMERAS_STR, ALL_STEREO_CAMERAS_STR)
+
+        if is_all_cameras and hasattr(self, "cameras") and self.cameras:
+            camera_name = self.cameras[0]
+        elif not is_all_cameras and camera_data:
+            camera_name = camera_data
+        else:
+            camera_name = ""
+
+        # Get scene name
+        scene_name = max_utils.get_scene_name()
+
+        preview = format_output_filename(
+            pattern=pattern,
+            camera_name=camera_name,
+            state_set_name=state_set_name,
+            scene_name=scene_name,
+        )
+
+        self.filename_preview_label.setText(preview)
 
     def _on_render_elements_validation_changed(self, warnings):
         """
@@ -416,13 +496,26 @@ class SceneSettingsWidget(QWidget):
     def on_focus_changed(self, old_widget, new_widget):
         """
         Event handler for when the active widget changes.
-        Checks for valid frame range in frame_override_txt QLineEdit.
+        Checks if the render output filename changed in Render Setup,
+        and validates frame range in frame_override_txt QLineEdit.
 
         :param old_widget: widget that lost focus
         :type old_widget: any QWidget
         :param new_widget: widget that gained focus
         :type new_widget: any QWidget
         """
+        # Check if render output filename changed in Render Setup dialog
+        current_rend_output = str(rt.rendOutputFilename or "")
+        if current_rend_output != self._last_rend_output_filename:
+            self._last_rend_output_filename = current_rend_output
+            output_path, output_name, output_ext = max_utils.get_render_output_info()
+            self.output_path_txt.setText(output_path)
+            self.output_filename_pattern_txt.setText(f"<camera>_<stateset>_{output_name}")
+            if output_ext:
+                index = self.output_ext_box.findData(output_ext)
+                if index >= 0:
+                    self.output_ext_box.setCurrentIndex(index)
+
         if self.frame_override_txt is not old_widget:
             return
 
@@ -471,7 +564,7 @@ class SceneSettingsWidget(QWidget):
         settings.renderer = str(rt.renderers.current).split(":")[0]
         self.proj_path_txt.setText(settings.project_path)
         self.output_path_txt.setText(settings.output_path)
-        self.output_name_txt.setText(settings.output_name)
+        self.output_filename_pattern_txt.setText(settings.output_filename_pattern)
         self.frame_override_chck.setChecked(settings.override_frame_range)
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)
@@ -519,7 +612,8 @@ class SceneSettingsWidget(QWidget):
         """
         settings.project_path = self.proj_path_txt.text()
         settings.output_path = self.output_path_txt.text()
-        settings.output_name = self.output_name_txt.text()
+        settings.output_name = self.output_filename_pattern_txt.text()
+        settings.output_filename_pattern = self.output_filename_pattern_txt.text()
         settings.output_ext = self.output_ext_box.currentData()
 
         settings.override_frame_range = self.frame_override_chck.isChecked()

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -9,12 +9,15 @@ import os
 
 import pymxs  # noqa
 from deadline.max_submitter.data_const import (
+    ALL_CAMERAS_STR,
     ALL_STATE_SETS_STR,
+    ALL_STEREO_CAMERAS_STR,
     ALLOWED_EXTENSIONS,
     ALLOWED_RENDERERS,
     SCENE_TWEAKS_MATS,
     STEREO_CAMERA_OPTIONS,
 )
+from deadline.max_shared.utilities.filename_utils import format_output_filename, get_tokens_tooltip
 from deadline.client.ui import block_signals
 from pymxs import runtime as rt
 from qtpy.QtCore import QRegularExpression, QSize, Qt  # type: ignore
@@ -121,9 +124,6 @@ class SceneSettingsWidget(QWidget):
         rt.pyCallback = self._update_renderer
         rt.callbacks.addScript(rt.Name("postRendererChange"), "pyCallback()")
         QApplication.instance().focusChanged.connect(self.on_focus_changed)
-
-        # Track render output filename to detect changes from Render Setup dialog
-        self._last_rend_output_filename = str(rt.rendOutputFilename or "")
 
     def _build_ui(self, settings):
         """
@@ -298,7 +298,9 @@ class SceneSettingsWidget(QWidget):
     def _build_output_filename_settings_ui(self):
         """
         Create a QGroupBox for the output filename pattern settings.
-        Replaces the old "Output Filename" QLineEdit.
+        Output filename settings shows a token-based
+        pattern field and a live preview label, allowing users
+        to customize filenames according to scene tokens
         """
         self.output_filename_grp_box = QGroupBox()
         self.output_filename_grp_box.setTitle("Output Filename Settings")
@@ -307,19 +309,7 @@ class SceneSettingsWidget(QWidget):
 
         # Filename Pattern
         self.output_filename_pattern_txt = QLineEdit(self)
-        self.output_filename_pattern_txt.setToolTip(
-            "Available tokens:\n"
-            "  <camera>   — Scene camera name (e.g., Camera001, RenderCam)\n"
-            "  <stateset> — State set name\n"
-            "  <scene>    — Scene file name (without extension)\n\n"
-            "Everything else is literal text.\n"
-            "Remove a token to exclude it from the filename.\n"
-            "Examples:\n"
-            "  <camera>_<stateset>_<scene>_###\n"
-            "  <camera>_<stateset>_myRender_###\n"
-            "  <scene>_###\n"
-            "  myScene_###"
-        )
+        self.output_filename_pattern_txt.setToolTip(get_tokens_tooltip())
         fn_lyt.addWidget(QLabel("Filename Pattern"), 0, 0)
         fn_lyt.addWidget(self.output_filename_pattern_txt, 0, 1)
         self.output_filename_pattern_txt.textChanged.connect(self._update_filename_preview)
@@ -327,7 +317,7 @@ class SceneSettingsWidget(QWidget):
         # Filename Preview
         self.filename_preview_label = QLabel(self)
         self.filename_preview_label.setStyleSheet("color: gray; font-style: italic;")
-        self.filename_preview_label.setToolTip("Preview of the resolved output filename")
+        self.filename_preview_label.setToolTip("Example preview of the resolved output filename")
         fn_lyt.addWidget(QLabel("Filename Preview"), 1, 0)
         fn_lyt.addWidget(self.filename_preview_label, 1, 1)
 
@@ -335,8 +325,6 @@ class SceneSettingsWidget(QWidget):
         """
         Update the filename preview label based on current UI values.
         """
-        from deadline.max_shared.utilities.filename_utils import format_output_filename
-        from deadline.max_submitter.data_const import ALL_CAMERAS_STR, ALL_STEREO_CAMERAS_STR
 
         pattern = self.output_filename_pattern_txt.text()
 
@@ -496,25 +484,13 @@ class SceneSettingsWidget(QWidget):
     def on_focus_changed(self, old_widget, new_widget):
         """
         Event handler for when the active widget changes.
-        Checks if the render output filename changed in Render Setup,
-        and validates frame range in frame_override_txt QLineEdit.
+        Validates frame range in frame_override_txt QLineEdit.
 
         :param old_widget: widget that lost focus
         :type old_widget: any QWidget
         :param new_widget: widget that gained focus
         :type new_widget: any QWidget
         """
-        # Check if render output filename changed in Render Setup dialog
-        current_rend_output = str(rt.rendOutputFilename or "")
-        if current_rend_output != self._last_rend_output_filename:
-            self._last_rend_output_filename = current_rend_output
-            output_path, output_name, output_ext = max_utils.get_render_output_info()
-            self.output_path_txt.setText(output_path)
-            self.output_filename_pattern_txt.setText(f"<camera>_<stateset>_{output_name}")
-            if output_ext:
-                index = self.output_ext_box.findData(output_ext)
-                if index >= 0:
-                    self.output_ext_box.setCurrentIndex(index)
 
         if self.frame_override_txt is not old_widget:
             return

--- a/src/deadline/max_submitter/utilities/max_utils.py
+++ b/src/deadline/max_submitter/utilities/max_utils.py
@@ -333,3 +333,21 @@ def get_state_set_names() -> list:
     for i in range(-1, master_state.Children.count - 2):
         state_sets.append([master_state.Children.Item[i].Name, i + 1])
     return state_sets
+
+
+def get_render_output_info() -> tuple[str, str, str]:
+    """
+    Gets render output information from 3ds Max render settings.
+
+    :returns: tuple of (output_path, output_name, output_ext)
+              If no render output is set, returns scene-based defaults
+    """
+    if rt.rendOutputFilename:
+        output_dir = os.path.split(rt.rendOutputFilename)[0]
+        output_file = os.path.split(rt.rendOutputFilename)[1]
+        output_name = Path(output_file).stem
+        output_ext = os.path.splitext(output_file)[1]
+        return output_dir.replace("\\", "/"), output_name, output_ext
+    else:
+        # Fall back to default scene-based naming
+        return get_scene_dir(), get_scene_name() + "_###", ""

--- a/src/deadline/max_submitter/utilities/max_utils.py
+++ b/src/deadline/max_submitter/utilities/max_utils.py
@@ -343,11 +343,8 @@ def get_render_output_info() -> tuple[str, str, str]:
               If no render output is set, returns scene-based defaults
     """
     if rt.rendOutputFilename:
-        output_dir = os.path.split(rt.rendOutputFilename)[0]
-        output_file = os.path.split(rt.rendOutputFilename)[1]
-        output_name = Path(output_file).stem
-        output_ext = os.path.splitext(output_file)[1]
-        return output_dir.replace("\\", "/"), output_name, output_ext
+        output_path = Path(rt.rendOutputFilename)
+        return str(output_path.parent), output_path.stem, output_path.suffix
     else:
         # Fall back to default scene-based naming
         return get_scene_dir(), get_scene_name() + "_###", ""

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_max_handler_base.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_max_handler_base.py
@@ -117,6 +117,23 @@ class TestDefaultMaxHandler:
         # WHEN/THEN - Should not raise exception
         maxhandlerbase.cleanup_render_elements(data)
 
+    @pytest.mark.parametrize(
+        "name,number,expected",
+        [
+            # With hash padding — zero-padded frame number replaces hashes
+            ("output_#####", 1, "output_00001"),
+            ("output_####", 42, "output_0042"),
+            ("output_###", 100, "output_100"),
+            # No hashes — return name as-is (single-frame, no numbering needed)
+            ("output", 0, "output"),
+            ("output", 7, "output"),
+        ],
+    )
+    def test_reformat_framenumber_padding(
+        self, maxhandlerbase: DefaultMaxHandler, name: str, number: int, expected: str
+    ) -> None:
+        assert maxhandlerbase.reformat_framenumber_padding(name, number) == expected
+
     def test_cleanup_render_elements_not_configured(self, maxhandlerbase: DefaultMaxHandler):
         """Tests that cleanup_render_elements handles unconfigured render elements gracefully"""
         # GIVEN

--- a/test/unit/deadline_shared_for_3ds_max/test_filename_utils.py
+++ b/test/unit/deadline_shared_for_3ds_max/test_filename_utils.py
@@ -1,0 +1,120 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for deadline.max_shared.utilities.filename_utils
+
+Covers the new output filename token formatting and frame padding logic
+added in the "fix: incorrect output filenames" commit.
+"""
+
+import pytest
+
+from deadline.max_shared.utilities.filename_utils import (
+    ensure_frame_padding,
+    format_output_filename,
+    is_single_frame,
+)
+
+
+# ============================================================================
+# is_single_frame
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "frame_range,expected",
+    [
+        ("0", True),
+        ("5", True),
+        ("100", True),
+        ("1-10", False),
+        ("1,3,5", False),
+        ("1,3,5-12", False),
+        ("", False),
+    ],
+)
+def test_is_single_frame(frame_range: str, expected: bool) -> None:
+    assert is_single_frame(frame_range) is expected
+
+
+# ============================================================================
+# ensure_frame_padding
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "pattern,frame_range,expected",
+    [
+        # Single frame — strip padding
+        ("myRender_####", "0", "myRender"),
+        ("myRender_###", "5", "myRender"),
+        # Single frame — no padding to strip
+        ("myRender", "0", "myRender"),
+        # Multi-frame — padding already present
+        ("myRender_####", "1-10", "myRender_####"),
+        ("myRender_###", "1,3,5", "myRender_###"),
+        # Multi-frame — padding auto-added
+        ("myRender", "1-10", "myRender_####"),
+        ("myRender", "0,5,10", "myRender_####"),
+    ],
+)
+def test_ensure_frame_padding(pattern: str, frame_range: str, expected: str) -> None:
+    assert ensure_frame_padding(pattern, frame_range) == expected
+
+
+# ============================================================================
+# format_output_filename
+# ============================================================================
+
+
+class TestFormatOutputFilename:
+    def test_all_tokens_filled(self) -> None:
+        result = format_output_filename(
+            "<camera>_<stateset>_<scene>_###",
+            camera_name="RenderCam",
+            state_set_name="DayLight",
+            scene_name="myScene",
+        )
+        assert result == "RenderCam_DayLight_myScene_###"
+
+    def test_empty_tokens_cleaned_up(self) -> None:
+        """Empty tokens should not leave double underscores or leading/trailing underscores."""
+        result = format_output_filename(
+            "<camera>_<stateset>_<scene>_###",
+            camera_name="",
+            state_set_name="",
+            scene_name="myScene",
+        )
+        assert result == "myScene_###"
+
+    def test_no_tokens(self) -> None:
+        result = format_output_filename("myRender_###")
+        assert result == "myRender_###"
+
+    def test_partial_tokens(self) -> None:
+        result = format_output_filename(
+            "<camera>_<stateset>_myRender_###",
+            camera_name="RenderCam",
+            state_set_name="DayLight",
+        )
+        assert result == "RenderCam_DayLight_myRender_###"
+
+    def test_only_camera(self) -> None:
+        result = format_output_filename(
+            "<camera>_<stateset>_<scene>_###",
+            camera_name="Cam1",
+        )
+        assert result == "Cam1_###"
+
+    def test_empty_pattern(self) -> None:
+        assert format_output_filename("") == ""
+
+    def test_all_tokens_empty(self) -> None:
+        """All tokens empty should still return the literal parts."""
+        result = format_output_filename(
+            "<camera>_<stateset>_<scene>_###",
+            camera_name="",
+            state_set_name="",
+            scene_name="",
+        )
+        assert result == "###"

--- a/test/unit/deadline_shared_for_3ds_max/test_filename_utils.py
+++ b/test/unit/deadline_shared_for_3ds_max/test_filename_utils.py
@@ -3,68 +3,42 @@
 """
 Tests for deadline.max_shared.utilities.filename_utils
 
-Covers the new output filename token formatting and frame padding logic
-added in the "fix: incorrect output filenames" commit.
+Covers the output filename token formatting.
 """
 
-import pytest
-
 from deadline.max_shared.utilities.filename_utils import (
-    ensure_frame_padding,
+    SUPPORTED_TOKENS,
     format_output_filename,
-    is_single_frame,
+    get_tokens_tooltip,
 )
 
 
-# ============================================================================
-# is_single_frame
-# ============================================================================
+class TestSupportedTokens:
+    def test_contains_expected_tokens(self) -> None:
+        assert "<camera>" in SUPPORTED_TOKENS
+        assert "<stateset>" in SUPPORTED_TOKENS
+        assert "<scene>" in SUPPORTED_TOKENS
+
+    def test_all_values_are_strings(self) -> None:
+        for token, desc in SUPPORTED_TOKENS.items():
+            assert isinstance(token, str)
+            assert isinstance(desc, str)
 
 
-@pytest.mark.parametrize(
-    "frame_range,expected",
-    [
-        ("0", True),
-        ("5", True),
-        ("100", True),
-        ("1-10", False),
-        ("1,3,5", False),
-        ("1,3,5-12", False),
-        ("", False),
-    ],
-)
-def test_is_single_frame(frame_range: str, expected: bool) -> None:
-    assert is_single_frame(frame_range) is expected
+class TestGetTokensTooltip:
+    def test_contains_all_tokens(self) -> None:
+        tooltip = get_tokens_tooltip()
+        for token in SUPPORTED_TOKENS:
+            assert token in tooltip
 
+    def test_contains_all_descriptions(self) -> None:
+        tooltip = get_tokens_tooltip()
+        for desc in SUPPORTED_TOKENS.values():
+            assert desc in tooltip
 
-# ============================================================================
-# ensure_frame_padding
-# ============================================================================
-
-
-@pytest.mark.parametrize(
-    "pattern,frame_range,expected",
-    [
-        # Single frame — strip padding
-        ("myRender_####", "0", "myRender"),
-        ("myRender_###", "5", "myRender"),
-        # Single frame — no padding to strip
-        ("myRender", "0", "myRender"),
-        # Multi-frame — padding already present
-        ("myRender_####", "1-10", "myRender_####"),
-        ("myRender_###", "1,3,5", "myRender_###"),
-        # Multi-frame — padding auto-added
-        ("myRender", "1-10", "myRender_####"),
-        ("myRender", "0,5,10", "myRender_####"),
-    ],
-)
-def test_ensure_frame_padding(pattern: str, frame_range: str, expected: str) -> None:
-    assert ensure_frame_padding(pattern, frame_range) == expected
-
-
-# ============================================================================
-# format_output_filename
-# ============================================================================
+    def test_starts_with_header(self) -> None:
+        tooltip = get_tokens_tooltip()
+        assert tooltip.startswith("Available tokens:")
 
 
 class TestFormatOutputFilename:
@@ -76,16 +50,6 @@ class TestFormatOutputFilename:
             scene_name="myScene",
         )
         assert result == "RenderCam_DayLight_myScene_###"
-
-    def test_empty_tokens_cleaned_up(self) -> None:
-        """Empty tokens should not leave double underscores or leading/trailing underscores."""
-        result = format_output_filename(
-            "<camera>_<stateset>_<scene>_###",
-            camera_name="",
-            state_set_name="",
-            scene_name="myScene",
-        )
-        assert result == "myScene_###"
 
     def test_no_tokens(self) -> None:
         result = format_output_filename("myRender_###")
@@ -100,21 +64,22 @@ class TestFormatOutputFilename:
         assert result == "RenderCam_DayLight_myRender_###"
 
     def test_only_camera(self) -> None:
+        """Only camera filled — other tokens become empty strings, delimiters remain."""
         result = format_output_filename(
             "<camera>_<stateset>_<scene>_###",
             camera_name="Cam1",
         )
-        assert result == "Cam1_###"
+        assert result == "Cam1___###"
 
     def test_empty_pattern(self) -> None:
         assert format_output_filename("") == ""
 
     def test_all_tokens_empty(self) -> None:
-        """All tokens empty should still return the literal parts."""
+        """All tokens empty — only literal delimiters and padding remain."""
         result = format_output_filename(
             "<camera>_<stateset>_<scene>_###",
             camera_name="",
             state_set_name="",
             scene_name="",
         )
-        assert result == "###"
+        assert result == "___###"

--- a/test/unit/deadline_submitter_for_3ds_max/test_data_classes.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_data_classes.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for deadline.max_submitter.data_classes
+
+Covers the changes made to RenderSubmitterUISettings:
+- output_filename_pattern field exists with correct default and sticky metadata
+- last_rend_output_filename field is removed
+"""
+
+import dataclasses
+
+from deadline.max_submitter.data_classes import RenderSubmitterUISettings
+
+
+class TestOutputFilenamePattern:
+    """Tests for the output_filename_pattern field."""
+
+    def test_field_exists(self) -> None:
+        settings = RenderSubmitterUISettings()
+        assert hasattr(settings, "output_filename_pattern")
+
+    def test_default_value(self) -> None:
+        settings = RenderSubmitterUISettings()
+        assert settings.output_filename_pattern == "<camera>_<stateset>_<scene>_###"
+
+    def test_is_sticky(self) -> None:
+        fields = {f.name: f for f in dataclasses.fields(RenderSubmitterUISettings)}
+        assert fields["output_filename_pattern"].metadata.get("sticky") is True
+
+
+class TestLastRendOutputFilenameRemoved:
+    """Verify that the removed field is no longer present."""
+
+    def test_no_last_rend_output_filename_field(self) -> None:
+        field_names = {f.name for f in dataclasses.fields(RenderSubmitterUISettings)}
+        assert "last_rend_output_filename" not in field_names
+
+    def test_no_last_rend_output_filename_attr(self) -> None:
+        settings = RenderSubmitterUISettings()
+        assert not hasattr(settings, "last_rend_output_filename")

--- a/test/unit/deadline_submitter_for_3ds_max/test_max_render_submitter.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_max_render_submitter.py
@@ -1,0 +1,76 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for deadline.max_submitter.max_render_submitter
+
+Covers the changes we made:
+- output_filename_pattern is used (not old output_name) in on_create_job_bundle_callback
+- get_render_output_info() is called instead of manual os.path.split in show_job_bundle_submitter
+- last_rend_output_filename is no longer saved in on_create_job_bundle_callback
+"""
+
+from pathlib import Path
+
+import pytest
+
+# max_render_submitter.py has bare imports (create_job_bundle, data_classes, etc.)
+# that only resolve inside 3ds Max's Python environment, so we can't import the module
+# in a normal test environment. Read the source file directly instead.
+
+_SOURCE_FILE = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "deadline"
+    / "max_submitter"
+    / "max_render_submitter.py"
+)
+
+
+@pytest.fixture(scope="module")
+def source_code() -> str:
+    return _SOURCE_FILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def show_job_bundle_submitter_source(source_code) -> str:
+    start = source_code.index("def show_job_bundle_submitter")
+    # This is the last function in the file, so grab to end
+    return source_code[start:]
+
+
+@pytest.fixture(scope="module")
+def on_create_job_bundle_callback_source(source_code) -> str:
+    start = source_code.index("def on_create_job_bundle_callback")
+    end = source_code.index("\ndef show_job_bundle_submitter")
+    return source_code[start:end]
+
+
+class TestShowJobBundleSubmitterUsesHelper:
+    """Verify show_job_bundle_submitter uses get_render_output_info() instead of os.path.split."""
+
+    def test_calls_get_render_output_info(self, show_job_bundle_submitter_source):
+        assert "get_render_output_info()" in show_job_bundle_submitter_source
+
+    def test_no_manual_os_path_split_on_rendOutputFilename(self, show_job_bundle_submitter_source):
+        """Should not manually split rt.rendOutputFilename — use the helper instead."""
+        assert "os.path.split(rt.rendOutputFilename)" not in show_job_bundle_submitter_source
+
+    def test_sets_output_filename_pattern(self, show_job_bundle_submitter_source):
+        """show_job_bundle_submitter should set output_filename_pattern on render_settings."""
+        assert "output_filename_pattern" in show_job_bundle_submitter_source
+
+
+class TestOnCreateJobBundleUsesOutputFilenamePattern:
+    """Verify on_create_job_bundle_callback reads output_filename_pattern from settings."""
+
+    def test_uses_output_filename_pattern(self, on_create_job_bundle_callback_source):
+        """State set data should be built from settings.output_filename_pattern."""
+        assert "settings.output_filename_pattern" in on_create_job_bundle_callback_source
+
+    def test_no_manual_os_path_split(self, on_create_job_bundle_callback_source):
+        """Should not manually split rt.rendOutputFilename in the callback."""
+        assert "os.path.split(rt.rendOutputFilename)" not in on_create_job_bundle_callback_source
+
+    def test_no_last_rend_output_filename(self, on_create_job_bundle_callback_source):
+        """on_create_job_bundle_callback should not reference last_rend_output_filename."""
+        assert "last_rend_output_filename" not in on_create_job_bundle_callback_source

--- a/test/unit/deadline_submitter_for_3ds_max/test_max_utils.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_max_utils.py
@@ -4,6 +4,8 @@ from typing import Any
 from unittest.mock import patch, MagicMock
 import pytest
 
+from deadline.max_submitter.utilities.max_utils import get_render_output_info
+
 
 class TestGetReferencedFilesFiltering:
     """Tests for output asset filtering in get_referenced_files()."""
@@ -184,3 +186,62 @@ class TestGetReferencedFilesFiltering:
         assert "C:/output/render.png" not in result
         assert "C:/videopost/out.avi" not in result
         assert "C:/output/element_ao.exr" not in result
+
+
+class TestGetRenderOutputInfo:
+    """Tests for get_render_output_info() — Path-based decomposition of render output."""
+
+    @pytest.fixture
+    def mock_rt(self):
+        with patch("deadline.max_submitter.utilities.max_utils.rt") as mock_rt:
+            yield mock_rt
+
+    def test_returns_path_stem_suffix(self, mock_rt):
+        """Standard render output is decomposed into parent, stem, suffix."""
+        mock_rt.rendOutputFilename = "C:\\output\\render_###.png"
+
+        output_dir, output_name, output_ext = get_render_output_info()
+
+        assert output_dir == "C:\\output"
+        assert output_name == "render_###"
+        assert output_ext == ".png"
+
+    def test_forward_slash_path(self, mock_rt):
+        mock_rt.rendOutputFilename = "C:/output/myScene_###.exr"
+
+        output_dir, output_name, output_ext = get_render_output_info()
+
+        assert output_name == "myScene_###"
+        assert output_ext == ".exr"
+
+    def test_no_extension(self, mock_rt):
+        mock_rt.rendOutputFilename = "C:\\output\\render_###"
+
+        output_dir, output_name, output_ext = get_render_output_info()
+
+        assert output_name == "render_###"
+        assert output_ext == ""
+
+    def test_empty_output_falls_back_to_scene(self, mock_rt):
+        """When rendOutputFilename is empty, fall back to scene-based defaults."""
+        mock_rt.rendOutputFilename = ""
+        mock_rt.maxFilePath = "C:\\scenes\\"
+        mock_rt.maxFileName = "myScene.max"
+
+        output_dir, output_name, output_ext = get_render_output_info()
+
+        assert output_dir == "C:/scenes/"
+        assert output_name == "myScene_###"
+        assert output_ext == ""
+
+    def test_none_output_falls_back_to_scene(self, mock_rt):
+        """When rendOutputFilename is None/falsy, fall back to scene-based defaults."""
+        mock_rt.rendOutputFilename = None
+        mock_rt.maxFilePath = "C:\\scenes\\"
+        mock_rt.maxFileName = "testStudio.max"
+
+        output_dir, output_name, output_ext = get_render_output_info()
+
+        assert output_dir == "C:/scenes/"
+        assert output_name == "testStudio_###"
+        assert output_ext == ""

--- a/test/unit/deadline_submitter_for_3ds_max/test_scene_settings_tab.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_scene_settings_tab.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for deadline.max_submitter.ui.scene_settings_tab
+
+Covers the changes we made:
+- Tooltip comes from get_tokens_tooltip() (single source of truth)
+- on_focus_changed no longer syncs render output
+- Top-level imports for format_output_filename and get_tokens_tooltip
+"""
+
+from pathlib import Path
+
+import pytest
+
+# Because the test __init__.py mocks qtpy, SceneSettingsWidget becomes a MagicMock
+# and inspect.getsource won't work. Read the source file directly instead.
+
+_SOURCE_FILE = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "deadline"
+    / "max_submitter"
+    / "ui"
+    / "scene_settings_tab.py"
+)
+
+
+@pytest.fixture(scope="module")
+def source_code() -> str:
+    return _SOURCE_FILE.read_text(encoding="utf-8")
+
+
+class TestOutputFilenameTooltipSource:
+    """Verify the filename pattern tooltip is built from get_tokens_tooltip()."""
+
+    def test_imports_get_tokens_tooltip(self, source_code):
+        """scene_settings_tab should import get_tokens_tooltip from filename_utils."""
+        assert "from deadline.max_shared.utilities.filename_utils import" in source_code
+        assert "get_tokens_tooltip" in source_code
+
+    def test_calls_get_tokens_tooltip(self, source_code):
+        """_build_output_filename_settings_ui should call get_tokens_tooltip() for the tooltip."""
+        assert "setToolTip(get_tokens_tooltip())" in source_code
+
+    def test_no_hardcoded_token_tooltip(self, source_code):
+        """The tooltip string should not be hardcoded — it should come from the helper."""
+        # Find the _build_output_filename_settings_ui method body
+        start = source_code.index("def _build_output_filename_settings_ui")
+        # Find the next def at the same indentation level
+        next_def = source_code.index("\n    def ", start + 1)
+        method_body = source_code[start:next_def]
+        assert "Available tokens:" not in method_body
+
+    def test_preview_tooltip_says_example(self, source_code):
+        """The preview label tooltip should say 'Example preview'."""
+        assert "Example preview" in source_code
+
+
+class TestOnFocusChangedNoRenderSync:
+    """Verify on_focus_changed does NOT sync render output settings."""
+
+    @pytest.fixture
+    def on_focus_changed_source(self, source_code) -> str:
+        start = source_code.index("def on_focus_changed")
+        next_def = source_code.index("\n    def ", start + 1)
+        return source_code[start:next_def]
+
+    def test_no_rend_output_reference(self, on_focus_changed_source):
+        """on_focus_changed should not reference rendOutputFilename or _last_rend_output_filename."""
+        assert "rendOutputFilename" not in on_focus_changed_source
+        assert "_last_rend_output_filename" not in on_focus_changed_source
+
+    def test_only_handles_frame_override(self, on_focus_changed_source):
+        """on_focus_changed should only deal with frame_override_txt validation."""
+        assert "frame_override_txt" in on_focus_changed_source
+        assert "output_filename" not in on_focus_changed_source
+        assert "output_path" not in on_focus_changed_source
+
+
+class TestTopLevelImports:
+    """Verify that format_output_filename and get_tokens_tooltip are top-level imports."""
+
+    def test_format_output_filename_imported(self, source_code):
+        assert "import" in source_code
+        assert "format_output_filename" in source_code
+
+    def test_get_tokens_tooltip_imported(self, source_code):
+        assert "get_tokens_tooltip" in source_code


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/128

### What was the problem/requirement? (What/Why)
https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/128 showed that users had their output filenames overwritten, with `camera` and `frame numbers` appended no matter what the user decides. As well, submitter `output filename` settings did not reflect in the job submission at all, and doesn't get used. The job parameters also always stated `image_###` as the default `outputFileName` no matter what.

### What was the solution? (How)

Fixed issue with output filename consistency across 3dsMax render settings, submitter, and job parameters.

Submitter also lacked output filename customizability, such as when user wanted to put <camera> or <scene> or other tokens into filename. This functionality was added drawing implementation from deadline 10, adding tokens such as:

`<scene>`
`<camera>`
`<stateset>`

to the submitter, and resolving these token names in the adaptor. Instead of the previous functionality, where these options were appended no matter what the user specifies. 

Render frame padding was also fixed, defaulting to `####` if rendering multiple frames, and no frame number if single frame. 

Sticky settings are also respected whenever user changes output filename in the 3dsMax render settings or the Submitter UI. 

<img width="685" height="224" alt="image" src="https://github.com/user-attachments/assets/7b4da51f-9307-4ff3-86ec-35d136e0fc7b" />


More information in the design doc: [docs/design/output-filename-with-tokens.md](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/compare/mainline...seant-aws:deadline-cloud-for-3ds-max:mainline#diff-1df7a1080c0bc1f33580f781862933287b7ab89e21065a49bd023b30ca4e9cfc)

### What is the impact of this change?

Customers can now customize their output filename with tokens such as `camera`, `stateset`, or `scene`. Further tokens can be added in the future.

Removed automatic frame padding manipulation (no more auto-adding _#### or stripping #). Customers adding # in filename will add frame padding as specified. WYSIWYG; filename pattern is passed through exactly as typed.

Customers also have consistency and more control over filenames set in both 3dsMax render settings, and Deadline Cloud submitter UI.

### How was this change tested?
Unit testing:
```
================================================================================= slowest 5 durations ================================================================================= 
0.13s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_max_init_timeout
0.04s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_run_data_wrong_schema
0.04s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_server_init_fail
0.04s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_on_run
0.04s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_cleanup::test_on_cleanup
================================================================================= 180 passed in 3.58s ================================================================================= 

```

Integ testing for the submitter was done via the submitter UI, as the screenshot showed above.

Integ testing is currently handled with manual script tests, and verifying outputs. Below I run a script to test the 3dsMax Adaptor, running the integ tests with the job bundle that I export from my local submitter. 

The script ran was: test-3dsmax-openjd-run.ps1, with outputs verified below.

Integ Testing:
```
Selected step: State01
Found 2 camera(s): Template-Camera-Close, Template-Camera-Far
Running 2 camera(s) x 2 frame(s) = 4 task(s)
Substituted initData template:
scene_file: C:/Users/RDP/Documents/3ds Max 2026/scenes/testStudio.max
renderer: Default_Scanline_Renderer
state_set: State01
output_file_name: <camera>_<scene>_<stateset>_KIRBY_####
output_file_path: 'C:\Users\RDP\Documents\3ds Max 2026\renderoutput'
output_file_format: '.png'
image_width: '1280'
image_height: '720'
Session ended successfully
...
Job: testStudio
Step: State01
Duration: 147.40925909997895 seconds
Chunks run: 4
...
Test completed successfully!
```

Integ Testing Outputs (Sample outputs for [2 cameras, 1 frame each] and [2 cameras, 2 frames each])
```
PS C:\Users\RDP\Documents\GitHub\deadline-cloud-for-3ds-max> cd "c:\Users\RDP\Documents\GitHub" ; Get-ChildItem "C:\Users\RDP\Documents\3ds Max 2026\renderoutput" | Sort-Object LastWriteTime -Descending | Select-Object -First 10 | Format-Table Name, LastWriteTime, Length
    
Name                                                    LastWriteTime         Length
----                                                    -------------         ------
Template-Camera-Far_testStudio_State01_KIRBY_0001.png   2/12/2026 6:06:34 PM 2293178
Template-Camera-Far_testStudio_State01_KIRBY_0000.png   2/12/2026 6:06:18 PM 2293253
Template-Camera-Close_testStudio_State01_KIRBY_0001.png 2/12/2026 6:06:02 PM 1489757
Template-Camera-Close_testStudio_State01_KIRBY_0000.png 2/12/2026 6:05:46 PM 1489975
Template-Camera-Far_testStudio_State01_KIRBY.png        2/12/2026 5:22:17 PM 2293553
Template-Camera-Close_testStudio_State01_KIRBY.png      2/12/2026 5:22:01 PM 1489685
```

### Was this change documented?
yes, documented in the design doc.

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
   - [ ] Yes
   - [ ] No

### Is this a breaking change?
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*