### PR TITLE
feat: add V-Ray export workflow with tile rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,10 @@ venv/
 # Temp folder
 tmp/
 
+# Dev helper scripts
+force_reload.ms
+test_job_bundle/
+scene_settings.json
+
 # Kiro specs
 .kiro/specs/

--- a/docs/design/vray-standalone-file-map.md
+++ b/docs/design/vray-standalone-file-map.md
@@ -1,0 +1,111 @@
+# V-Ray Standalone Submitter — File Map
+
+Overview of all files added for the V-Ray Standalone workflow.
+
+```
+src/deadline/max_submitter/
+├── vray_standalone_submitter.py        — Main submitter logic: job bundle creation for
+│                                         local export and farm export modes, path mapping
+│                                         script loading, vrscene path fix script loading,
+│                                         tile rendering integration
+├── vrscene_settings.py                 — Settings dataclass with sticky persistence (export
+│                                         mode, region grid, output format, movie settings)
+├── ui/
+│   └── vray_standalone_tab.py          — Qt UI tab: export mode radios, job options, region
+│                                         grid spinners, output format dropdown, browse button
+├── utilities/
+│   ├── vrscene_job_submission.py       — Job template loading and parameter builders:
+│   │                                     tile coordinate calculation, script injection,
+│   │                                     parameter value builders for all job types
+│   ├── vrscene_utils.py                — V-Ray helpers: renderer detection, vrscene export
+│   │                                     (local), settings validation, output format detection
+│   └── vray_executable_utils.py        — Executable path resolution for vray.exe and
+│                                         3dsmaxcmd.exe (env vars + install path fallback)
+├── scripts/
+│   ├── fix_vrscene_paths.py            — Farm script: runs 3dsmaxcmd export then reverses
+│   │                                     session paths so render -remapPath works correctly
+│   ├── path_mapping_render.py          — Farm script: reads path mapping rules and calls
+│   │                                     vray.exe with -remapPath arguments
+│   ├── tile_render.py                  — Farm script: renders a single tile region with vray.exe
+│   ├── tile_merge.py                   — Farm script: merges tile images into complete frames
+│   │                                     using Pillow (PNG/JPEG/TIFF) or OpenEXR
+│   ├── create_movie.py                 — Farm script: creates MP4 from frames (future release)
+│   └── export_vrscene_farm.ms          — MAXScript: exports vrscene on the farm worker via
+│                                         3dsmaxcmd, called by fix_vrscene_paths.py
+└── job_templates/
+    ├── vray_render_job_template.yaml   — OpenJD template: single-step vray.exe render
+    ├── vray_export_job_template.yaml   — OpenJD template: vrscene export step (farm mode)
+    ├── vray_tile_render_job_template.yaml — OpenJD template: RenderRegions + MergeRegions steps
+    └── vray_combined_job_template.yaml — OpenJD template: export + render combined (farm mode)
+
+install_files/
+└── AWSDeadline-SubmitToDeadlineCloud-VRayStandalone.mcr  — 3ds Max macro for menu entry
+                                                             (installer bundling: follow-up PR)
+
+force_reload.ms                         — Dev helper: reloads Python modules in 3ds Max
+```
+
+## Architecture Integration
+
+How the V-Ray Standalone feature relates to the existing submitter/adaptor architecture.
+
+### Existing Architecture Flow
+
+```
+run_ui.py
+  → show_job_bundle_submitter()
+    → SubmitMaxJobToDeadlineDialog(
+        job_setup_widget_type = SceneSettingsWidget,
+        on_create_job_bundle_callback = on_create_job_bundle_callback
+      )
+```
+
+The existing callback builds an OpenJD job template that uses the `3dsmax-openjd` adaptor.
+The farm worker launches 3ds Max and renders inside it.
+
+### V-Ray Hook Points
+
+The V-Ray feature hooks into the existing architecture at exactly two points:
+
+1. **`submit_dialog.py`** — `SubmitMaxJobToDeadlineDialog.__init__()` intercepts the original
+   callback, wraps it in `_on_create_job_bundle_wrapper()`, and calls
+   `_add_vray_export_tab_if_available()`. When V-Ray is the active renderer, a "V-Ray Export"
+   tab appears in the dialog.
+
+2. **Submit-time routing** — The wrapper checks `vray_export_widget.is_vray_export_enabled()`:
+   - Enabled → routes to `on_create_vrscene_job_bundle_callback` with `VRSceneRenderSubmitterUISettings`
+   - Disabled → passes through to the original `on_create_job_bundle_callback` with `RenderSubmitterUISettings`
+
+No other existing files are modified (except `data_const.py` for the settings file extension constant).
+
+### Adaptor vs Adaptor-Free
+
+| | Existing 3ds Max Workflow | V-Ray Standalone Workflow |
+|---|---|---|
+| Rendering | `3dsmax-openjd` adaptor launches 3ds Max on the farm | Farm scripts call `vray.exe` directly |
+| Job template | Loaded from `default_max_job_template.yaml` | Loaded from YAML files in `job_templates/` |
+| Path mapping | Handled by the adaptor | `path_mapping_render.py` reads `Session.PathMappingRulesFile` |
+| Settings class | `RenderSubmitterUISettings` | `VRSceneRenderSubmitterUISettings` |
+| UI tab | `SceneSettingsWidget` | `VRayStandaloneSettingsWidget` |
+| Sticky settings ext | `.deadline_render_settings.json` | `.deadline_vrscene_settings.json` |
+
+### Executable Path Resolution
+
+Farm workers need `vray.exe` (Windows) on the `PATH` or via environment variable.
+Set `VRAY_EXECUTABLE` to the full path of `vray.exe` on each worker — this is the recommended
+approach and should be configured in the fleet host configuration or worker environment.
+The fallback derives the path from `VRAY_FOR_3DSMAX{version}_MAIN` (set by the V-Ray installer).
+
+Similarly, farm export mode requires `3dsmaxcmd.exe`. Set `MAXCMD_EXECUTABLE` to its full path,
+or the submitter will derive it from the current 3ds Max installation at submit time.
+
+### Coupling Summary
+
+The V-Ray feature is a parallel workflow that shares the dialog shell but has its own:
+- Settings dataclass (`vrscene_settings.py`)
+- UI tab (`vray_standalone_tab.py`)
+- Submit callback (`vray_standalone_submitter.py`)
+- Job templates (`job_templates/`)
+- Farm scripts (`scripts/`)
+
+Everything is additive. The only modified existing files are `submit_dialog.py` (callback wrapper + tab injection) and `data_const.py` (one constant).

--- a/install_files/AWSDeadline-SubmitToDeadlineCloud-VRayStandalone.mcr
+++ b/install_files/AWSDeadline-SubmitToDeadlineCloud-VRayStandalone.mcr
@@ -1,0 +1,49 @@
+-- AWS Deadline Cloud - V-Ray Standalone Submitter Macro
+-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+macroScript SubmitToDeadlineCloudVRayStandalone
+	category:"AWS Deadline Cloud"
+	buttonText:"Submit V-Ray Standalone"
+	toolTip:"Submit V-Ray Standalone Render Job To Deadline Cloud"
+	icon:#("Deadline",1)
+(
+	-- Check if V-Ray is the current renderer
+	local isVRay = false
+	try
+	(
+		local rendererName = (classof renderers.current) as string
+		isVRay = (findString rendererName "VRay" != undefined) or (findString rendererName "V_Ray" != undefined)
+	)
+	catch
+	(
+		isVRay = false
+	)
+	
+	if not isVRay then
+	(
+		messageBox "V-Ray Standalone workflow requires V-Ray as the active renderer.\n\nPlease set V-Ray as your current renderer to use this workflow." title:"V-Ray Not Active"
+		return false
+	)
+	
+	-- Import the Python module and run the UI
+	python.Execute "import sys"
+	python.Execute "import os"
+	
+	-- Try development path first, then installed path
+	local devPath = "C:\\Users\\Administrator\\gitrepos\\deadline-cloud-for-3ds-max\\src\\deadline\\max_submitter"
+	local installedPath = (getDir #scripts) + "\\deadline\\max_submitter"
+	
+	local submitterPath = installedPath
+	if (doesFileExist (devPath + "\\run_vray_standalone_ui.py")) then (
+		submitterPath = devPath
+		format "Using development path: %\n" submitterPath
+	) else (
+		format "Using installed path: %\n" submitterPath
+	)
+	
+	python.Execute ("sys.path.insert(0, r'" + submitterPath + "')")
+	
+	-- Launch the V-Ray Standalone submitter
+	python.Execute "from run_vray_standalone_ui import main"
+	python.Execute "main()"
+)

--- a/scripts/MAXScript_VRayStandaloneExport.ms
+++ b/scripts/MAXScript_VRayStandaloneExport.ms
@@ -1,0 +1,104 @@
+-- V-Ray Standalone Export MAXScript Job
+-- Runs on Deadline workers to export vrscene files
+-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+try
+(
+	local du = DeadlineUtil  -- Interface provided by Deadline 3ds Max plugin
+	if du == undefined do
+	(
+		-- Stand-in struct for testing outside Deadline
+		struct DeadlineUtilStruct
+		(
+			fn SetTitle title = ( format "Title: %\n" title ),
+			fn SetProgress percent = (true),
+			fn FailRender msg = ( throw msg ),
+			fn GetJobInfoEntry key = ( undefined ),
+			fn LogMessage msg = ( format "INFO: %\n" msg ),
+			fn WarnMessage msg = ( format "WARNING: %\n" msg ),
+			CurrentFrame = ((sliderTime as string) as integer),
+			CurrentTask = ( -1 ),
+			SceneFileName = ( maxFilePath + maxFileName ),
+			SceneFilePath = ( maxFilePath )
+		)
+		du = DeadlineUtilStruct()
+	)
+	
+	fn ExportToVRayStd exportPath startFrame endFrame incrBaseFrame: =
+	(
+		-- Create output directory
+		makeDir (getFileNamePath exportPath) all:true
+		sysinfo.currentdir = getFileNamePath exportPath
+		
+		-- Ensure VRayRT is the active shade renderer
+		if not (iskindof renderers.activeShade VRayRT) do 
+			renderers.activeShade = VRayRT()
+		
+		-- Export based on frame range
+		if startFrame == endFrame then
+			-- Single frame export
+			vrayExportRTScene exportPath separateFiles:false
+		else if incrBaseFrame != unsupplied and incrBaseFrame != startFrame then
+			-- Incremental export (not first frame)
+			vrayExportRTScene exportPath separateFiles:false startFrame:startFrame endFrame:endFrame incrBaseFrame:incrBaseFrame
+		else
+			-- Full animation or first frame of incremental
+			vrayExportRTScene exportPath separateFiles:false startFrame:startFrame endFrame:endFrame
+	)
+	
+	local st = timestamp()
+	
+	du.SetTitle "VRSCENE Export MAXScript Job"
+	du.LogMessage ">Starting VRSCENE Export MAXScript Job..."
+	
+	-- Get job parameters
+	local startFrame = (du.GetJobInfoEntry "Render_StartFrame") as integer
+	local endFrame = (du.GetJobInfoEntry "Render_EndFrame") as integer
+	local vrsceneName = du.GetJobInfoEntry "Render_InputFilename"
+	local exportAnimationMode = du.GetJobInfoEntry "Render_ExportAnimationMode"
+	
+	-- Default to Single File mode
+	if exportAnimationMode == "" do
+		exportAnimationMode = "1"
+	exportAnimationMode = exportAnimationMode as integer
+	
+	du.LogMessage ">Exporting VRSCENE File..."
+	
+	case exportAnimationMode of
+	(
+		1: (
+			-- Single File: Export entire animation to one vrscene
+			ExportToVRayStd vrsceneName startFrame endFrame
+		)
+		2: (
+			-- File Per Frame: Export current frame to separate vrscene
+			local frameVrsceneName = (getFilenamePath vrsceneName) + (getFilenameFile vrsceneName) + "." + (formattedPrint du.CurrentFrame format:"04i") + (getFilenameType vrsceneName)
+			ExportToVRayStd frameVrsceneName du.CurrentFrame (du.CurrentFrame + 1)
+		)
+		3: (
+			-- File Per Frame (Incremental): Export with reference to first frame
+			local frameVrsceneName = (getFilenamePath vrsceneName) + (getFilenameFile vrsceneName) + "." + (formattedPrint du.CurrentFrame format:"04i") + (getFilenameType vrsceneName)
+			ExportToVRayStd frameVrsceneName du.CurrentFrame (du.CurrentFrame + 1) incrBaseFrame:startFrame
+		)
+	)
+	
+	du.LogMessage ("+Finished VRSCENE Export MAXScript Job in "+ ((timestamp() - st)/1000.0) as string + " sec.")
+	true
+)
+catch
+(
+	-- Error handling with stack trace (Max 2017+)
+	if ((maxVersion())[1]/1000 as integer) >= 19 then
+	(
+		if hasCurrentExceptionStackTrace() then
+		(
+			local errorMessage = getCurrentException()
+			DeadlineUtil.WarnMessage("MaxScript Error: " + errorMessage)
+			local stackTrace = getCurrentExceptionStackTrace()
+			stackTrace = filterString stackTrace "\n"
+			for line in stackTrace do
+				DeadlineUtil.WarnMessage(line)
+		)
+	)
+	throw()
+)

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -109,3 +109,17 @@ STEREO_CAMERA_OPTIONS = [
     ["Left, Right and Center", "All"],
     ["Disable Stereo Camera Submission", "None"],
 ]
+
+# V-Ray Standalone Workflow Constants
+VRSCENE_EXPORT_MODES = [
+    ["Export VRSCENE On This Workstation", 1],
+    ["Export VRSCENE On Deadline", 2],
+]
+
+VRSCENE_EXPORT_ANIMATION_MODES = [
+    ["Single File", 1],
+    ["File Per Frame", 2],
+    ["File Per Frame (Incremental)", 3],
+]
+
+VRSCENE_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_vrscene_settings.json"

--- a/src/deadline/max_submitter/job_templates/vray_combined_job_template.yaml
+++ b/src/deadline/max_submitter/job_templates/vray_combined_job_template.yaml
@@ -1,0 +1,46 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: VRay Export and Render
+parameterDefinitions:
+- name: MaxCmdExecutable
+  type: STRING
+  default: 3dsmaxcmd
+  description: 3dsmaxcmd.exe executable for MAXScript execution
+- name: VRayExecutable
+  type: STRING
+  default: vray
+  description: V-Ray Standalone executable
+- name: SceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  description: The 3ds Max scene file to export
+- name: VRSceneOutputPath
+  type: PATH
+  objectType: FILE
+  dataFlow: INOUT
+  description: Output path for the vrscene file(s)
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  description: Output directory for rendered images
+- name: Frames
+  type: STRING
+  description: Frame range
+- name: ExportAnimationMode
+  type: INT
+  default: '1'
+  allowedValues:
+  - '1'
+  - '2'
+  - '3'
+  description: 1=Single File, 2=File Per Frame, 3=File Per Frame (Incremental)
+- name: OutputFileName
+  type: STRING
+  description: Output filename with extension
+- name: RegionColumns
+  type: INT
+  description: Number of region columns
+- name: RegionRows
+  type: INT
+  description: Number of region rows

--- a/src/deadline/max_submitter/job_templates/vray_export_job_template.yaml
+++ b/src/deadline/max_submitter/job_templates/vray_export_job_template.yaml
@@ -1,0 +1,51 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: VRayStandaloneExport
+parameterDefinitions:
+- name: SceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  description: The 3ds Max scene file to export
+- name: VRSceneOutputPath
+  type: PATH
+  objectType: FILE
+  dataFlow: OUT
+  description: Output path for the vrscene file
+- name: StartFrame
+  type: INT
+  default: '1'
+- name: EndFrame
+  type: INT
+  default: '1'
+- name: ExportAnimationMode
+  type: INT
+  default: '1'
+  allowedValues:
+  - '1'
+  - '2'
+  - '3'
+  description: 1=Single File, 2=File Per Frame, 3=File Per Frame (Incremental)
+steps:
+- name: ExportVRScene
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.StartFrame}}-{{Param.EndFrame}}'
+  stepEnvironments:
+  - name: 3dsMax
+    description: Runs 3ds Max to export vrscene
+    script:
+      actions:
+        onRun:
+          command: 3dsmaxbatch
+          args:
+          - -sceneFile
+          - '{{Param.SceneFile}}'
+          - -script
+          - '{{Task.File.ExportScript}}'
+      embeddedFiles:
+      - name: ExportScript
+        type: TEXT
+        filename: export_vrscene.ms
+        data: INJECT_EXPORT_SCRIPT

--- a/src/deadline/max_submitter/job_templates/vray_render_job_template.yaml
+++ b/src/deadline/max_submitter/job_templates/vray_render_job_template.yaml
@@ -1,0 +1,47 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: VRay Standalone Render
+parameterDefinitions:
+- name: VRayExecutable
+  type: STRING
+  default: vray
+  description: V-Ray Standalone executable
+- name: VRSceneOutputPath
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  description: The vrscene file to render
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  description: Output directory for rendered images
+- name: OutputFileName
+  type: STRING
+  description: Output filename with extension
+- name: Frames
+  type: STRING
+  description: Frame range to render
+- name: RegionColumns
+  type: INT
+  description: Number of region columns
+- name: RegionRows
+  type: INT
+  description: Number of region rows
+steps:
+- name: RenderVRScene
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  script:
+    embeddedFiles:
+    - name: SetupAndRender
+      type: TEXT
+      filename: setup_and_render.py
+      data: INJECT_PATH_MAPPING_SCRIPT
+    actions:
+      onRun:
+        command: python
+        args:
+        - '{{Task.File.SetupAndRender}}'

--- a/src/deadline/max_submitter/job_templates/vray_tile_render_job_template.yaml
+++ b/src/deadline/max_submitter/job_templates/vray_tile_render_job_template.yaml
@@ -1,0 +1,88 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: VRay Tile Render
+parameterDefinitions:
+- name: VRayExecutable
+  type: STRING
+  default: vray
+  description: V-Ray Standalone executable
+- name: VRSceneOutputPath
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  description: The vrscene file to render
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  description: Output directory for rendered images
+- name: OutputFileName
+  type: STRING
+  description: Output filename with extension
+- name: Frames
+  type: STRING
+  description: Frame range to render
+- name: ImageWidth
+  type: INT
+  description: Image width in pixels
+- name: ImageHeight
+  type: INT
+  description: Image height in pixels
+- name: RegionColumns
+  type: INT
+  description: Number of tile columns
+- name: RegionRows
+  type: INT
+  description: Number of tile rows
+- name: CreateMovie
+  type: STRING
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: MovieFilename
+  type: STRING
+- name: FrameRate
+  type: INT
+steps:
+- name: RenderRegions
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+    - name: RegionCol
+      type: INT
+      range: '1-{{Param.RegionColumns}}'
+    - name: RegionRow
+      type: INT
+      range: '1-{{Param.RegionRows}}'
+  script:
+    embeddedFiles:
+    - name: RenderTile
+      type: TEXT
+      filename: render_tile.py
+      data: INJECT_TILE_RENDER_SCRIPT
+    actions:
+      onRun:
+        command: python
+        args:
+        - '{{Task.File.RenderTile}}'
+- name: MergeRegions
+  dependencies:
+  - dependsOn: RenderRegions
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  script:
+    embeddedFiles:
+    - name: MergeTiles
+      type: TEXT
+      filename: merge_tiles.py
+      data: INJECT_TILE_MERGE_SCRIPT
+    actions:
+      onRun:
+        command: python
+        args:
+        - '{{Task.File.MergeTiles}}'

--- a/src/deadline/max_submitter/run_vray_standalone_ui.py
+++ b/src/deadline/max_submitter/run_vray_standalone_ui.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Entry point for V-Ray Standalone submitter UI.
+This can be called from MAXScript or directly from Python.
+"""
+
+import logging
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
+_logger = logging.getLogger(__name__)
+
+
+def main():
+    """
+    Main entry point for V-Ray Standalone submitter.
+    """
+    try:
+        from vray_standalone_submitter import show_vray_standalone_submitter
+
+        _logger.info("Launching V-Ray Standalone submitter...")
+        window = show_vray_standalone_submitter()
+        return window
+    except Exception as e:
+        _logger.error(f"Failed to launch V-Ray Standalone submitter: {e}")
+        import traceback
+
+        traceback.print_exc()
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deadline/max_submitter/scripts/create_movie.py
+++ b/src/deadline/max_submitter/scripts/create_movie.py
@@ -1,0 +1,68 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#!/usr/bin/env python3
+# Create Movie Script
+# Creates an MP4 movie from rendered frames using ffmpeg.
+
+import os
+import subprocess
+import sys
+
+
+def normalize_path(p):
+    # Convert backslashes to forward slashes to avoid escape issues.
+    return p.replace("\\", "/")
+
+
+def main():
+    create_movie = r"{{Param.CreateMovie}}"
+    if create_movie != "true":
+        print("Movie creation disabled, skipping")
+        return 0
+
+    output_dir = normalize_path(r"{{Param.OutputDir}}")
+    output_filename = r"{{Param.OutputFileName}}"
+    movie_filename = r"{{Param.MovieFilename}}"
+    frame_rate = int(r"{{Param.FrameRate}}")
+
+    base, ext = os.path.splitext(output_filename)
+
+    # ffmpeg input pattern: base.%04d.ext
+    input_pattern = os.path.join(output_dir, f"{base}.%04d{ext}")
+    movie_path = os.path.join(output_dir, movie_filename)
+
+    print("=== Create Movie ===")
+    print(f"Input pattern: {input_pattern}")
+    print(f"Output: {movie_path}")
+    print(f"Frame rate: {frame_rate}")
+
+    cmd = [
+        "ffmpeg",
+        "-framerate",
+        str(frame_rate),
+        "-i",
+        input_pattern,
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "18",
+        movie_path,
+    ]
+
+    print(f"Running: {' '.join(cmd)}")
+
+    try:
+        subprocess.run(cmd, check=True)
+        print(f"Movie created: {movie_path}")
+        return 0
+    except FileNotFoundError:
+        print("ERROR: ffmpeg not found. Cannot create movie.", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: ffmpeg failed with exit code {e.returncode}", file=sys.stderr)
+        return e.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/deadline/max_submitter/scripts/export_vrscene_farm.ms
+++ b/src/deadline/max_submitter/scripts/export_vrscene_farm.ms
@@ -1,0 +1,68 @@
+-- V-Ray Standalone Export Script for Deadline Cloud
+-- This script is run via 3dsmaxcmd.exe with the scene file already specified
+
+fn ExportToVRayStd exportPath startFrame endFrame incrBaseFrame: =
+(
+    makeDir (getFileNamePath exportPath) all:true
+    sysinfo.currentdir = getFileNamePath exportPath
+    
+    -- Ensure V-Ray RT is active shade renderer
+    if not (iskindof renderers.activeShade VRayRT) do 
+        renderers.activeShade = VRayRT()
+    
+    -- Export based on frame range
+    if startFrame == endFrame then
+        vrayExportRTScene exportPath separateFiles:false
+    else if incrBaseFrame != unsupplied and incrBaseFrame != startFrame then
+        vrayExportRTScene exportPath separateFiles:false startFrame:startFrame endFrame:endFrame incrBaseFrame:incrBaseFrame
+    else
+        vrayExportRTScene exportPath separateFiles:false startFrame:startFrame endFrame:endFrame
+)
+
+try (
+    format "=== V-Ray Export Script Starting ===\n"
+    format "Renderer: %\n" (classof renderers.current)
+    format "ActiveShade: %\n" (classof renderers.activeShade)
+    
+    -- VRSceneOutputPath is resolved by OpenJD at runtime to the session path
+    local vrsceneOutputPath = @"{{{{Param.VRSceneOutputPath}}}}"
+    local exportAnimationMode = {export_animation_mode}
+    local startFrame = {start_frame}
+    local endFrame = {end_frame}
+    
+    format "Output: %\n" vrsceneOutputPath
+    format "Mode: %\n" exportAnimationMode
+    format "Range: % - %\n" startFrame endFrame
+    
+    case exportAnimationMode of
+    (
+        1: (
+            -- Single File
+            format "Exporting single vrscene file...\n"
+            ExportToVRayStd vrsceneOutputPath startFrame endFrame
+        )
+        2: (
+            -- File Per Frame
+            local currentFrame = {start_frame}
+            local paddedFrame = formattedPrint currentFrame format:"04i"
+            local frameVrsceneName = (getFilenamePath vrsceneOutputPath) + (getFilenameFile vrsceneOutputPath) + "." + paddedFrame + ".vrscene"
+            format "Exporting per-frame vrscene: %\n" frameVrsceneName
+            ExportToVRayStd frameVrsceneName currentFrame (currentFrame + 1)
+        )
+        3: (
+            -- File Per Frame (Incremental)
+            local currentFrame = {start_frame}
+            local paddedFrame = formattedPrint currentFrame format:"04i"
+            local frameVrsceneName = (getFilenamePath vrsceneOutputPath) + (getFilenameFile vrsceneOutputPath) + "." + paddedFrame + ".vrscene"
+            format "Exporting incremental vrscene: %\n" frameVrsceneName
+            ExportToVRayStd frameVrsceneName currentFrame (currentFrame + 1) incrBaseFrame:startFrame
+        )
+    )
+    
+    format "=== Export completed successfully ===\n"
+    quitMax #noPrompt exitCode:0
+) catch (
+    local errMsg = getCurrentException()
+    format "ERROR: %\n" errMsg
+    quitMax #noPrompt exitCode:1
+)

--- a/src/deadline/max_submitter/scripts/export_vrscene_local.ms
+++ b/src/deadline/max_submitter/scripts/export_vrscene_local.ms
@@ -1,0 +1,58 @@
+-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+-- V-Ray Local Export Script
+-- Exports the current scene to a vrscene file using the specified animation mode.
+-- Placeholders are filled in by Python's str.format() before passing to rt.execute().
+
+fn ExportToVRayStd exportPath startFrame endFrame incrBaseFrame: =
+(
+    makeDir (getFileNamePath exportPath) all:true
+    sysinfo.currentdir = getFileNamePath exportPath
+
+    if not (iskindof renderers.activeShade VRayRT) do
+        renderers.activeShade = VRayRT()
+
+    if startFrame == endFrame then
+        vrayExportRTScene exportPath separateFiles:false
+    else if incrBaseFrame != unsupplied and incrBaseFrame != startFrame then
+        vrayExportRTScene exportPath separateFiles:false startFrame:startFrame endFrame:endFrame incrBaseFrame:incrBaseFrame
+    else
+        vrayExportRTScene exportPath separateFiles:false startFrame:startFrame endFrame:endFrame
+)
+
+try (
+    case {export_animation_mode} of
+    (
+        1: (
+            -- Single File
+            ExportToVRayStd @"{vrscene_path_escaped}" {start_frame} {end_frame}
+        )
+        2: (
+            -- File Per Frame
+            for i = {start_frame} to {end_frame} do
+            (
+                local paddedFrame = formattedPrint i format:"04i"
+                local frameVrsceneName = @"{output_dir_escaped}\\" + "{base_name}." + paddedFrame + ".vrscene"
+                ExportToVRayStd frameVrsceneName i (i + 1)
+            )
+        )
+        3: (
+            -- File Per Frame (Incremental)
+            local paddedFrame = formattedPrint {start_frame} format:"04i"
+            local frameVrsceneName = @"{output_dir_escaped}\\" + "{base_name}." + paddedFrame + ".vrscene"
+            ExportToVRayStd frameVrsceneName {start_frame} ({start_frame} + 1)
+
+            local vrsceneFileHandle = createfile @"{vrscene_path_escaped}"
+            for i = ({start_frame} + 1) to {end_frame} do
+            (
+                paddedFrame = formattedPrint i format:"04i"
+                frameVrsceneName = @"{output_dir_escaped}\\" + "{base_name}." + paddedFrame + ".vrscene"
+                ExportToVRayStd frameVrsceneName i (i + 1) incrBaseFrame:{start_frame}
+                format "#include \"%\"\n" frameVrsceneName to:vrsceneFileHandle
+            )
+            close vrsceneFileHandle
+        )
+    )
+    "SUCCESS"
+) catch (
+    getCurrentException()
+)

--- a/src/deadline/max_submitter/scripts/fix_vrscene_paths.py
+++ b/src/deadline/max_submitter/scripts/fix_vrscene_paths.py
@@ -1,0 +1,120 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#!/usr/bin/env python3
+# V-Ray Export + Path Fix Script
+# Runs 3dsmaxcmd to export the vrscene, then replaces session-specific paths
+# with original source paths so the render step's -remapPath works correctly.
+
+import glob
+import json
+import os
+import subprocess
+import sys
+
+
+def normalize_path(p):
+    return p.replace("\\", "/")
+
+
+def run_export():
+    # Step 1: Run 3dsmaxcmd to export the vrscene
+    maxcmd = r"{{Param.MaxCmdExecutable}}"
+    scene_file = r"{{Param.SceneFile}}"
+    export_script = r"{{Task.File.ExportScript}}"
+
+    cmd = [maxcmd, scene_file, f"-script:{export_script}"]
+    print("=== Running 3dsmaxcmd Export ===")
+    print(f"  Command: {' '.join(cmd)}")
+
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"ERROR: 3dsmaxcmd failed with exit code {result.returncode}")
+        return result.returncode
+
+    print("=== Export completed ===")
+    return 0
+
+
+def fix_vrscene_paths():
+    # Step 2: Fix session paths in the exported vrscene
+    rules_file = normalize_path(r"{{Session.PathMappingRulesFile}}")
+    vrscene_path = normalize_path(r"{{Param.VRSceneOutputPath}}")
+
+    print("=== Fix VRScene Paths ===")
+    print(f"VRScene: {vrscene_path}")
+    print(f"Rules file: {rules_file}")
+
+    # Build reverse mapping: destination (session path) -> source (original path)
+    reverse_map = {}
+    if os.path.exists(rules_file):
+        try:
+            with open(rules_file, "r") as f:
+                data = json.load(f)
+                rules = data.get("path_mapping_rules", [])
+                for rule in rules:
+                    source = rule.get("source_path", "")
+                    dest = rule.get("destination_path", "")
+                    if source and dest:
+                        # Replace dest paths with source paths in the vrscene
+                        # Use both forward-slash and backslash variants
+                        reverse_map[dest.replace("\\", "/")] = source.replace("\\", "/")
+                        reverse_map[dest] = source
+                        print(f"  Reverse map: {dest} -> {source}")
+        except Exception as e:
+            print(f"Warning: Failed to parse rules: {e}")
+    else:
+        print("No path mapping rules found, nothing to fix")
+        return 0
+
+    if not reverse_map:
+        print("No mappings to reverse, nothing to fix")
+        return 0
+
+    # Find all vrscene files (could be multiple for per-frame export)
+    vrscene_dir = os.path.dirname(vrscene_path)
+    vrscene_base = os.path.splitext(os.path.basename(vrscene_path))[0]
+    vrscene_files = glob.glob(os.path.join(vrscene_dir, vrscene_base + "*.vrscene"))
+
+    if not vrscene_files:
+        if os.path.exists(vrscene_path):
+            vrscene_files = [vrscene_path]
+        else:
+            print(f"WARNING: No vrscene files found at {vrscene_path}")
+            return 0
+
+    for vrs_file in vrscene_files:
+        print(f"Processing: {vrs_file}")
+        try:
+            with open(vrs_file, "r", encoding="utf-8", errors="replace") as f:
+                content = f.read()
+
+            replacements = 0
+            for session_path, original_path in reverse_map.items():
+                count = content.count(session_path)
+                if count > 0:
+                    content = content.replace(session_path, original_path)
+                    replacements += count
+                    print(f"  Replaced {count} occurrences of session path")
+
+            if replacements > 0:
+                with open(vrs_file, "w", encoding="utf-8") as f:
+                    f.write(content)
+                print(f"  Fixed {replacements} path(s) in {vrs_file}")
+            else:
+                print(f"  No session paths found in {vrs_file}")
+        except Exception as e:
+            print(f"  ERROR processing {vrs_file}: {e}")
+            return 1
+
+    print("=== Path fix complete ===")
+    return 0
+
+
+def main():
+    rc = run_export()
+    if rc != 0:
+        return rc
+    return fix_vrscene_paths()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/deadline/max_submitter/scripts/path_mapping_render.py
+++ b/src/deadline/max_submitter/scripts/path_mapping_render.py
@@ -1,0 +1,82 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#!/usr/bin/env python3
+# V-Ray Path Mapping Script
+# Reads Deadline Cloud path mapping rules and executes V-Ray with -remapPath args.
+
+import json
+import subprocess
+import os
+import sys
+
+
+def normalize_path(p):
+    return p.replace("\\", "/")
+
+
+def main():
+    rules_file = normalize_path(r"{{Session.PathMappingRulesFile}}")
+    remap_args = []
+
+    if os.path.exists(rules_file):
+        try:
+            with open(rules_file, "r") as f:
+                data = json.load(f)
+                rules = data.get("path_mapping_rules", [])
+                print(f"Found {len(rules)} path mapping rule(s)")
+                for rule in rules:
+                    source = rule.get("source_path", "")
+                    dest = rule.get("destination_path", "")
+                    if source and dest:
+                        remap_args.append(f"-remapPath={source}={dest}")
+                        print(f"  Path mapping: {source} -> {dest}")
+        except Exception as e:
+            print(f"Warning: Failed to parse path mapping rules: {e}")
+    else:
+        print(f"Warning: Path mapping rules file not found: {rules_file}")
+
+    vray_cmd = normalize_path(r"{{Param.VRayExecutable}}")
+    scene_file = normalize_path(r"{{Param.VRSceneOutputPath}}")
+    output_dir = normalize_path(r"{{Param.OutputDir}}")
+    output_filename = r"{{Param.OutputFileName}}"
+    frame = r"{{Task.Param.Frame}}"
+
+    if not os.path.exists(scene_file):
+        print(f"ERROR: Scene file not found: {scene_file}")
+        scene_dir = os.path.dirname(scene_file)
+        if os.path.exists(scene_dir):
+            print(f"Files in {scene_dir}:")
+            for f_name in os.listdir(scene_dir):
+                print(f"  {f_name}")
+        return 1
+
+    # Build output path — pad frame number into filename
+    base, ext = os.path.splitext(output_filename)
+    padded_frame = str(int(frame)).zfill(4)
+    output_filepath = os.path.join(output_dir, f"{base}.{padded_frame}{ext}")
+    os.makedirs(output_dir, exist_ok=True)
+    print(f"Output: {output_filepath}")
+
+    cmd = [
+        vray_cmd,
+        f"-sceneFile={scene_file}",
+        f"-imgFile={output_filepath}",
+        *remap_args,
+        f"-frames={frame}",
+        "-display=0",
+    ]
+
+    print(f"\nExecuting V-Ray:\n  {' '.join(cmd)}\n")
+
+    try:
+        result = subprocess.run(cmd, check=True)
+        return result.returncode
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: V-Ray failed with exit code {e.returncode}", file=sys.stderr)
+        return e.returncode
+    except FileNotFoundError:
+        print(f"ERROR: V-Ray not found: {vray_cmd}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/deadline/max_submitter/scripts/tile_merge.py
+++ b/src/deadline/max_submitter/scripts/tile_merge.py
@@ -1,0 +1,190 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#!/usr/bin/env python3
+# V-Ray Tile Merge Script
+# Merges rendered tile regions into complete frames.
+# V-Ray -region outputs full-size images (only region has pixels, rest is black).
+# Uses Pillow for PNG/TIFF/JPG, OpenEXR+numpy for EXR.
+
+import os
+import subprocess
+import sys
+import tempfile
+
+# Create a known install directory for pip packages
+_pip_target = os.path.join(tempfile.gettempdir(), "deadline_pip_packages")
+os.makedirs(_pip_target, exist_ok=True)
+if _pip_target not in sys.path:
+    sys.path.insert(0, _pip_target)
+
+
+def ensure_package(package_name, import_name=None):
+    import importlib
+
+    if import_name is None:
+        import_name = package_name
+    try:
+        __import__(import_name)
+    except ImportError:
+        print(f"Installing {package_name} to {_pip_target}...")
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--target", _pip_target, package_name],
+            check=True,
+        )
+        importlib.invalidate_caches()
+        __import__(import_name)
+        print(f"Installed {package_name}")
+
+
+def normalize_path(p):
+    return p.replace("\\", "/")
+
+
+def merge_tiles_pillow(tile_paths, grid_cols, grid_rows, image_width, image_height, output_path):
+    from PIL import Image, ImageChops
+
+    delta_x, remainder_x = divmod(image_width, grid_cols)
+    delta_y, remainder_y = divmod(image_height, grid_rows)
+
+    first_tile = Image.open(tile_paths[0])
+    tile_is_fullsize = first_tile.size[0] == image_width and first_tile.size[1] == image_height
+    mode = first_tile.mode
+    first_tile.close()
+
+    if tile_is_fullsize:
+        print("  Full-size tiles — additive compositing")
+    else:
+        print("  Tile-sized tiles — offset pasting")
+
+    canvas = Image.new(mode, (image_width, image_height))
+
+    for row in range(grid_rows):
+        for col in range(grid_cols):
+            tile_index = row * grid_cols + col
+            tile_img = Image.open(tile_paths[tile_index])
+
+            if tile_is_fullsize:
+                canvas = ImageChops.add(canvas, tile_img)
+            else:
+                canvas.paste(tile_img, (delta_x * col, delta_y * row))
+
+            tile_img.close()
+
+    canvas.save(output_path)
+    print(f"Saved: {output_path}")
+
+
+def merge_tiles_exr(tile_paths, grid_cols, grid_rows, image_width, image_height, output_path):
+    import numpy as np
+    import OpenEXR
+    import Imath
+
+    first_exr = OpenEXR.InputFile(tile_paths[0])
+    header = first_exr.header()
+    channels = list(header["channels"].keys())
+    pixel_type = Imath.PixelType(Imath.PixelType.FLOAT)
+
+    dw = header["dataWindow"]
+    tile_w = dw.max.x - dw.min.x + 1
+    tile_h = dw.max.y - dw.min.y + 1
+    first_exr.close()
+
+    tile_is_fullsize = tile_w == image_width and tile_h == image_height
+    print(f"  EXR channels: {channels}")
+
+    delta_x, remainder_x = divmod(image_width, grid_cols)
+    delta_y, remainder_y = divmod(image_height, grid_rows)
+
+    channel_data = {ch: np.zeros((image_height, image_width), dtype=np.float32) for ch in channels}
+
+    for row in range(grid_rows):
+        for col in range(grid_cols):
+            tile_index = row * grid_cols + col
+            exr_file = OpenEXR.InputFile(tile_paths[tile_index])
+            exr_dw = exr_file.header()["dataWindow"]
+            tw = exr_dw.max.x - exr_dw.min.x + 1
+            th = exr_dw.max.y - exr_dw.min.y + 1
+
+            if tile_is_fullsize:
+                for ch in channels:
+                    arr = np.frombuffer(exr_file.channel(ch, pixel_type), dtype=np.float32).reshape(
+                        (th, tw)
+                    )
+                    channel_data[ch] += arr
+            else:
+                x_start = delta_x * col
+                x_end = delta_x * (col + 1)
+                y_start = delta_y * row
+                y_end = delta_y * (row + 1)
+                if col == grid_cols - 1:
+                    x_end += remainder_x
+                if row == grid_rows - 1:
+                    y_end += remainder_y
+                for ch in channels:
+                    arr = np.frombuffer(exr_file.channel(ch, pixel_type), dtype=np.float32).reshape(
+                        (th, tw)
+                    )
+                    channel_data[ch][y_start:y_end, x_start:x_end] = arr
+
+            exr_file.close()
+
+    out_header = OpenEXR.Header(image_width, image_height)
+    out_header["channels"] = header["channels"]
+    out_file = OpenEXR.OutputFile(output_path, out_header)
+    out_file.writePixels({ch: channel_data[ch].tobytes() for ch in channels})
+    out_file.close()
+    print(f"Saved EXR: {output_path}")
+
+
+def main():
+    output_dir = normalize_path(r"{{Param.OutputDir}}")
+    output_filename = r"{{Param.OutputFileName}}"
+    frame = r"{{Task.Param.Frame}}"
+    image_width = int(r"{{Param.ImageWidth}}")
+    image_height = int(r"{{Param.ImageHeight}}")
+    total_cols = int(r"{{Param.RegionColumns}}")
+    total_rows = int(r"{{Param.RegionRows}}")
+
+    base, ext = os.path.splitext(output_filename)
+    padded_frame = str(int(frame)).zfill(4)
+    is_exr = ext.lower() == ".exr"
+
+    print("=== Merge Regions ===")
+    print(f"Frame: {frame}, Grid: {total_cols}x{total_rows}, Image: {image_width}x{image_height}")
+
+    if is_exr:
+        ensure_package("numpy")
+        ensure_package("OpenEXR")
+    else:
+        ensure_package("Pillow", "PIL")
+
+    # Verify tile files exist
+    tile_paths = []
+    missing = 0
+    for row in range(total_rows):
+        for col in range(total_cols):
+            tile_index = row * total_cols + col
+            tile_file = os.path.join(output_dir, f"_tile{tile_index}_{base}.{padded_frame}{ext}")
+            tile_paths.append(tile_file)
+            if not os.path.exists(tile_file):
+                print(f"ERROR: Missing tile: {tile_file}")
+                missing += 1
+
+    if missing > 0:
+        print(f"ERROR: {missing} tile(s) missing")
+        return 1
+
+    final_output = os.path.join(output_dir, f"{base}.{padded_frame}{ext}")
+    print(f"Merging {len(tile_paths)} tiles into: {final_output}")
+
+    if is_exr:
+        merge_tiles_exr(tile_paths, total_cols, total_rows, image_width, image_height, final_output)
+    else:
+        merge_tiles_pillow(
+            tile_paths, total_cols, total_rows, image_width, image_height, final_output
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/deadline/max_submitter/scripts/tile_render.py
+++ b/src/deadline/max_submitter/scripts/tile_render.py
@@ -1,0 +1,102 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#!/usr/bin/env python3
+# V-Ray Tile Render Script
+
+import json
+import os
+import subprocess
+import sys
+
+
+def normalize_path(p):
+    return p.replace("\\", "/")
+
+
+def main():
+    vray_cmd = normalize_path(r"{{Param.VRayExecutable}}")
+    scene_file = normalize_path(r"{{Param.VRSceneOutputPath}}")
+    output_dir = normalize_path(r"{{Param.OutputDir}}")
+    output_filename = r"{{Param.OutputFileName}}"
+    frame = r"{{Task.Param.Frame}}"
+    image_width = int(r"{{Param.ImageWidth}}")
+    image_height = int(r"{{Param.ImageHeight}}")
+    total_cols = int(r"{{Param.RegionColumns}}")
+    total_rows = int(r"{{Param.RegionRows}}")
+
+    # Convert 1-based OpenJD params to 0-based
+    col = int(r"{{Task.Param.RegionCol}}") - 1
+    row = int(r"{{Task.Param.RegionRow}}") - 1
+
+    print("=== Tile Render Task ===")
+    print(f"Frame: {frame}, Col: {col}, Row: {row}")
+    print(f"Image: {image_width}x{image_height}, Grid: {total_cols}x{total_rows}")
+
+    # Pixel-based region coordinates (divmod, last tile gets remainder)
+    delta_x, remainder_x = divmod(image_width, total_cols)
+    delta_y, remainder_y = divmod(image_height, total_rows)
+    x_start = delta_x * col
+    x_end = delta_x * (col + 1)
+    y_start = delta_y * row
+    y_end = delta_y * (row + 1)
+    if col == total_cols - 1:
+        x_end += remainder_x
+    if row == total_rows - 1:
+        y_end += remainder_y
+
+    print(f"Region: [{x_start},{y_start},{x_end},{y_end}]")
+
+    # Tile output filename: _tile{N}_{base}.{frame}.{ext}
+    tile_index = row * total_cols + col
+    base, ext = os.path.splitext(output_filename)
+    padded_frame = str(int(frame)).zfill(4)
+    tile_filename = f"_tile{tile_index}_{base}.{padded_frame}{ext}"
+    tile_filepath = os.path.join(output_dir, tile_filename)
+    print(f"Output: {tile_filepath}")
+
+    # Read path mapping rules
+    rules_file = normalize_path(r"{{Session.PathMappingRulesFile}}")
+    remap_args = []
+    if os.path.exists(rules_file):
+        try:
+            with open(rules_file, "r") as f:
+                data = json.load(f)
+                rules = data.get("path_mapping_rules", [])
+                print(f"Found {len(rules)} path mapping rule(s)")
+                for rule in rules:
+                    source = rule.get("source_path", "")
+                    dest = rule.get("destination_path", "")
+                    if source and dest:
+                        remap_args.append(f"-remapPath={source}={dest}")
+                        print(f"  Path mapping: {source} -> {dest}")
+        except Exception as e:
+            print(f"Warning: Failed to parse path mapping rules: {e}")
+
+    # Build and execute V-Ray command
+    region_str = f"{x_start};{y_start};{x_end};{y_end}"
+    cmd = [
+        vray_cmd,
+        f"-sceneFile={scene_file}",
+        f"-imgFile={tile_filepath}",
+        f"-imgWidth={image_width}",
+        f"-imgHeight={image_height}",
+        f"-region={region_str}",
+        f"-frames={frame}",
+        "-display=0",
+        *remap_args,
+    ]
+
+    print(f"\nExecuting V-Ray:\n  {' '.join(cmd)}\n")
+
+    try:
+        result = subprocess.run(cmd, check=True)
+        return result.returncode
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: V-Ray failed with exit code {e.returncode}", file=sys.stderr)
+        return e.returncode
+    except FileNotFoundError:
+        print(f"ERROR: V-Ray not found: {vray_cmd}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/deadline/max_submitter/ui/submit_dialog.py
+++ b/src/deadline/max_submitter/ui/submit_dialog.py
@@ -7,7 +7,11 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import logging
 
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
-from utilities import submission_utils
+from pymxs import runtime as rt
+from ui.vray_standalone_tab import VRayStandaloneSettingsWidget
+from utilities import max_utils, submission_utils
+from utilities.vrscene_utils import is_vray_renderer
+from vrscene_settings import VRSceneRenderSubmitterUISettings
 
 _logger = logging.getLogger(__name__)
 
@@ -17,7 +21,113 @@ class SubmitMaxJobToDeadlineDialog(SubmitJobToDeadlineDialog):
     Inherited from original SubmitJobToDeadlineDialog.
     - 3ds Max needs custom close function
     - Override the submit function to revert scene to original state when cancel button gets pressed
+    - Adds V-Ray Export tab when V-Ray is the active renderer
     """
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the submit dialog.
+
+        Args:
+            **kwargs: Arguments passed to parent class
+        """
+        # Store the original callback
+        self._original_callback = kwargs.get("on_create_job_bundle_callback")
+
+        # Replace with our wrapper callback
+        kwargs["on_create_job_bundle_callback"] = self._on_create_job_bundle_wrapper
+
+        # Call parent constructor
+        super().__init__(**kwargs)
+
+        # Add V-Ray Export tab if V-Ray is active
+        self._add_vray_export_tab_if_available()
+
+    def _on_create_job_bundle_wrapper(
+        self,
+        widget,
+        job_bundle_dir,
+        settings,
+        queue_parameters,
+        asset_references,
+        output_directories=None,
+        host_requirements=None,
+        purpose=None,
+    ):
+        """
+        Wrapper callback that routes to V-Ray export or regular 3ds Max render.
+
+        Checks if V-Ray Export is enabled and routes accordingly.
+        """
+        # Check if V-Ray Export tab exists and is enabled
+        if hasattr(self, "vray_export_widget") and self.vray_export_widget.is_vray_export_enabled():
+            _logger.info("V-Ray Export is enabled - creating V-Ray export job")
+
+            # Get V-Ray settings from the tab (creates new settings object)
+            vrscene_settings = self.vray_export_widget.update_settings()
+
+            # Update scene file and vrscene filename from current scene
+            vrscene_settings.scene_file = rt.maxFilePath + rt.maxFileName
+            vrscene_settings.vrscene_filename = max_utils.get_scene_name()
+
+            # Imported here to avoid circular import:
+            # submit_dialog -> vray_standalone_submitter -> submit_dialog
+            from vray_standalone_submitter import on_create_vrscene_job_bundle_callback
+
+            on_create_vrscene_job_bundle_callback(
+                widget=widget,
+                job_bundle_dir=job_bundle_dir,
+                settings=vrscene_settings,
+                queue_parameters=queue_parameters,
+                asset_references=asset_references,
+                host_requirements=host_requirements,
+                purpose=purpose,
+            )
+        else:
+            _logger.info("V-Ray Export is disabled - creating regular 3ds Max render job")
+
+            # Call original 3ds Max render job creation
+            if self._original_callback:
+                self._original_callback(
+                    widget=widget,
+                    job_bundle_dir=job_bundle_dir,
+                    settings=settings,
+                    queue_parameters=queue_parameters,
+                    asset_references=asset_references,
+                    output_directories=output_directories,
+                    host_requirements=host_requirements,
+                    purpose=purpose,
+                )
+
+    def _add_vray_export_tab_if_available(self):
+        """
+        Add V-Ray Export tab if V-Ray is the active renderer.
+        """
+        try:
+            if is_vray_renderer():
+                _logger.info("V-Ray detected - adding V-Ray Export tab")
+
+                # Create V-Ray settings
+                vrscene_settings = VRSceneRenderSubmitterUISettings()
+                vrscene_settings.name = max_utils.get_scene_name()
+                vrscene_settings.frame_list = max_utils.get_frames()
+                vrscene_settings.scene_file = rt.maxFilePath + rt.maxFileName
+                vrscene_settings.output_path = max_utils.get_scene_dir()
+                vrscene_settings.vrscene_filename = max_utils.get_scene_name()
+                vrscene_settings.load_sticky_settings()
+
+                # Create V-Ray widget
+                self.vray_export_widget = VRayStandaloneSettingsWidget(
+                    initial_settings=vrscene_settings, parent=self
+                )
+
+                # Add as a new tab
+                if hasattr(self, "tabs"):
+                    self.tabs.addTab(self.vray_export_widget, "V-Ray Export")
+                    _logger.info("V-Ray Export tab added successfully")
+
+        except Exception as e:
+            _logger.warning(f"Could not add V-Ray Export tab: {e}")
 
     def close(self):
         """

--- a/src/deadline/max_submitter/ui/vray_standalone_tab.py
+++ b/src/deadline/max_submitter/ui/vray_standalone_tab.py
@@ -1,0 +1,367 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+3ds Max Deadline Cloud Submitter - V-Ray Standalone Tab UI
+"""
+
+import os
+
+from data_const import (
+    VRSCENE_EXPORT_ANIMATION_MODES,
+)
+from utilities.vrscene_utils import is_vray_renderer
+from qtpy.QtCore import Qt  # type: ignore
+from qtpy.QtWidgets import (  # type: ignore
+    QCheckBox,
+    QComboBox,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QRadioButton,
+    QSizePolicy,
+    QSpacerItem,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class VRayStandaloneSettingsWidget(QWidget):
+    """V-Ray Standalone workflow settings tab."""
+
+    def __init__(self, initial_settings, parent=None):
+        super().__init__(parent=parent)
+
+        self.developer_options = (
+            os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE"
+        )
+
+        self._build_ui(initial_settings)
+        self._configure_settings(initial_settings)
+        self._update_rollout_title()
+
+    def _build_ui(self, settings):
+        main_layout = QVBoxLayout(self)
+
+        # Enable V-Ray Export checkbox at the top
+        self.enable_vray_export_checkbox = QCheckBox("Enable V-Ray Standalone Export")
+        self.enable_vray_export_checkbox.setToolTip(
+            "When enabled, submits a V-Ray Standalone export and render job instead of a 3ds Max render job."
+        )
+        self.enable_vray_export_checkbox.setChecked(False)
+        self.enable_vray_export_checkbox.stateChanged.connect(self._on_enable_changed)
+        main_layout.addWidget(self.enable_vray_export_checkbox)
+
+        # Submit To V-Ray Standalone Group
+        self.vray_export_group = QGroupBox("Submit To V-Ray Standalone")
+        vray_export_layout = QVBoxLayout()
+        self.vray_export_group.setLayout(vray_export_layout)
+        self.vray_export_group.setEnabled(False)  # Disabled by default
+
+        # Export mode radio buttons
+        self.radio_local_export = QRadioButton("Export VRSCENE On This Workstation")
+        self.radio_local_export.setToolTip(
+            "Exporting on the Workstation can block it for a while, but has no 3ds Max startup overhead.\n\n"
+            "Exporting On Deadline offsets the processing time to the network, but requires a Worker running Windows and 3ds Max."
+        )
+        self.radio_farm_export = QRadioButton("Export VRSCENE On Deadline")
+        self.radio_farm_export.setToolTip(
+            "Exporting on the Workstation can block it for a while, but has no 3ds Max startup overhead.\n\n"
+            "Exporting On Deadline offsets the processing time to the network, but requires a Worker running Windows and 3ds Max."
+        )
+
+        vray_export_layout.addWidget(self.radio_local_export)
+        vray_export_layout.addWidget(self.radio_farm_export)
+
+        # Export Animation dropdown
+        export_anim_layout = QHBoxLayout()
+        export_anim_label = QLabel("Export Animation:")
+        self.export_animation_combo = QComboBox()
+        for mode_label, mode_value in VRSCENE_EXPORT_ANIMATION_MODES:
+            self.export_animation_combo.addItem(mode_label, mode_value)
+        self.export_animation_combo.setToolTip(
+            "'Single File' will create one VRSCENE file for the entire animation sequence.\n\n"
+            "'File Per Frame' will create one VRSCENE file for each frame in the animation. "
+            "Each VRSCENE file will be self-contained. This usually produces larger files, but is better suited "
+            "for parallel rendering since rendering each frame depends on exactly one VRSCENE file.\n\n"
+            "'File Per Frame (Incremental)' will produce an initial VRSCENE for the first frame which contains "
+            "all of the initial geometry, materials, and renderer settings. VRSCENE files created for subsequent "
+            "frames will reference the first frame and only specify differential changes for the frame. "
+            "This often reduces the size of the VRSCENE files but the rendering of all frames will depend on "
+            "the first VRSCENE file. When the scene is heavily animated with geometry modifiers this export mode "
+            "degrades and 'Files Per Frame' is preferrable."
+        )
+        export_anim_layout.addWidget(export_anim_label)
+        export_anim_layout.addWidget(self.export_animation_combo)
+        export_anim_layout.addStretch()
+        vray_export_layout.addLayout(export_anim_layout)
+
+        main_layout.addWidget(self.vray_export_group)
+
+        # Job Options Group
+        self.job_options_group = QGroupBox("Job Options")
+        job_options_layout = QGridLayout()
+        self.job_options_group.setLayout(job_options_layout)
+        self.job_options_group.setEnabled(False)  # Disabled by default
+
+        row = 0
+
+        # Job Name
+        job_options_layout.addWidget(QLabel("Job Name:"), row, 0)
+        self.job_name_edit = QLineEdit()
+        job_options_layout.addWidget(self.job_name_edit, row, 1, 1, 3)
+        row += 1
+
+        # Comment
+        job_options_layout.addWidget(QLabel("Comment:"), row, 0)
+        self.comment_edit = QLineEdit()
+        job_options_layout.addWidget(self.comment_edit, row, 1, 1, 3)
+        row += 1
+
+        # Priority
+        job_options_layout.addWidget(QLabel("Priority:"), row, 0)
+        self.priority_spin = QSpinBox()
+        self.priority_spin.setMinimum(0)
+        self.priority_spin.setMaximum(100)
+        self.priority_spin.setValue(50)
+        job_options_layout.addWidget(self.priority_spin, row, 1)
+        row += 1
+
+        # Frame List
+        job_options_layout.addWidget(QLabel("Frame List:"), row, 0)
+        self.frame_list_edit = QLineEdit()
+        self.frame_list_edit.setToolTip("Frame range to render (e.g., 1-100 or 1,5,10-20)")
+        job_options_layout.addWidget(self.frame_list_edit, row, 1, 1, 3)
+        row += 1
+
+        # Output Path
+        job_options_layout.addWidget(QLabel("Output Path:"), row, 0)
+        self.output_path_edit = QLineEdit()
+        self.output_path_edit.setToolTip(
+            "Directory where vrscene files and rendered images will be saved"
+        )
+        job_options_layout.addWidget(self.output_path_edit, row, 1, 1, 2)
+
+        # Browse button for output path
+        self.output_path_browse_btn = QPushButton("Browse...")
+        self.output_path_browse_btn.clicked.connect(self._browse_output_path)
+        job_options_layout.addWidget(self.output_path_browse_btn, row, 3)
+        row += 1
+
+        main_layout.addWidget(self.job_options_group)
+
+        # Region Rendering Group
+        self.region_group = QGroupBox("Region Rendering")
+        region_layout = QGridLayout()
+        self.region_group.setLayout(region_layout)
+        self.region_group.setEnabled(False)  # Disabled by default
+
+        region_layout.addWidget(QLabel("Columns:"), 0, 0)
+        self.region_columns_spin = QSpinBox()
+        self.region_columns_spin.setMinimum(1)
+        self.region_columns_spin.setMaximum(10)
+        self.region_columns_spin.setValue(2)
+        self.region_columns_spin.setToolTip("Number of columns to divide the image into")
+        region_layout.addWidget(self.region_columns_spin, 0, 1)
+
+        region_layout.addWidget(QLabel("Rows:"), 0, 2)
+        self.region_rows_spin = QSpinBox()
+        self.region_rows_spin.setMinimum(1)
+        self.region_rows_spin.setMaximum(10)
+        self.region_rows_spin.setValue(2)
+        self.region_rows_spin.setToolTip("Number of rows to divide the image into")
+        region_layout.addWidget(self.region_rows_spin, 0, 3)
+
+        # Movie creation (deferred to future release)
+        self.create_movie_check = QCheckBox("Create Movie from Frames")
+        self.create_movie_check.setToolTip("Coming in a future release")
+        self.create_movie_check.setVisible(False)
+        self.create_movie_check.stateChanged.connect(self._on_create_movie_changed)
+        region_layout.addWidget(self.create_movie_check, 1, 0, 1, 4)
+
+        self._movie_filename_label = QLabel("  Movie Filename:")
+        self._movie_filename_label.setVisible(False)
+        region_layout.addWidget(self._movie_filename_label, 2, 0)
+        self.movie_filename_edit = QLineEdit()
+        self.movie_filename_edit.setText("output.mp4")
+        self.movie_filename_edit.setVisible(False)
+        region_layout.addWidget(self.movie_filename_edit, 2, 1, 1, 3)
+
+        self._movie_framerate_label = QLabel("  Frame Rate:")
+        self._movie_framerate_label.setVisible(False)
+        region_layout.addWidget(self._movie_framerate_label, 3, 0)
+        self.movie_framerate_spin = QSpinBox()
+        self.movie_framerate_spin.setMinimum(1)
+        self.movie_framerate_spin.setMaximum(120)
+        self.movie_framerate_spin.setValue(24)
+        self.movie_framerate_spin.setVisible(False)
+        region_layout.addWidget(self.movie_framerate_spin, 3, 1)
+
+        # Output format
+        region_layout.addWidget(QLabel("Output Format:"), 4, 0)
+        self.output_format_combo = QComboBox()
+        self.output_format_combo.addItem("Auto-detect", "auto")
+        self.output_format_combo.addItem("PNG", "png")
+        self.output_format_combo.addItem("EXR", "exr")
+        self.output_format_combo.addItem("TIFF", "tiff")
+        self.output_format_combo.addItem("JPG", "jpg")
+        self.output_format_combo.setToolTip(
+            "Output image format for rendered frames. Auto-detect uses the format from 3ds Max render settings."
+        )
+        region_layout.addWidget(self.output_format_combo, 4, 1, 1, 3)
+
+        # Output filename override
+        region_layout.addWidget(QLabel("Output Filename:"), 5, 0)
+        self.output_filename_edit = QLineEdit()
+        self.output_filename_edit.setPlaceholderText("Leave empty to use scene name")
+        self.output_filename_edit.setToolTip(
+            "Override the output filename (without extension). Leave empty to use the scene name."
+        )
+        region_layout.addWidget(self.output_filename_edit, 5, 1, 1, 3)
+
+        main_layout.addWidget(self.region_group)
+
+        # Developer options
+        if self.developer_options:
+            self.include_adaptor_wheels = QCheckBox(
+                "Developer Option: Include Adaptor Wheels", self
+            )
+            main_layout.addWidget(self.include_adaptor_wheels)
+
+        # Spacer
+        main_layout.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding))
+
+        # Check if V-Ray is available
+        if not is_vray_renderer():
+            self.setEnabled(False)
+            status_label = QLabel(
+                "V-Ray Standalone workflow is only available when V-Ray is the active renderer"
+            )
+            status_label.setStyleSheet("QLabel { color: #cc6600; font-style: italic; }")
+            main_layout.addWidget(status_label)
+
+        # Connect signals
+        self.radio_local_export.toggled.connect(self._update_rollout_title)
+        self.radio_farm_export.toggled.connect(self._update_rollout_title)
+
+    def _on_enable_changed(self, state):
+        enabled = state == 2
+        self.vray_export_group.setEnabled(enabled)
+        self.job_options_group.setEnabled(enabled)
+        self.region_group.setEnabled(enabled)
+
+    def is_vray_export_enabled(self):
+        return self.enable_vray_export_checkbox.isChecked()
+
+    def _configure_settings(self, settings):
+        # Set export mode
+        if settings.export_mode == 1:
+            self.radio_local_export.setChecked(True)
+        else:
+            self.radio_farm_export.setChecked(True)
+
+        # Set export animation mode
+        index = self.export_animation_combo.findData(settings.export_animation_mode)
+        if index >= 0:
+            self.export_animation_combo.setCurrentIndex(index)
+
+        # Set job options
+        self.job_name_edit.setText(settings.name)
+        self.comment_edit.setText(settings.description)
+        self.priority_spin.setValue(settings.priority)
+        self.frame_list_edit.setText(settings.frame_list)
+        self.output_path_edit.setText(settings.output_path)
+
+        # Set region settings
+        self.region_columns_spin.setValue(settings.vrscene_render_region_columns)
+        self.region_rows_spin.setValue(settings.vrscene_render_region_rows)
+
+        # Set movie settings
+        self.create_movie_check.setChecked(settings.vrscene_create_movie)
+        self.movie_filename_edit.setText(settings.vrscene_movie_filename)
+        self.movie_framerate_spin.setValue(settings.vrscene_movie_framerate)
+
+        # Set output settings
+        index = self.output_format_combo.findData(settings.output_format)
+        if index >= 0:
+            self.output_format_combo.setCurrentIndex(index)
+        self.output_filename_edit.setText(settings.output_filename_override)
+
+        if self.developer_options:
+            self.include_adaptor_wheels.setChecked(settings.include_adaptor_wheels)
+
+    def _update_rollout_title(self):
+        title = "Submit To V-Ray Standalone"
+        if not self.vray_export_group.isChecked():
+            if self.radio_local_export.isChecked():
+                title += " [Local Export]"
+            else:
+                title += " [On Deadline]"
+        self.vray_export_group.setTitle(title)
+
+    def _on_create_movie_changed(self, state):
+        enabled = state == Qt.Checked
+        self.movie_filename_edit.setEnabled(enabled)
+        self.movie_framerate_spin.setEnabled(enabled)
+
+    def _browse_output_path(self):
+        """Open a directory browser for output path."""
+        from qtpy.QtWidgets import QFileDialog
+
+        current_path = self.output_path_edit.text()
+        if not current_path:
+            from pymxs import runtime as rt
+
+            current_path = rt.maxFilePath
+
+        directory = QFileDialog.getExistingDirectory(
+            self,
+            "Select Output Directory",
+            current_path,
+            QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks,
+        )
+
+        if directory:
+            self.output_path_edit.setText(directory)
+
+    def update_settings(self, settings=None):
+        """Update settings object from current UI values."""
+        # Create new settings if not provided
+        if settings is None:
+            from vrscene_settings import VRSceneRenderSubmitterUISettings
+
+            settings = VRSceneRenderSubmitterUISettings()
+
+        # Export settings
+        settings.export_mode = 1 if self.radio_local_export.isChecked() else 2
+        settings.export_animation_mode = self.export_animation_combo.currentData()
+
+        # Job options
+        settings.name = self.job_name_edit.text()
+        settings.description = self.comment_edit.text()
+        settings.priority = self.priority_spin.value()
+        settings.frame_list = self.frame_list_edit.text()
+        settings.output_path = self.output_path_edit.text()
+
+        # Region settings
+        settings.vrscene_render_region_columns = self.region_columns_spin.value()
+        settings.vrscene_render_region_rows = self.region_rows_spin.value()
+
+        # Movie settings
+        settings.vrscene_create_movie = self.create_movie_check.isChecked()
+        settings.vrscene_movie_filename = self.movie_filename_edit.text()
+        settings.vrscene_movie_framerate = self.movie_framerate_spin.value()
+
+        # Output settings
+        settings.output_format = self.output_format_combo.currentData()
+        settings.output_filename_override = self.output_filename_edit.text()
+
+        if self.developer_options:
+            settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()
+        else:
+            settings.include_adaptor_wheels = False
+
+        return settings

--- a/src/deadline/max_submitter/utilities/vray_executable_utils.py
+++ b/src/deadline/max_submitter/utilities/vray_executable_utils.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Utilities for finding V-Ray and 3ds Max executable paths."""
+
+import logging
+import os
+
+from pymxs import runtime as rt
+
+_logger = logging.getLogger(__name__)
+
+
+def get_vray_executable_path() -> str:
+    """Find vray.exe — checks VRAY_EXECUTABLE env var, then V-Ray environment.
+
+    Set the VRAY_EXECUTABLE environment variable to the full path of vray.exe
+    for reliable detection. Falls back to deriving the path from V-Ray's own
+    environment variables (e.g. VRAY_FOR_3DSMAX2025_MAIN).
+    """
+    # Primary: explicit env var
+    env_path = os.environ.get("VRAY_EXECUTABLE", "")
+    if env_path and os.path.exists(env_path):
+        return env_path
+
+    # Fallback: derive from V-Ray's own env vars (set by V-Ray installer)
+    try:
+        max_version = 2000 + (int(rt.maxVersion()[0] / 1000.0) - 2)
+        vray_main = os.environ.get(f"VRAY_FOR_3DSMAX{max_version}_MAIN", "")
+        if vray_main:
+            candidate = os.path.join(vray_main, "vray.exe")
+            if os.path.exists(candidate):
+                return candidate
+    except Exception as e:
+        _logger.debug(f"V-Ray env var fallback failed: {e}")
+
+    raise FileNotFoundError(
+        "V-Ray executable not found. Please set the VRAY_EXECUTABLE environment "
+        "variable to the full path of vray.exe."
+    )
+
+
+def get_3dsmax_executable_path() -> str:
+    """Find 3dsmaxcmd.exe — checks MAXCMD_EXECUTABLE env var, then current 3ds Max install.
+
+    Set the MAXCMD_EXECUTABLE environment variable to the full path of 3dsmaxcmd.exe
+    for reliable detection. Falls back to the current 3ds Max installation directory.
+    """
+    # Primary: explicit env var
+    env_path = os.environ.get("MAXCMD_EXECUTABLE", "")
+    if env_path and os.path.exists(env_path):
+        return env_path
+
+    # Fallback: derive from current 3ds Max session
+    try:
+        max_dir = rt.symbolicPaths.getPathValue("$max")
+        max_cmd_path = os.path.join(max_dir, "3dsmaxcmd.exe")
+        if os.path.exists(max_cmd_path):
+            return max_cmd_path
+    except Exception as e:
+        _logger.debug(f"3ds Max path fallback failed: {e}")
+
+    raise FileNotFoundError(
+        "3dsmaxcmd.exe not found. Please set the MAXCMD_EXECUTABLE environment "
+        "variable to the full path of 3dsmaxcmd.exe."
+    )

--- a/src/deadline/max_submitter/utilities/vrscene_job_submission.py
+++ b/src/deadline/max_submitter/utilities/vrscene_job_submission.py
@@ -1,0 +1,235 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+V-Ray Standalone Job Submission Utilities
+"""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+_TEMPLATE_DIR = Path(__file__).parent.parent / "job_templates"
+
+
+def _load_job_template(template_name: str) -> dict:
+    """Load a YAML job template from the job_templates directory."""
+    with open(_TEMPLATE_DIR / template_name) as fh:
+        return yaml.safe_load(fh)
+
+
+def _inject_embedded_script(template: dict, placeholder: str, script_content: str) -> None:
+    """Replace a placeholder string in embedded file data fields with actual script content."""
+    for step in template.get("steps", []):
+        # Check step-level script
+        script_section = step.get("script", {})
+        for ef in script_section.get("embeddedFiles", []):
+            if ef.get("data") == placeholder:
+                ef["data"] = script_content
+        # Check stepEnvironments
+        for env in step.get("stepEnvironments", []):
+            env_script = env.get("script", {})
+            for ef in env_script.get("embeddedFiles", []):
+                if ef.get("data") == placeholder:
+                    ef["data"] = script_content
+
+
+def calculate_region_coordinates(
+    column: int,
+    row: int,
+    total_columns: int,
+    total_rows: int,
+    image_width: int,
+    image_height: int,
+) -> Tuple[int, int, int, int]:
+    """
+    Calculate pixel-based region coordinates for a tile (Deadline 10 style).
+    Top-left origin, exclusive end coordinates. Last tile gets remainder pixels.
+
+    Returns (xStart, yStart, xEnd, yEnd) in pixels.
+    """
+    if total_columns < 1 or total_rows < 1:
+        raise ValueError(f"Grid must be at least 1x1, got {total_columns}x{total_rows}")
+    if image_width < 1 or image_height < 1:
+        raise ValueError(f"Image must be at least 1x1, got {image_width}x{image_height}")
+    if column < 0 or column >= total_columns:
+        raise ValueError(f"Column {column} out of bounds for {total_columns} columns")
+    if row < 0 or row >= total_rows:
+        raise ValueError(f"Row {row} out of bounds for {total_rows} rows")
+
+    delta_x, remainder_x = divmod(image_width, total_columns)
+    delta_y, remainder_y = divmod(image_height, total_rows)
+
+    if delta_x < 1 or delta_y < 1:
+        raise ValueError(
+            f"Image {image_width}x{image_height} too small for {total_columns}x{total_rows} grid"
+        )
+
+    # Region boundaries
+    x_start = delta_x * column
+    x_end = delta_x * (column + 1)
+    y_start = delta_y * row
+    y_end = delta_y * (row + 1)
+
+    # Last tile gets remainder
+    if column == total_columns - 1:
+        x_end += remainder_x
+    if row == total_rows - 1:
+        y_end += remainder_y
+
+    return (x_start, y_start, x_end, y_end)
+
+
+def get_tile_index(column: int, row: int, total_columns: int) -> int:
+    """Row-major tile index: row * cols + col."""
+    return row * total_columns + column
+
+
+def _get_tile_render_script() -> str:
+    """Reads the tile_render.py script from the scripts directory."""
+    script_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts")
+    script_path = os.path.join(script_dir, "tile_render.py")
+    with open(script_path, "r") as f:
+        return f.read()
+
+
+def _get_tile_merge_script() -> str:
+    """Reads the tile_merge.py script from the scripts directory."""
+    script_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts")
+    script_path = os.path.join(script_dir, "tile_merge.py")
+    with open(script_path, "r") as f:
+        return f.read()
+
+
+def create_tile_rendering_job_template(
+    settings,
+    vrscene_path: str,
+    output_filename: str,
+    start_frame: int,
+    end_frame: int,
+) -> Dict[str, Any]:
+    """
+    Create job template with tile rendering steps. Loaded from YAML.
+
+    Steps: RenderRegions (N×M tasks/frame) → MergeRegions (1 task/frame).
+    """
+    template = _load_job_template("vray_tile_render_job_template.yaml")
+    template["name"] = f"{settings.name} - VRay Tile Render"
+
+    # Inject embedded scripts
+    _inject_embedded_script(template, "INJECT_TILE_RENDER_SCRIPT", _get_tile_render_script())
+    _inject_embedded_script(template, "INJECT_TILE_MERGE_SCRIPT", _get_tile_merge_script())
+
+    # Set dynamic parameter defaults from settings
+    if start_frame == end_frame:
+        frames = str(start_frame)
+    else:
+        frames = f"{start_frame}-{end_frame}"
+
+    defaults = {
+        "OutputFileName": output_filename,
+        "Frames": frames,
+        "ImageWidth": str(settings.image_width),
+        "ImageHeight": str(settings.image_height),
+        "RegionColumns": str(settings.vrscene_render_region_columns),
+        "RegionRows": str(settings.vrscene_render_region_rows),
+        "CreateMovie": "true" if settings.vrscene_create_movie else "false",
+        "MovieFilename": settings.vrscene_movie_filename,
+        "FrameRate": str(settings.vrscene_movie_framerate),
+    }
+    for param in template.get("parameterDefinitions", []):
+        if param["name"] in defaults:
+            param["default"] = defaults[param["name"]]
+
+    return template
+
+
+def _get_create_movie_script() -> str:
+    """Reads the create_movie.py script from the scripts directory."""
+    script_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts")
+    script_path = os.path.join(script_dir, "create_movie.py")
+    with open(script_path, "r") as f:
+        return f.read()
+
+
+def create_vrscene_render_job_parameters(
+    settings,
+    vrscene_path: str,
+    output_path: str,
+    start_frame: int,
+    end_frame: int,
+    vray_executable: str,
+) -> List[Dict[str, Any]]:
+    """Create parameter values for vrscene render job."""
+    # Determine frame range string
+    if start_frame == end_frame:
+        frames = str(start_frame)
+    else:
+        frames = f"{start_frame}-{end_frame}"
+
+    # Get output filename from vrscene
+    vrscene_name = Path(vrscene_path).stem
+    output_filename = f"{vrscene_name}.png"
+
+    parameters = [
+        {"name": "VRayExecutable", "value": vray_executable},
+        {"name": "VRSceneOutputPath", "value": vrscene_path},
+        {"name": "OutputDir", "value": output_path},
+        {"name": "OutputFileName", "value": output_filename},
+        {"name": "Frames", "value": frames},
+        {"name": "RegionColumns", "value": str(settings.vrscene_render_region_columns)},
+        {"name": "RegionRows", "value": str(settings.vrscene_render_region_rows)},
+    ]
+
+    return parameters
+
+
+def create_export_job_parameters(
+    settings,
+    vrscene_path: str,
+    start_frame: int,
+    end_frame: int,
+) -> List[Dict[str, Any]]:
+    """Create parameter values for vrscene export job (farm mode)."""
+    parameters = [
+        {"name": "SceneFile", "value": settings.scene_file},
+        {"name": "VRSceneOutputPath", "value": vrscene_path},
+        {"name": "StartFrame", "value": str(start_frame)},
+        {"name": "EndFrame", "value": str(end_frame)},
+        {"name": "ExportAnimationMode", "value": str(settings.export_animation_mode)},
+    ]
+
+    return parameters
+
+
+def get_frame_range_from_string(frame_string: str) -> Tuple[int, int]:
+    """Parse frame range string (e.g. "1-100") and return (start, end)."""
+    # Handle simple cases
+    if "-" in frame_string:
+        parts = frame_string.split("-")
+        start = int(parts[0].split(",")[-1].strip())
+        end = int(parts[-1].split(",")[0].strip())
+        return start, end
+    elif "," in frame_string:
+        frames = [int(f.strip()) for f in frame_string.split(",")]
+        return min(frames), max(frames)
+    else:
+        frame = int(frame_string.strip())
+        return frame, frame
+
+
+def create_export_job_template() -> Dict[str, Any]:
+    """Create job template for vrscene export job (farm mode). Loaded from YAML."""
+    template = _load_job_template("vray_export_job_template.yaml")
+    _inject_embedded_script(template, "INJECT_EXPORT_SCRIPT", _get_export_script_content())
+    return template
+
+
+def _get_export_script_content() -> str:
+    """Read the MAXScript export script from the scripts directory."""
+    script_path = Path(__file__).parent.parent / "scripts" / "export_vrscene_farm.ms"
+    if not script_path.exists():
+        raise FileNotFoundError(f"Export script not found at {script_path}")
+    with open(script_path, "r") as f:
+        return f.read()

--- a/src/deadline/max_submitter/utilities/vrscene_utils.py
+++ b/src/deadline/max_submitter/utilities/vrscene_utils.py
@@ -1,0 +1,179 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+V-Ray Scene Export Utilities
+"""
+
+import logging
+import os
+from typing import List, Tuple
+
+from pymxs import runtime as rt
+
+_logger = logging.getLogger(__name__)
+
+
+def is_vray_renderer() -> bool:
+    """Check if the current renderer is V-Ray."""
+    try:
+        renderer_class = str(rt.classof(rt.renderers.current))
+        return "VRay" in renderer_class or "V_Ray" in renderer_class
+    except Exception:
+        return False
+
+
+def get_vrscene_filename(scene_name: str, output_path: str) -> str:
+    """Generate vrscene filepath from scene name and output directory."""
+    if not scene_name:
+        scene_name = "untitled"
+
+    vrscene_name = f"{scene_name}.vrscene"
+    return os.path.join(output_path, vrscene_name)
+
+
+def get_frame_vrscene_filename(base_path: str, frame: int) -> str:
+    """Generate frame-specific vrscene filename (e.g. scene.0001.vrscene)."""
+    dir_path = os.path.dirname(base_path)
+    base_name = os.path.splitext(os.path.basename(base_path))[0]
+    ext = os.path.splitext(base_path)[1]
+
+    padded_frame = f"{frame:04d}"
+    return os.path.join(dir_path, f"{base_name}.{padded_frame}{ext}")
+
+
+def export_vrscene_local(
+    vrscene_path: str,
+    start_frame: int,
+    end_frame: int,
+    export_animation_mode: int,
+) -> Tuple[bool, str]:
+    """Export vrscene file(s) locally. Returns (success, message)."""
+    if not is_vray_renderer():
+        return False, "Current renderer is not V-Ray. Cannot export vrscene."
+
+    try:
+        # Ensure output directory exists
+        os.makedirs(os.path.dirname(vrscene_path), exist_ok=True)
+
+        _logger.info(f"Exporting V-Ray scene to: {vrscene_path}")
+        _logger.info(f"Export mode: {export_animation_mode}, Frames: {start_frame}-{end_frame}")
+
+        # Escape backslashes for MAXScript
+        vrscene_path_escaped = vrscene_path.replace("\\", "\\\\")
+        output_dir_escaped = os.path.dirname(vrscene_path).replace("\\", "\\\\")
+        base_name = os.path.splitext(os.path.basename(vrscene_path))[0]
+
+        # Load MAXScript export template and inject runtime values
+        script_path = os.path.join(
+            os.path.dirname(__file__), "..", "scripts", "export_vrscene_local.ms"
+        )
+        with open(script_path, "r") as f:
+            template = f.read()
+        export_script = template.format(
+            export_animation_mode=export_animation_mode,
+            start_frame=start_frame,
+            end_frame=end_frame,
+            vrscene_path_escaped=vrscene_path_escaped,
+            output_dir_escaped=output_dir_escaped,
+            base_name=base_name,
+        )
+
+        result = rt.execute(export_script)
+
+        if result and "SUCCESS" in str(result):
+            _logger.info("Successfully exported vrscene")
+            return True, vrscene_path
+        else:
+            error_msg = f"Failed to export vrscene: {result}"
+            _logger.error(error_msg)
+            return False, error_msg
+
+    except Exception as e:
+        error_msg = f"Exception during vrscene export: {str(e)}"
+        _logger.error(error_msg)
+        return False, error_msg
+
+
+def validate_vrscene_export_settings(settings) -> List[str]:
+    """Validate settings, return list of error messages (empty if valid)."""
+    errors = []
+
+    # Check if V-Ray is the current renderer
+    if not is_vray_renderer():
+        errors.append("V-Ray scene export requires V-Ray as the active renderer")
+        return errors
+
+    # Validate output path
+    if settings.export_mode == 1:  # Local export
+        output_dir = settings.output_path
+        if not output_dir:
+            errors.append("Output path cannot be empty")
+        else:
+            try:
+                os.makedirs(output_dir, exist_ok=True)
+            except Exception as e:
+                errors.append(f"Cannot write to output directory: {output_dir} - {str(e)}")
+
+    # Validate frame range
+    if not settings.frame_list or not settings.frame_list.strip():
+        errors.append("Frame range cannot be empty")
+
+    # Validate region settings
+    if settings.vrscene_render_region_columns < 1 or settings.vrscene_render_region_columns > 10:
+        errors.append("Region columns must be between 1 and 10")
+
+    if settings.vrscene_render_region_rows < 1 or settings.vrscene_render_region_rows > 10:
+        errors.append("Region rows must be between 1 and 10")
+
+    return errors
+
+
+def get_output_format_from_scene() -> str:
+    """Auto-detect output format from 3ds Max render settings. Defaults to 'png'."""
+    try:
+        # Query 3ds Max render output filename
+        output_filename = rt.rendOutputFilename
+
+        if output_filename and str(output_filename).strip():
+            # Extract extension
+            _, ext = os.path.splitext(str(output_filename))
+
+            if ext:
+                # Normalize and validate
+                normalized = normalize_output_format(ext)
+                if validate_output_format(normalized):
+                    _logger.info(f"Detected output format from scene: {normalized}")
+                    return normalized
+
+        _logger.info("No output format detected, defaulting to png")
+        return "png"
+
+    except Exception as e:
+        _logger.warning(f"Error detecting output format: {e}, defaulting to png")
+        return "png"
+
+
+def validate_output_format(format_str: str) -> bool:
+    """Check if format is supported (png, exr, tiff, tif, jpg, jpeg)."""
+    # Normalize first
+    normalized = normalize_output_format(format_str)
+
+    # List of supported formats
+    supported_formats = {"png", "exr", "tiff", "tif", "jpg", "jpeg"}
+
+    return normalized in supported_formats
+
+
+def normalize_output_format(format_str: str) -> str:
+    """Normalize format to lowercase without leading dot (e.g. '.PNG' -> 'png')."""
+    if not format_str:
+        return ""
+
+    # Convert to string and strip whitespace
+    normalized = str(format_str).strip().lower()
+
+    # Remove leading dot if present
+    if normalized.startswith("."):
+        normalized = normalized[1:]
+
+    return normalized

--- a/src/deadline/max_submitter/vray_standalone_submitter.py
+++ b/src/deadline/max_submitter/vray_standalone_submitter.py
@@ -1,0 +1,523 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+3ds Max Deadline Cloud Submitter - V-Ray Standalone Workflow
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import pymxs  # noqa
+import qtmax
+from deadline.client.job_bundle._yaml import deadline_yaml_dump
+from deadline.client.job_bundle.submission import AssetReferences
+from deadline.client.ui.dialogs._types import JobBundlePurpose
+from pymxs import runtime as rt
+from qtpy.QtCore import Qt  # type: ignore
+from ui.submit_dialog import SubmitMaxJobToDeadlineDialog
+from ui.vray_standalone_tab import VRayStandaloneSettingsWidget
+from utilities import max_utils
+from utilities.vrscene_job_submission import (
+    _inject_embedded_script,
+    _load_job_template,
+    create_tile_rendering_job_template,
+    create_vrscene_render_job_parameters,
+    get_frame_range_from_string,
+)
+from utilities.vrscene_utils import (
+    export_vrscene_local,
+    get_output_format_from_scene,
+    get_vrscene_filename,
+    normalize_output_format,
+    validate_vrscene_export_settings,
+)
+from utilities.vray_executable_utils import (
+    get_vray_executable_path,
+    get_3dsmax_executable_path,
+)
+from vrscene_settings import VRSceneRenderSubmitterUISettings
+
+_logger = logging.getLogger(__name__)
+
+
+def _get_fix_vrscene_paths_script() -> str:
+    """
+    Reads the fix_vrscene_paths.py script from the scripts directory.
+    This script exports vrscene via 3dsmaxcmd, then reverses
+    session-specific paths back to originals so render -remapPath works.
+    """
+    script_path = os.path.join(os.path.dirname(__file__), "scripts", "fix_vrscene_paths.py")
+    with open(script_path, "r") as f:
+        return f.read()
+
+
+def _get_path_mapping_script() -> str:
+    """
+    Reads the path_mapping_render.py script from the scripts directory.
+    This script reads path mapping rules and executes V-Ray with -remapPath arguments.
+    """
+    script_path = os.path.join(os.path.dirname(__file__), "scripts", "path_mapping_render.py")
+    with open(script_path, "r") as f:
+        return f.read()
+
+
+def on_create_vrscene_job_bundle_callback(
+    widget: SubmitMaxJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: VRSceneRenderSubmitterUISettings,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+) -> None:
+    """Callback for creating V-Ray Standalone job bundle (local or farm export)."""
+    _logger.debug("Start on_create_vrscene_job_bundle_callback")
+
+    # Validate settings
+    validation_errors = validate_vrscene_export_settings(settings)
+    if validation_errors:
+        error_msg = "Validation failed:\n" + "\n".join(validation_errors)
+        _logger.error(error_msg)
+        raise ValueError(error_msg)
+
+    # Get frame range
+    start_frame, end_frame = get_frame_range_from_string(settings.frame_list)
+
+    # Generate vrscene filename
+    scene_name = max_utils.get_scene_name()
+    vrscene_path = get_vrscene_filename(scene_name, settings.output_path)
+
+    job_bundle_path = Path(job_bundle_dir)
+
+    if settings.export_mode == 1:
+        # ===== LOCAL EXPORT MODE =====
+        _logger.info("Exporting vrscene locally...")
+
+        success, message = export_vrscene_local(
+            vrscene_path,
+            start_frame,
+            end_frame,
+            settings.export_animation_mode,
+        )
+
+        if not success:
+            raise RuntimeError(f"Failed to export vrscene: {message}")
+
+        _logger.info(f"Successfully exported vrscene to: {message}")
+
+        # Add vrscene file(s) to asset references
+        if settings.export_animation_mode == 1:
+            # Single file
+            asset_references.input_filenames.add(vrscene_path)
+        elif settings.export_animation_mode == 2:
+            # File per frame - add all frame files
+            dir_path = os.path.dirname(vrscene_path)
+            base_name = os.path.splitext(os.path.basename(vrscene_path))[0]
+            for frame in range(start_frame, end_frame + 1):
+                frame_file = os.path.join(dir_path, f"{base_name}.{frame:04d}.vrscene")
+                if os.path.exists(frame_file):
+                    asset_references.input_filenames.add(frame_file)
+        else:
+            # Incremental - add master file and all frame files
+            asset_references.input_filenames.add(vrscene_path)
+            dir_path = os.path.dirname(vrscene_path)
+            base_name = os.path.splitext(os.path.basename(vrscene_path))[0]
+            for frame in range(start_frame, end_frame + 1):
+                frame_file = os.path.join(dir_path, f"{base_name}.{frame:04d}.vrscene")
+                if os.path.exists(frame_file):
+                    asset_references.input_filenames.add(frame_file)
+
+        # Create render job bundle using vrscene template
+        _create_vrscene_render_job_bundle(
+            job_bundle_path,
+            settings,
+            vrscene_path,
+            start_frame,
+            end_frame,
+            queue_parameters,
+            asset_references,
+        )
+
+    else:
+        # ===== FARM EXPORT MODE =====
+        _logger.info("Creating combined export and render job bundle...")
+
+        # Create a single job bundle with both export and render steps
+        _create_combined_export_render_job_bundle(
+            job_bundle_path,
+            settings,
+            vrscene_path,
+            start_frame,
+            end_frame,
+            queue_parameters,
+            asset_references,
+        )
+
+    # Save sticky settings
+    settings.save_sticky_settings()
+
+
+def _get_export_maxscript(settings, start_frame: int, end_frame: int) -> str:
+    """Read the farm export MAXScript template and fill in runtime values."""
+    script_path = os.path.join(os.path.dirname(__file__), "scripts", "export_vrscene_farm.ms")
+    with open(script_path, "r") as f:
+        template = f.read()
+    return template.format(
+        export_animation_mode=settings.export_animation_mode,
+        start_frame=start_frame,
+        end_frame=end_frame,
+    )
+
+
+def _create_combined_export_render_job_bundle(
+    job_bundle_path: Path,
+    settings: VRSceneRenderSubmitterUISettings,
+    vrscene_path: str,
+    start_frame: int,
+    end_frame: int,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+) -> None:
+    """
+    Create job bundle with export + render steps (farm mode).
+    When tile rendering is enabled, adds RenderRegions/MergeRegions steps.
+    """
+    _logger.info("Creating combined export and render job bundle...")
+
+    max_executable = get_3dsmax_executable_path()
+    vray_executable = get_vray_executable_path()
+    _logger.info(f"Using 3ds Max executable: {max_executable}")
+    _logger.info(f"Using V-Ray executable: {vray_executable}")
+
+    # Determine frame range string
+    if start_frame == end_frame:
+        frames = str(start_frame)
+    else:
+        frames = f"{start_frame}-{end_frame}"
+
+    output_filename = _determine_output_filename(settings, vrscene_path)
+    _logger.info(f"Output filename: {output_filename}")
+
+    tile_rendering = _is_tile_rendering_enabled(settings)
+    if tile_rendering:
+        _logger.info(
+            f"Tile rendering enabled: {settings.vrscene_render_region_columns}x"
+            f"{settings.vrscene_render_region_rows}"
+        )
+
+    # Load base template (parameter definitions)
+    job_template = _load_job_template("vray_combined_job_template.yaml")
+    job_template["name"] = f"{settings.name} - VRay Export and Render"
+
+    # Set dynamic parameter defaults
+    defaults = {
+        "Frames": frames,
+        "ExportAnimationMode": str(settings.export_animation_mode),
+        "OutputFileName": output_filename,
+        "RegionColumns": str(settings.vrscene_render_region_columns),
+        "RegionRows": str(settings.vrscene_render_region_rows),
+    }
+    for param in job_template.get("parameterDefinitions", []):
+        if param["name"] in defaults:
+            param["default"] = defaults[param["name"]]
+
+    # Build the export step (dynamic MAXScript content)
+    export_step = {
+        "name": "ExportVRScene",
+        "parameterSpace": {
+            "taskParameterDefinitions": [
+                {
+                    "name": "Frame",
+                    "type": "INT",
+                    "range": "{{Param.Frames}}",
+                }
+            ]
+        },
+        "script": {
+            "embeddedFiles": [
+                {
+                    "name": "ExportScript",
+                    "type": "TEXT",
+                    "filename": "export_vrscene.ms",
+                    "data": _get_export_maxscript(settings, start_frame, end_frame),
+                },
+                {
+                    "name": "FixVRScenePaths",
+                    "type": "TEXT",
+                    "filename": "fix_vrscene_paths.py",
+                    "data": _get_fix_vrscene_paths_script(),
+                },
+            ],
+            "actions": {
+                "onRun": {
+                    "command": "python",
+                    "args": ["{{Task.File.FixVRScenePaths}}"],
+                },
+            },
+        },
+    }
+
+    # Build parameter values
+    parameter_values = [
+        {"name": "MaxCmdExecutable", "value": max_executable},
+        {"name": "VRayExecutable", "value": vray_executable},
+        {"name": "SceneFile", "value": settings.scene_file},
+        {"name": "VRSceneOutputPath", "value": vrscene_path},
+        {"name": "OutputDir", "value": settings.output_path},
+        {"name": "Frames", "value": frames},
+        {"name": "ExportAnimationMode", "value": str(settings.export_animation_mode)},
+        {"name": "OutputFileName", "value": output_filename},
+        {"name": "RegionColumns", "value": str(settings.vrscene_render_region_columns)},
+        {"name": "RegionRows", "value": str(settings.vrscene_render_region_rows)},
+    ]
+
+    if tile_rendering:
+        # Add tile rendering parameters
+        tile_params = [
+            {"name": "ImageWidth", "type": "INT", "default": str(settings.image_width)},
+            {"name": "ImageHeight", "type": "INT", "default": str(settings.image_height)},
+            {
+                "name": "CreateMovie",
+                "type": "STRING",
+                "default": "true" if settings.vrscene_create_movie else "false",
+                "allowedValues": ["true", "false"],
+            },
+            {"name": "MovieFilename", "type": "STRING", "default": settings.vrscene_movie_filename},
+            {
+                "name": "FrameRate",
+                "type": "INT",
+                "default": str(settings.vrscene_movie_framerate),
+            },
+        ]
+        job_template["parameterDefinitions"].extend(tile_params)
+
+        parameter_values.extend(
+            [
+                {"name": "ImageWidth", "value": str(settings.image_width)},
+                {"name": "ImageHeight", "value": str(settings.image_height)},
+                {
+                    "name": "CreateMovie",
+                    "value": "true" if settings.vrscene_create_movie else "false",
+                },
+                {"name": "MovieFilename", "value": settings.vrscene_movie_filename},
+                {"name": "FrameRate", "value": str(settings.vrscene_movie_framerate)},
+            ]
+        )
+
+        # Get tile rendering steps from the tile template
+        tile_template = create_tile_rendering_job_template(
+            settings, vrscene_path, output_filename, start_frame, end_frame
+        )
+        tile_steps = tile_template["steps"]
+        tile_steps[0]["dependencies"] = [{"dependsOn": "ExportVRScene"}]
+
+        job_template["steps"] = [export_step] + tile_steps
+    else:
+        # Load render step from the render template
+        render_template = _load_job_template("vray_render_job_template.yaml")
+        _inject_embedded_script(
+            render_template, "INJECT_PATH_MAPPING_SCRIPT", _get_path_mapping_script()
+        )
+        render_step = render_template["steps"][0]
+        render_step["dependencies"] = [{"dependsOn": "ExportVRScene"}]
+
+        job_template["steps"] = [export_step, render_step]
+
+    # Add queue parameters
+    parameter_values.extend(queue_parameters)
+
+    # Write template
+    with open(job_bundle_path / "template.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump(job_template, f, indent=1)
+
+    # Write parameter values
+    with open(job_bundle_path / "parameter_values.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump({"parameterValues": parameter_values}, f, indent=1)
+
+    # Write asset references
+    with open(job_bundle_path / "asset_references.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump(asset_references.to_dict(), f, indent=1)
+
+    _logger.info(f"Combined export and render job bundle created at: {job_bundle_path}")
+
+
+def _determine_output_filename(
+    settings: VRSceneRenderSubmitterUISettings, vrscene_path: str
+) -> str:
+    """Determine output filename from user override or auto-detect + format."""
+    if settings.output_filename_override and settings.output_filename_override.strip():
+        return settings.output_filename_override.strip()
+
+    # Determine format: use configured format or auto-detect
+    if settings.output_format and settings.output_format.lower() != "auto":
+        fmt = normalize_output_format(settings.output_format)
+    else:
+        fmt = get_output_format_from_scene()
+
+    if not fmt:
+        fmt = "png"
+
+    vrscene_name = Path(vrscene_path).stem
+    return f"{vrscene_name}.{fmt}"
+
+
+def _is_tile_rendering_enabled(settings: VRSceneRenderSubmitterUISettings) -> bool:
+    """Check if tile rendering is enabled (more than 1 column or 1 row)."""
+    return settings.vrscene_render_region_columns > 1 or settings.vrscene_render_region_rows > 1
+
+
+def _create_vrscene_render_job_bundle(
+    job_bundle_path: Path,
+    settings: VRSceneRenderSubmitterUISettings,
+    vrscene_path: str,
+    start_frame: int,
+    end_frame: int,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+    export_job_dependency: bool = False,
+) -> None:
+    """
+    Create job bundle for vrscene render job (local export mode).
+    Uses tile rendering template when columns > 1 or rows > 1.
+    """
+    _logger.info("Creating vrscene render job bundle...")
+
+    vray_executable = get_vray_executable_path()
+    _logger.info(f"Using V-Ray executable: {vray_executable}")
+
+    output_filename = _determine_output_filename(settings, vrscene_path)
+    _logger.info(f"Output filename: {output_filename}")
+
+    if _is_tile_rendering_enabled(settings):
+        # Tile rendering: use the multi-step tile template
+        _logger.info(
+            f"Tile rendering enabled: {settings.vrscene_render_region_columns}x"
+            f"{settings.vrscene_render_region_rows}"
+        )
+        job_template = create_tile_rendering_job_template(
+            settings,
+            vrscene_path,
+            output_filename,
+            start_frame,
+            end_frame,
+        )
+
+        # Build parameter values for tile rendering
+        if start_frame == end_frame:
+            frames = str(start_frame)
+        else:
+            frames = f"{start_frame}-{end_frame}"
+
+        parameter_values = [
+            {"name": "VRayExecutable", "value": vray_executable},
+            {"name": "VRSceneOutputPath", "value": vrscene_path},
+            {"name": "OutputDir", "value": settings.output_path},
+            {"name": "OutputFileName", "value": output_filename},
+            {"name": "Frames", "value": frames},
+            {"name": "ImageWidth", "value": str(settings.image_width)},
+            {"name": "ImageHeight", "value": str(settings.image_height)},
+            {"name": "RegionColumns", "value": str(settings.vrscene_render_region_columns)},
+            {"name": "RegionRows", "value": str(settings.vrscene_render_region_rows)},
+            {"name": "CreateMovie", "value": "true" if settings.vrscene_create_movie else "false"},
+            {"name": "MovieFilename", "value": settings.vrscene_movie_filename},
+            {"name": "FrameRate", "value": str(settings.vrscene_movie_framerate)},
+        ]
+    else:
+        # Standard single-step render (no tiling) — load from YAML template
+        job_template = _load_job_template("vray_render_job_template.yaml")
+        job_template["name"] = f"{settings.name} - VRay Standalone Render"
+        _inject_embedded_script(
+            job_template, "INJECT_PATH_MAPPING_SCRIPT", _get_path_mapping_script()
+        )
+
+        parameter_values = create_vrscene_render_job_parameters(
+            settings,
+            vrscene_path,
+            settings.output_path,
+            start_frame,
+            end_frame,
+            vray_executable,
+        )
+
+    # Add queue parameters
+    parameter_values.extend(queue_parameters)
+
+    # Write template
+    with open(job_bundle_path / "template.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump(job_template, f, indent=1)
+
+    # Write parameter values
+    with open(job_bundle_path / "parameter_values.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump({"parameterValues": parameter_values}, f, indent=1)
+
+    # Write asset references
+    with open(job_bundle_path / "asset_references.yaml", "w", encoding="utf8") as f:
+        deadline_yaml_dump(asset_references.to_dict(), f, indent=1)
+
+    _logger.info(f"Render job bundle created at: {job_bundle_path}")
+
+
+def show_vray_standalone_submitter():
+    """Show the V-Ray Standalone submitter UI."""
+    _logger.info("Opening Deadline Cloud V-Ray Standalone Submitter interface")
+
+    # Get main max window
+    main_window = qtmax.GetQMaxMainWindow()
+
+    # Create settings
+    vrscene_settings = VRSceneRenderSubmitterUISettings()
+
+    # Set settings dependent on scene
+    vrscene_settings.name = max_utils.get_scene_name()
+    vrscene_settings.frame_list = max_utils.get_frames()
+    vrscene_settings.scene_file = rt.maxFilePath + rt.maxFileName
+    vrscene_settings.output_path = max_utils.get_scene_dir()
+    vrscene_settings.vrscene_filename = max_utils.get_scene_name()
+
+    # Get image resolution for tile coordinate calculation
+    vrscene_settings.image_width = rt.renderWidth
+    vrscene_settings.image_height = rt.renderHeight
+
+    # Load sticky settings
+    vrscene_settings.load_sticky_settings()
+
+    # Set output directories
+    output_directories: set[str] = {vrscene_settings.output_path}
+    vrscene_settings.output_directories = list(output_directories)
+
+    # Fill in auto-detected input files
+    auto_detected_attachments = AssetReferences()
+    relative_dir_base = rt.maxFilePath
+    input_files: set[str] = {
+        os.path.abspath(os.path.normpath(os.path.join(relative_dir_base, path)))
+        for path in max_utils.get_referenced_files()
+    }
+    auto_detected_attachments.input_filenames = input_files
+
+    attachments = AssetReferences(
+        input_filenames=set(vrscene_settings.input_filenames),
+        input_directories=set(vrscene_settings.input_directories),
+        output_directories=set(vrscene_settings.output_directories),
+    )
+
+    # For V-Ray Standalone, we need vray package instead of 3dsmax
+    conda_packages = "vray imagemagick ffmpeg"
+
+    # Instantiate and show the Submitter UI
+    window = SubmitMaxJobToDeadlineDialog(
+        job_setup_widget_type=VRayStandaloneSettingsWidget,
+        initial_job_settings=vrscene_settings,
+        initial_shared_parameter_values={
+            "CondaPackages": conda_packages,
+        },
+        auto_detected_attachments=auto_detected_attachments,
+        attachments=attachments,
+        on_create_job_bundle_callback=on_create_vrscene_job_bundle_callback,
+        parent=main_window,
+        f=Qt.Tool,
+        show_host_requirements_tab=False,  # Not needed for vrscene rendering
+    )
+    window.show()
+    return window

--- a/src/deadline/max_submitter/vrscene_settings.py
+++ b/src/deadline/max_submitter/vrscene_settings.py
@@ -1,0 +1,103 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""V-Ray Standalone Settings Data Class."""
+
+import dataclasses
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+import pymxs  # noqa
+from data_const import VRSCENE_SUBMITTER_SETTINGS_FILE_EXT
+from pymxs import runtime as rt
+
+
+@dataclass
+class VRSceneRenderSubmitterUISettings:
+    """Settings for V-Ray Standalone workflow."""
+
+    submitter_name: str = field(default="VRayStandalone")
+
+    # Shared job settings
+    name: str = field(default="", metadata={"sticky": True})
+    description: str = field(default="", metadata={"sticky": True})
+    priority: int = field(default=50, metadata={"sticky": True})
+    initial_status: str = field(default="READY", metadata={"sticky": True})
+    max_failed_tasks_count: int = field(default=20, metadata={"sticky": True})
+    max_retries_per_task: int = field(default=5, metadata={"sticky": True})
+
+    # Export settings
+    export_mode: int = field(default=1, metadata={"sticky": True})  # 1=Local, 2=Farm
+    export_animation_mode: int = field(
+        default=1, metadata={"sticky": True}
+    )  # 1=Single, 2=PerFrame, 3=Incremental
+
+    # Scene settings
+    scene_file: str = field(default="")
+    output_path: str = field(default="")
+    vrscene_filename: str = field(default="")  # Derived from scene name
+    frame_list: str = field(default="", metadata={"sticky": True})
+
+    # V-Ray Standalone Render Options
+    vrscene_render_region_columns: int = field(default=2, metadata={"sticky": True})
+    vrscene_render_region_rows: int = field(default=2, metadata={"sticky": True})
+    vrscene_create_movie: bool = field(default=False, metadata={"sticky": True})
+    vrscene_movie_filename: str = field(default="output.mp4", metadata={"sticky": True})
+    vrscene_movie_framerate: int = field(default=24, metadata={"sticky": True})
+
+    # Output settings
+    output_format: str = field(default="auto", metadata={"sticky": True})
+    output_filename_override: str = field(default="", metadata={"sticky": True})
+
+    # Image resolution (read from 3ds Max render settings at submission time)
+    image_width: int = field(default=1920)
+    image_height: int = field(default=1080)
+
+    # Attachments
+    input_filenames: List[str] = field(default_factory=list, metadata={"sticky": True})
+    input_directories: List[str] = field(default_factory=list, metadata={"sticky": True})
+    output_directories: List[str] = field(default_factory=list, metadata={"sticky": True})
+
+    # Developer options
+    include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
+
+    def load_sticky_settings(self) -> None:
+        """Load sticky settings from JSON file alongside the max scene."""
+        scene = rt.maxFilePath + rt.maxFileName
+        sticky_settings_filename = Path(scene).with_suffix(VRSCENE_SUBMITTER_SETTINGS_FILE_EXT)
+        if sticky_settings_filename.exists() and sticky_settings_filename.is_file():
+            try:
+                with open(sticky_settings_filename, encoding="utf8") as fh:
+                    sticky_settings = json.load(fh)
+
+                if isinstance(sticky_settings, dict):
+                    sticky_fields = {
+                        field.name: field
+                        for field in dataclasses.fields(self)
+                        if field.metadata.get("sticky")
+                    }
+                    for name, value in sticky_settings.items():
+                        # Only set fields that are defined in the dataclass
+                        if name in sticky_fields:
+                            setattr(self, name, value)
+            except (OSError, json.JSONDecodeError):
+                import traceback
+
+                traceback.print_exc()
+                print(
+                    f"WARNING: Failed to load sticky settings file {sticky_settings_filename}, reverting to the "
+                    "default settings."
+                )
+
+    def save_sticky_settings(self) -> None:
+        """Save sticky settings to JSON file alongside the max scene."""
+        scene = rt.maxFilePath + rt.maxFileName
+        sticky_settings_filename = Path(scene).with_suffix(VRSCENE_SUBMITTER_SETTINGS_FILE_EXT)
+        with open(sticky_settings_filename, "w", encoding="utf8") as fh:
+            obj = {
+                field.name: getattr(self, field.name)
+                for field in dataclasses.fields(self)
+                if field.metadata.get("sticky")
+            }
+            json.dump(obj, fh, indent=1)

--- a/test/unit/deadline_submitter_for_3ds_max/test_vrscene_job_submission.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_vrscene_job_submission.py
@@ -1,0 +1,129 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for vrscene_job_submission pure-logic functions."""
+
+import pytest
+
+from deadline.max_submitter.utilities.vrscene_job_submission import (
+    calculate_region_coordinates,
+    get_frame_range_from_string,
+)
+
+
+class TestCalculateRegionCoordinates:
+    """Tests for pixel-based tile coordinate calculation."""
+
+    def test_single_tile_covers_full_image(self):
+        result = calculate_region_coordinates(0, 0, 1, 1, 1920, 1080)
+        assert result == (0, 0, 1920, 1080)
+
+    def test_2x2_grid_top_left(self):
+        result = calculate_region_coordinates(0, 0, 2, 2, 1920, 1080)
+        assert result == (0, 0, 960, 540)
+
+    def test_2x2_grid_top_right(self):
+        result = calculate_region_coordinates(1, 0, 2, 2, 1920, 1080)
+        assert result == (960, 0, 1920, 540)
+
+    def test_2x2_grid_bottom_left(self):
+        result = calculate_region_coordinates(0, 1, 2, 2, 1920, 1080)
+        assert result == (0, 540, 960, 1080)
+
+    def test_2x2_grid_bottom_right(self):
+        result = calculate_region_coordinates(1, 1, 2, 2, 1920, 1080)
+        assert result == (960, 540, 1920, 1080)
+
+    def test_remainder_pixels_go_to_last_column(self):
+        # 1921 / 2 = 960 remainder 1 — last column gets the extra pixel
+        result = calculate_region_coordinates(1, 0, 2, 1, 1921, 1080)
+        assert result == (960, 0, 1921, 1080)
+
+    def test_remainder_pixels_go_to_last_row(self):
+        # 1081 / 2 = 540 remainder 1 — last row gets the extra pixel
+        result = calculate_region_coordinates(0, 1, 1, 2, 1920, 1081)
+        assert result == (0, 540, 1920, 1081)
+
+    def test_remainder_pixels_both_axes(self):
+        # 1921 / 3 = 640 r1, 1081 / 3 = 360 r1
+        # Bottom-right tile (2,2) should get remainder on both axes
+        result = calculate_region_coordinates(2, 2, 3, 3, 1921, 1081)
+        assert result == (1280, 720, 1921, 1081)
+        # Middle tile should NOT get remainder
+        result_mid = calculate_region_coordinates(1, 1, 3, 3, 1921, 1081)
+        assert result_mid == (640, 360, 1280, 720)
+
+    def test_tiles_cover_full_image_no_gaps(self):
+        """All tiles together should cover every pixel exactly once."""
+        cols, rows, w, h = 3, 2, 1920, 1080
+        covered = set()
+        for r in range(rows):
+            for c in range(cols):
+                x0, y0, x1, y1 = calculate_region_coordinates(c, r, cols, rows, w, h)
+                for x in range(x0, x1):
+                    for y in range(y0, y1):
+                        assert (x, y) not in covered, f"Pixel ({x},{y}) covered twice"
+                        covered.add((x, y))
+        assert len(covered) == w * h
+
+    def test_3x3_grid_standard_hd(self):
+        # 1920 / 3 = 640 exact, 1080 / 3 = 360 exact
+        assert calculate_region_coordinates(0, 0, 3, 3, 1920, 1080) == (0, 0, 640, 360)
+        assert calculate_region_coordinates(2, 2, 3, 3, 1920, 1080) == (1280, 720, 1920, 1080)
+
+    # --- Error cases ---
+
+    def test_zero_columns_raises(self):
+        with pytest.raises(ValueError, match="at least 1x1"):
+            calculate_region_coordinates(0, 0, 0, 1, 1920, 1080)
+
+    def test_zero_rows_raises(self):
+        with pytest.raises(ValueError, match="at least 1x1"):
+            calculate_region_coordinates(0, 0, 1, 0, 1920, 1080)
+
+    def test_column_out_of_bounds_raises(self):
+        with pytest.raises(ValueError, match="out of bounds"):
+            calculate_region_coordinates(2, 0, 2, 2, 1920, 1080)
+
+    def test_row_out_of_bounds_raises(self):
+        with pytest.raises(ValueError, match="out of bounds"):
+            calculate_region_coordinates(0, 2, 2, 2, 1920, 1080)
+
+    def test_negative_column_raises(self):
+        with pytest.raises(ValueError, match="out of bounds"):
+            calculate_region_coordinates(-1, 0, 2, 2, 1920, 1080)
+
+    def test_zero_image_width_raises(self):
+        with pytest.raises(ValueError, match="at least 1x1"):
+            calculate_region_coordinates(0, 0, 1, 1, 0, 1080)
+
+    def test_image_too_small_for_grid_raises(self):
+        with pytest.raises(ValueError, match="too small"):
+            calculate_region_coordinates(0, 0, 100, 1, 10, 10)
+
+
+class TestGetFrameRangeFromString:
+    """Tests for frame range string parsing."""
+
+    def test_single_frame(self):
+        assert get_frame_range_from_string("1") == (1, 1)
+
+    def test_single_frame_with_whitespace(self):
+        assert get_frame_range_from_string("  42  ") == (42, 42)
+
+    def test_simple_range(self):
+        assert get_frame_range_from_string("1-100") == (1, 100)
+
+    def test_range_same_frame(self):
+        assert get_frame_range_from_string("5-5") == (5, 5)
+
+    def test_comma_separated(self):
+        assert get_frame_range_from_string("1,5,10") == (1, 10)
+
+    def test_comma_separated_unordered(self):
+        assert get_frame_range_from_string("10,1,5") == (1, 10)
+
+    def test_zero_frame(self):
+        assert get_frame_range_from_string("0") == (0, 0)
+
+    def test_large_range(self):
+        assert get_frame_range_from_string("0-9999") == (0, 9999)

--- a/test/unit/deadline_submitter_for_3ds_max/test_vrscene_utils.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_vrscene_utils.py
@@ -1,0 +1,82 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for vrscene_utils pure-logic functions."""
+
+import pytest
+
+from deadline.max_submitter.utilities.vrscene_utils import (
+    normalize_output_format,
+    validate_output_format,
+    get_vrscene_filename,
+    get_frame_vrscene_filename,
+)
+
+
+class TestNormalizeOutputFormat:
+    """Tests for format string normalization."""
+
+    def test_lowercase(self):
+        assert normalize_output_format("PNG") == "png"
+
+    def test_strip_leading_dot(self):
+        assert normalize_output_format(".png") == "png"
+
+    def test_dot_and_uppercase(self):
+        assert normalize_output_format(".EXR") == "exr"
+
+    def test_whitespace(self):
+        assert normalize_output_format("  jpg  ") == "jpg"
+
+    def test_empty_string(self):
+        assert normalize_output_format("") == ""
+
+    def test_already_normalized(self):
+        assert normalize_output_format("tiff") == "tiff"
+
+    def test_mixed_case_with_dot(self):
+        assert normalize_output_format(".Jpeg") == "jpeg"
+
+
+class TestValidateOutputFormat:
+    """Tests for format validation."""
+
+    @pytest.mark.parametrize("fmt", ["png", "exr", "tiff", "tif", "jpg", "jpeg"])
+    def test_supported_formats(self, fmt):
+        assert validate_output_format(fmt) is True
+
+    @pytest.mark.parametrize("fmt", [".PNG", ".EXR", "TIFF", ".jpg"])
+    def test_supported_formats_unnormalized(self, fmt):
+        assert validate_output_format(fmt) is True
+
+    @pytest.mark.parametrize("fmt", ["bmp", "gif", "webp", "vrimg", ""])
+    def test_unsupported_formats(self, fmt):
+        assert validate_output_format(fmt) is False
+
+
+class TestGetVrsceneFilename:
+    """Tests for vrscene filepath generation."""
+
+    def test_basic(self):
+        result = get_vrscene_filename("MyScene", "C:/output")
+        assert result.endswith("MyScene.vrscene")
+        assert "output" in result
+
+    def test_empty_scene_name_defaults_to_untitled(self):
+        result = get_vrscene_filename("", "C:/output")
+        assert "untitled.vrscene" in result
+
+
+class TestGetFrameVrsceneFilename:
+    """Tests for frame-specific vrscene filename generation."""
+
+    def test_frame_padding(self):
+        result = get_frame_vrscene_filename("C:/output/scene.vrscene", 1)
+        assert result.endswith("scene.0001.vrscene")
+
+    def test_frame_padding_large_number(self):
+        result = get_frame_vrscene_filename("C:/output/scene.vrscene", 1234)
+        assert result.endswith("scene.1234.vrscene")
+
+    def test_preserves_directory(self):
+        result = get_frame_vrscene_filename("C:/my/path/scene.vrscene", 5)
+        assert "my" in result and "path" in result


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

3ds Max users with V-Ray needed the ability to export .vrscene files and render them using V-Ray Standalone on Deadline Cloud, with support for tile-based region rendering to handle high-resolution outputs. The existing submitter only supported direct 3ds Max rendering through the adaptor.

### What was the solution? (How)

Added a V-Ray Standalone export workflow with two modes:
- **Local export**: Export .vrscene on the workstation, then render on the farm
- **Farm export**: Export and render entirely on the farm using 3dsmaxcmd + V-Ray Standalone

Tile rendering splits frames into an N×M grid using V-Ray's ``-region`` flag, renders each tile as a separate task, then merges them using additive compositing (Pillow for PNG/TIFF/JPG, OpenEXR+numpy for EXR). A V-Ray Export tab is injected into the existing submitter when V-Ray is the active renderer.

Key files: submitter logic, job template generation with embedded render/merge scripts, UI tab, settings dataclass, workflow registry, executable path discovery, and OS-agnostic path mapping.

### What is the impact of this change?

- Adds a new V-Ray Standalone submission workflow (no changes to existing 3ds Max adaptor workflow)
- Modifies ``submit_dialog.py`` to inject V-Ray Export tab (only when V-Ray is detected)
- Adds one constant to ``data_const.py``
- No changes to adaptor code

### How was this change tested?

- 52 new unit tests covering tile coordinate calculation, frame range parsing, output format validation, and vrscene filename generation (all passing)
- Full test suite: 258 passed, 0 failed
- Lint (ruff) and format (black) checks passing
- Manual end-to-end testing: local export + render, farm export + render, tile rendering with merge, on Deadline Cloud farm with 3ds Max 2025 + V-Ray 6

### Was this change documented?

Yes. Architecture doc at ``docs/design/vray-standalone-file-map.md`` and design specs under ``.kiro/specs/``.

### Did you modify schema files?

- [ ] Yes
- [x] No

### Is this a breaking change?

No. This is a new feature with no changes to existing workflows or APIs.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

[test-results.txt](https://github.com/user-attachments/files/25977890/test-results.txt)
[fmt-results.txt](https://github.com/user-attachments/files/25977922/fmt-results.txt)
[lint-results.txt](https://github.com/user-attachments/files/25977926/lint-results.txt)
