### PR TITLE
chore: ignore windows module failling mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,13 @@ module = [
   "qtpy.*"
 ]
 
+[[tool.mypy.overrides]]
+# winreg is a Windows-only stdlib module whose type stubs are incomplete
+# on non-Windows platforms, causing false attr-defined errors.
+module = "test.integ.conftest"
+warn_unused_ignores = false
+disable_error_code = ["attr-defined"]
+
 # --- RUFF / BLACK ---
 
 [tool.ruff]

--- a/src/deadline/max_submitter/utilities/max_utils.py
+++ b/src/deadline/max_submitter/utilities/max_utils.py
@@ -6,7 +6,7 @@
 
 import logging
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pymxs  # separate import to initialize
 from pymxs import runtime as rt
@@ -343,7 +343,7 @@ def get_render_output_info() -> tuple[str, str, str]:
               If no render output is set, returns scene-based defaults
     """
     if rt.rendOutputFilename:
-        output_path = Path(rt.rendOutputFilename)
+        output_path = PureWindowsPath(rt.rendOutputFilename)
         return str(output_path.parent), output_path.stem, output_path.suffix
     else:
         # Fall back to default scene-based naming


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Publish workflow were failling due to fail mypy and fail test

### What was the solution? (How)
- Fix test to be windows true path as test are design for windows but being run on Linux
- Tell mypy to ignore conftest as it's only meant for Windows and mypy is ran on Linux

### What is the impact of this change?
Release process will work

### How was this change tested?
Run the publish script workflow:
```
============================================================================================= slowest 5 durations ==============================================================================================
0.18s call     test/test_copyright_headers.py::test_copyright_headers
0.16s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_start::test_max_init_timeout
0.06s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_cleanup::test_on_cleanup
0.06s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_on_run::test_on_run_render_fail
0.05s call     test/unit/deadline_adaptor_for_3ds_max/MaxAdaptor/test_adaptor.py::TestMaxAdaptor_semantic_version::test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped
============================================================================================= 206 passed in 4.06s ==============================================================================================
──────────────────────────────────────────────────────────────────────────────────────────────────── sdist ─────────────────────────────────────────────────────────────────────────────────────────────────────
Copying _version.py to src/deadline/max_adaptor
Copying _version.py to src/deadline/max_submitter
dist/deadline_cloud_for_3ds_max-0.0.post136+ge880dcc57.d20260310.tar.gz
──────────────────────────────────────────────────────────────────────────────────────────────────── wheel ─────────────────────────────────────────────────────────────────────────────────────────────────────
Copying _version.py to src/deadline/max_adaptor
Copying _version.py to src/deadline/max_submitter
dist/deadline_cloud_for_3ds_max-0.0.post136+ge880dcc57.d20260310-py3-none-any.whl
ERROR    InvalidConfiguration: Missing 'codeartifact' section from ~/.pypirc.                                                                                                                                   
         More info: https://packaging.python.org/specifications/pypirc/   
```
The error is due to this not being run on a github workflow so you can ignore it

### Was this change documented?
No

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
   - [ ] Yes
   - [x] No

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*