### PR TITLE
fix: Move render element cleanup from per-frame to session end

### DIFF
--- a/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
+++ b/src/deadline/max_adaptor/MaxAdaptor/adaptor.py
@@ -495,7 +495,13 @@ class MaxAdaptor(Adaptor[AdaptorConfiguration]):
         """
         self._performing_cleanup = True
 
+        # Restore render elements to their original state before closing Max.
+        # This is done here (once per session) rather than after each frame,
+        # so that render element configuration persists across tasks in the
+        # same session.
         self._action_queue.enqueue_action(Action("close"), front=True)
+        if self.init_data.get(_ENABLED_MODIFY_RENDER_ELEMENTS_KEY, "false").lower() == "true":
+            self._action_queue.enqueue_action(Action("cleanup_render_elements", {}), front=True)
         is_not_timed_out = self._get_timer(self._MAX_END_TIMEOUT_SECONDS)
         while self._max_is_running and is_not_timed_out():
             time.sleep(0.1)

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/default_max_handler.py
@@ -208,13 +208,6 @@ class DefaultMaxHandler:
         except Exception:
             # Re-raise the exception after cleanup
             raise
-        finally:
-            # Restore render elements after rendering if they were configured
-            if render_elements_configured:
-                try:
-                    self.cleanup_render_elements(data)
-                except Exception as e:
-                    self.log_to_console(f"Warning: Render elements cleanup failed: {e}")
 
     def _configure_renderer_output(
         self, output_name: str, output_dir: str, output_format: str


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When a single worker runs multiple frames in one session with `RenderElementsModified` enabled, render elements (Diffuse, Specular, Shadow, etc.) are only output for frame 1. Frames 2+ only produce the beauty pass.

The root cause: `start_render` in `DefaultMaxHandler` had a `finally` block that called `cleanup_render_elements` after every frame. This restored the original scene state and cleared `is_configured`, `cached_settings`, and `original_state` on the `RenderElementManager`. On subsequent frames, `has_render_elements_configured()` returned `False`, so render element filename updates were skipped entirely.

### What was the solution? (How)

- Removed the per-frame `cleanup_render_elements` call from the `finally` block in `DefaultMaxHandler.start_render`. Render element configuration now persists across all tasks in a session.
- Added a `restore_render_elements` action to `MaxAdaptor.on_cleanup`, so the original scene state is still properly restored when the session ends.

### What is the impact of this change?

Multi-frame jobs with render elements enabled will now correctly output render element files for every frame, not just the first one. This applies to all renderers (Scanline, V-Ray, Arnold, Corona, Redshift) since the fix is in the shared `DefaultMaxHandler` base class.

### How was this change tested?

- All 333 unit tests pass
- Manual integration test on Windows with 3ds Max 2026, Default Scanline Renderer, 4-frame job with 3 render elements (Diffuse, Specular, Shadow) and `RenderElementsModified=true`

### Was this change documented?
yes

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No. The render element restore still happens — just at session end instead of after each frame.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
