### PR TITLE
fix: enable header check in hatch run test and add missing headers

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -5,7 +5,7 @@ pre-install-commands = [
 
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
-test = "pytest --cov-config pyproject.toml {args:test/unit}"
+test = "pytest --cov-config pyproject.toml {args:test/unit test/test_copyright_headers.py}"
 test-installer = "pytest --no-cov {args:test/installer} -vvv"
 typing = "mypy {args:src test}"
 style = [

--- a/src/deadline/max_submitter/setup_adaptor_wheels.py
+++ b/src/deadline/max_submitter/setup_adaptor_wheels.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
 #!/usr/bin/env python3
 """Cross-platform script to set up adaptor wheels in a virtual environment."""
 import json

--- a/test/installer/__init__.py
+++ b/test/installer/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/test_copyright_headers.py
+++ b/test/test_copyright_headers.py
@@ -19,7 +19,7 @@ class FileMissingCopyRight(Exception):
 
 
 def _check_file(filename: Path) -> None:
-    with open(filename) as infile:
+    with open(filename, encoding="utf-8", errors="ignore") as infile:
         lines_read = 0
         for line in infile:
             if _copyright_header_re.search(line):
@@ -42,7 +42,7 @@ def _check_file(filename: Path) -> None:
 def _is_version_file(filename: Path) -> bool:
     if filename.name != "_version.py":
         return False
-    with open(filename) as infile:
+    with open(filename, encoding="utf-8", errors="ignore") as infile:
         lines_read = 0
         for line in infile:
             if _generated_by_scm.search(line):


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

The copyright header test was failing due to two issues:

1. **Unicode decode error**: The test was failing with Unicode decode errors when reading files that contained non-ASCII characters
2. **Missing copyright headers**: Two files were missing required copyright headers:
   - `src/deadline/max_submitter/setup_adaptor_wheels.py`
   - `test/installer/__init__.py`
3. **Test not included in default run**: The copyright header test (`test/test_copyright_headers.py`) was not being executed as part of the standard `hatch run test` command, so developers and CI wouldn't catch missing headers during normal development workflow

## What was the solution? (How)

1. **Fixed Unicode handling**: Modified `test/test_copyright_headers.py` to open files with `encoding="utf-8", errors="ignore"` instead of default encoding, preventing Unicode decode errors
2. **Added missing headers**: Added the required copyright header `# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.` to both missing files
3. **Integrated header check**: Modified `hatch.toml` to include copyright header test in the default test command by changing from `{args:test/unit}` to `{args:test/unit test/test_copyright_headers.py}`

## What is the impact of this change?

- **Improved reliability**: Tests no longer fail due to Unicode decode errors
- **Better compliance**: All files now have required copyright headers
- **Enhanced developer workflow**: Copyright header validation is now part of the standard test suite, catching missing headers early in development
- **Consistent enforcement**: Developers will automatically run copyright checks with `hatch run test`

## How was this change tested?

- Verified that `hatch run test` now includes and passes the copyright header test
- Confirmed that all previously failing copyright header tests now pass
- Removed header from files and confirmed test fail `FAILED test/test_copyright_headers.py::test_copyright_headers - Exception: Found 2 files without copyright headers:`

## Was this change documented?

No additional documentation was needed as this was an internal test infrastructure fix.

## Did you modify schema files?

- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [ ] No

## Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*