### PR TITLE
feat: Add support for VRay 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ AWS Deadline Cloud officially supports rendering 3ds Max jobs using the followin
 * Autodesk Scanline 
 * Autodesk Raytracer (ART) 
 * Chaos Corona 
+* Chaos V-Ray 5 (CPU & GPU)
 * Chaos V-Ray 6 (CPU & GPU)
 * Chaos V-Ray 7 (CPU & GPU)
 * Maxon Redshift

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -24,6 +24,8 @@ ALLOWED_RENDERERS = [
     "Default_Scanline_Renderer",
     "ART_Renderer",
     "Corona",
+    "V_Ray_5",
+    "V_Ray_GPU_5",
     "V_Ray_6",
     "V_Ray_GPU_6",
     "V_Ray_7",

--- a/test/unit/deadline_submitter_for_3ds_max/test_sanity_checks.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_sanity_checks.py
@@ -163,6 +163,18 @@ class TestSanityChecks:
         with raises(Exception):
             check_sanity(default_settings)
 
+    def test_check_sanity_specific_state_set_vray_5_update_renderer(
+        self,
+        mock_pymx_runtime: Mock,
+        default_settings: RenderSubmitterUISettings,
+    ) -> None:
+        """Test that V_Ray_5__update_2_3 renderer is accepted (starts with V_Ray_5)"""
+        mock_pymx_runtime.renderers.current = "V_Ray_5__update_2_3:V-Ray 5, update 2.3"
+        mock_pymx_runtime.rendOutputFilename = ""
+
+        # Should not raise an exception
+        check_sanity_specific_state_set(default_settings, "test_state_set")
+
     def test_check_sanity_specific_state_set_vray_6_update_renderer(
         self,
         mock_pymx_runtime: Mock,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have a request to add support for `VRay 5` 

### What was the solution? (How)
Enable `VRay 5` for our adaptor

### What is the impact of this change?
Solve https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues, we can now render with `VRay 5`

### How was this change tested?
- Make sure we can export bundle/render with VRay 5 and 3dsMax 2023
- Make sure that job bundle can be rendered and the output is as expected

### Was this change documented?
Yes

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*