### PR TITLE
feat: add Autodesk Product Help MCP to dev and design powers

### DIFF
--- a/.kiro/powers/3dsmax-design-power/POWER.md
+++ b/.kiro/powers/3dsmax-design-power/POWER.md
@@ -59,9 +59,24 @@ def export_vrscene(self, data: dict) -> None:
 4. **Flag new sections** with `<!-- REVIEW: description -->` comments in the appendix
 5. **Don't include review tags** in final generated code
 
+## MCP Tools
+
+This power includes the **Autodesk Product Help MCP** server (`autodesk-product-help`), which provides direct access to Autodesk's official documentation for 110+ products including 3ds Max, V-Ray, and MAXScript.
+
+Use it to:
+- Research 3ds Max SDK/MAXScript APIs during design work
+- Look up V-Ray render settings, parameters, and scripting interfaces
+- Find official Autodesk documentation for feature design references
+
+The server exposes two tools:
+- `get_available_products` - List all supported Autodesk products and their release codes
+- `search_help_content` - Search Autodesk documentation by product, release, and query
+
+When searching, use product code `3DSMAX` for 3ds Max documentation.
+
 ## Research Requirements
 
-Before finalizing any design, research 3ds Max/V-Ray APIs, Deadline 10 implementation, and internet sources. Refer to **research-guide.md** for details.
+Before finalizing any design, research 3ds Max/V-Ray APIs, Deadline 10 implementation, and internet sources. Use the Autodesk Product Help MCP to look up official documentation. Refer to **research-guide.md** for details.
 
 ## Key Technical Patterns
 

--- a/.kiro/powers/3dsmax-design-power/mcp.json
+++ b/.kiro/powers/3dsmax-design-power/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "autodesk-product-help": {
+      "url": "https://developer.api.autodesk.com/knowledge/public/v1/mcp",
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}

--- a/.kiro/powers/3dsmax-dev-power/POWER.md
+++ b/.kiro/powers/3dsmax-dev-power/POWER.md
@@ -16,9 +16,25 @@ This project is a Python package that provides:
 - **3ds Max Adaptor**: Runs 3ds Max renders on Deadline Cloud workers
 - **3ds Max Submitter**: UI for submitting jobs from 3ds Max to Deadline Cloud
 
+## MCP Tools
+
+This power includes the **Autodesk Product Help MCP** server (`autodesk-product-help`), which provides direct access to Autodesk's official documentation for 110+ products including 3ds Max, V-Ray, and MAXScript.
+
+Use it to:
+- Look up 3ds Max SDK/MAXScript documentation while developing adaptor or submitter code
+- Search for V-Ray render settings and parameters
+- Find official Autodesk troubleshooting guides for 3ds Max issues
+
+The server exposes two tools:
+- `get_available_products` - List all supported Autodesk products and their release codes
+- `search_help_content` - Search Autodesk documentation by product, release, and query
+
+When searching, use product code `3DSMAX` for 3ds Max documentation.
+
 ## Available Steering Files
 
 - **build-and-test.md** - Complete build and test workflow
+- **dev-guide.md** - Development guide and conventions
 - **integration-testing.md** - Guide for running and creating integration tests
 - **troubleshooting.md** - Common issues and solutions
 

--- a/.kiro/powers/3dsmax-dev-power/mcp.json
+++ b/.kiro/powers/3dsmax-dev-power/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "autodesk-product-help": {
+      "url": "https://developer.api.autodesk.com/knowledge/public/v1/mcp",
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}

--- a/powers
+++ b/powers
@@ -1,0 +1,1 @@
+.kiro/powers


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Autodesk just released a proper MCP server for their documentation. Previously, we used Kiro / IDE's built in web scraping tools which do not work well.

### What was the solution? (How)
- Lets add the MCP to the Kiro dev and debug powers. It will help accelerate development.

### What is the impact of this change?
- AI can read docs!

### How was this change tested?
- I activated the power, and then generated a design for this ticket: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/221
- 
### Was this change documented?
- NA

### Did you modify schema files?
- [ ] Yes
- [X] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
   - [ ] Yes
   - [X] No

### Is this a breaking change?
No 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*