### PR TITLE
feat: add onRun timeout

### DIFF
--- a/src/deadline/max_submitter/create_job_bundle.py
+++ b/src/deadline/max_submitter/create_job_bundle.py
@@ -593,6 +593,13 @@ def _create_step_definitions(
                 init_data_key = RENDER_ELEMENT_PARAM_MAPPING.get(param, param.lower())
                 init_data["data"] += f"{init_data_key}: '{{{{Param.{param}}}}}'\n"
 
+        # Inject per-task run timeout when the user has configured one.
+        # The timeout field on onRun is enforced by the OpenJD session runtime;
+        # no adaptor changes are needed.
+        if settings.task_run_timeout_seconds > 0:
+            on_run_action = step["script"]["actions"]["onRun"]
+            on_run_action["timeout"] = settings.task_run_timeout_seconds
+
         job_template["steps"].append(step)
 
     return job_template

--- a/src/deadline/max_submitter/data_classes.py
+++ b/src/deadline/max_submitter/data_classes.py
@@ -243,6 +243,9 @@ class RenderSubmitterUISettings:
     # Developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 
+    # Per-task render timeout in seconds. 0 means no timeout (preserves current behaviour).
+    task_run_timeout_seconds: int = field(default=0, metadata={"sticky": True})
+
     def load_sticky_settings(self) -> None:
         """
         Reads sticky settings from the sticky settings json file saved alongside the max scene

--- a/src/deadline/max_submitter/ui/scene_settings_tab.py
+++ b/src/deadline/max_submitter/ui/scene_settings_tab.py
@@ -39,6 +39,7 @@ from qtpy.QtWidgets import (  # type: ignore
     QRadioButton,
     QSizePolicy,
     QSpacerItem,
+    QSpinBox,
     QStyledItemDelegate,
     QTableWidget,
     QTableWidgetItem,
@@ -299,7 +300,37 @@ class SceneSettingsWidget(QWidget):
             )
             lyt.addWidget(self.include_adaptor_wheels, 8, 0, 1, 2)
 
-        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 9, 0)
+        # Task run timeout row
+        timeout_row_widget = QWidget(self)
+        timeout_row_lyt = QHBoxLayout(timeout_row_widget)
+        timeout_row_lyt.setContentsMargins(0, 0, 0, 0)
+
+        self.task_timeout_chck = QCheckBox("Override Task Run Timeout", self)
+        self.task_timeout_chck.setToolTip(
+            "When checked, a frame render that exceeds the timeout will be cancelled.\n"
+            "Leave unchecked to allow renders to run until complete."
+        )
+
+        self.task_timeout_spinbox = QSpinBox(self)
+        self.task_timeout_spinbox.setMinimum(1)
+        self.task_timeout_spinbox.setMaximum(86400)
+        self.task_timeout_spinbox.setSingleStep(60)
+        self.task_timeout_spinbox.setSuffix(" s")
+        self.task_timeout_spinbox.setToolTip(
+            "Maximum seconds a single frame render may run before it is cancelled.\n"
+            "Examples: 3600 = 1 hour, 7200 = 2 hours, 86400 = 24 hours."
+        )
+
+        timeout_row_lyt.addWidget(self.task_timeout_chck)
+        timeout_row_lyt.addWidget(self.task_timeout_spinbox)
+        timeout_row_lyt.addStretch()
+
+        lyt.addWidget(timeout_row_widget, 9, 0, 1, 2)
+
+        self.task_timeout_chck.toggled.connect(self._on_task_timeout_toggled)
+        self.task_timeout_spinbox.valueChanged.connect(self._on_task_timeout_value_changed)
+
+        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 
         self._fill_cameras_box(0)
 
@@ -713,6 +744,14 @@ class SceneSettingsWidget(QWidget):
         if settings.submission_mode == SubmissionMode.BATCH_RENDER.value:
             self._refresh_batch_views()
 
+        # Restore task run timeout state
+        timeout_enabled = settings.task_run_timeout_seconds > 0
+        self.task_timeout_chck.setChecked(timeout_enabled)
+        self.task_timeout_spinbox.setValue(
+            settings.task_run_timeout_seconds if timeout_enabled else 3600
+        )
+        self.task_timeout_spinbox.setEnabled(timeout_enabled)
+
         # Sync group box enabled states with the selected radio button
         self._on_submission_mode_changed()
 
@@ -773,6 +812,12 @@ class SceneSettingsWidget(QWidget):
             enabled_views = []
         settings.batch_render.enabled_views = enabled_views
 
+        # Task run timeout
+        if self.task_timeout_chck.isChecked():
+            settings.task_run_timeout_seconds = self.task_timeout_spinbox.value()
+        else:
+            settings.task_run_timeout_seconds = 0
+
     def activate_frame_override_changed(self, state):
         """
         Set the activated/deactivated status of the Frame override text box
@@ -784,6 +829,18 @@ class SceneSettingsWidget(QWidget):
         Set the activated/deactivated status of the Custom material combo box
         """
         self.custom_mat_box.setEnabled(Qt.CheckState(state) == Qt.Checked)
+
+    def _on_task_timeout_toggled(self, checked: bool) -> None:
+        """
+        Enable/disable the timeout spin box and update the settings value.
+        """
+        self.task_timeout_spinbox.setEnabled(checked)
+
+    def _on_task_timeout_value_changed(self, value: int) -> None:
+        """
+        Keep the spin box value in sync (actual settings write happens in update_settings).
+        """
+        pass  # update_settings reads the widget state; no extra action needed here
 
     def _update_renderer(self):
         """

--- a/test/integ/test_3dsmax_adaptors.py
+++ b/test/integ/test_3dsmax_adaptors.py
@@ -198,6 +198,44 @@ class TestBatchRenderAdaptors:
         ), f"Expected error about invalid pixel aspect, got:\n{output}"
 
 
+@pytest.mark.adaptor
+class TestTaskRunTimeoutAdaptor:
+    """
+    Verifies that the onRun timeout field is enforced by the OpenJD session runtime.
+
+    The test template has timeout: 5 on onRun and a Start-Sleep -Seconds 30 in
+    runRender, so the sleep always outlasts the timeout. We assert that:
+      1. The step exits with a non-zero return code (task cancelled).
+      2. The OpenJD TIMEOUT message appears in the output.
+    """
+
+    def test_task_run_timeout_adaptor(self, script_location: Path, tmp_path: Path) -> None:
+        test_file_location = script_location / "task_run_timeout_test"
+        scene_location = script_location / "minimal_test" / TEST_SCENE_FOLDER / "test.max"
+        output_path = tmp_path / OUTPUT_FOLDER
+
+        job_params = {
+            "MaxSceneFile": str(scene_location),
+            "State01_Frames": "1",
+            "State01_OutputFilePath": str(output_path),
+            "State01_OutputFileName": "timeout_test_###",
+            "State01_OutputFileFormat": ".jpg",
+            "State01_ImageWidth": 320,
+            "State01_ImageHeight": 240,
+        }
+
+        output = run_adaptor_test(
+            test_file_location / EXPECTED_JOB_BUNDLE_FOLDER / TEMPLATE,
+            job_params,
+            expect_failure=True,
+        )
+
+        assert "TIMEOUT" in output, (
+            "Expected 'TIMEOUT' in adaptor output when onRun timeout is exceeded.\n"
+            f"Actual output:\n{output}"
+        )
+
+
 def _load_job_params(test_file_location: Path) -> dict:
     """
     Load job parameters from the parameter_values.yaml file in the expected job bundle.

--- a/test/integ/test_3dsmax_submitters.py
+++ b/test/integ/test_3dsmax_submitters.py
@@ -381,3 +381,47 @@ class TestSubmitters:
             assert (
                 frames_value == "1-2"
             ), f"Step '{step_name}' frame range should be '1-2' (override), got '{frames_value}'"
+
+    def test_task_run_timeout_submitter(self, script_location: Path, tmp_path: Path) -> None:
+        """
+        Verify that setting task_run_timeout_seconds on the submitter settings
+        produces a job template where every step's onRun action has the correct
+        timeout value.
+        """
+        EXPECTED_TIMEOUT = 30
+
+        job_history_dir = tmp_path / JOB_HISTORY_FOLDER
+        # Reuse the minimal_test scene — no render output needed for this test.
+        output_path = script_location / "minimal_test" / TEST_SCENE_FOLDER
+        scene_location = script_location / "minimal_test" / TEST_SCENE_FOLDER / "test.max"
+
+        self._cleanup_sticky_settings(scene_location, script_location)
+
+        os.makedirs(job_history_dir, exist_ok=True)
+        os.makedirs(output_path, exist_ok=True)
+
+        max_exec = MaxExecutableHandler()
+
+        run_submitter_test(
+            max_exec.max_executable.full_path,
+            str(script_location / "task_run_timeout_test" / "_test_max.py"),
+            str(scene_location),
+            str(job_history_dir),
+            str(output_path),
+        )
+
+        assert is_valid_template(job_history_dir / TEMPLATE)
+
+        with open(job_history_dir / TEMPLATE) as f:
+            template = yaml.safe_load(f)
+
+        assert template["steps"], "Template has no steps"
+        for step in template["steps"]:
+            on_run = step["script"]["actions"]["onRun"]
+            assert (
+                "timeout" in on_run
+            ), f"Step '{step['name']}' onRun action is missing 'timeout' field"
+            assert on_run["timeout"] == EXPECTED_TIMEOUT, (
+                f"Step '{step['name']}' onRun timeout: "
+                f"expected {EXPECTED_TIMEOUT}, got {on_run['timeout']}"
+            )

--- a/test/integ/test_scripts/task_run_timeout_test/_test_max.py
+++ b/test/integ/test_scripts/task_run_timeout_test/_test_max.py
@@ -1,0 +1,74 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Submitter test script for the task_run_timeout feature.
+
+Runs inside 3ds Max via 3dsmaxbatch. Sets task_run_timeout_seconds = 30 on the
+settings object and exports a job bundle. The test then verifies that the generated
+template.yaml has `timeout: 30` on the onRun action of every step.
+"""
+
+from pymxs import runtime as rt
+
+from deadline.client.ui.dialogs._types import JobBundlePurpose
+
+from deadline.max_submitter.max_render_submitter import (
+    show_job_bundle_submitter,
+    on_create_job_bundle_callback,
+)
+from deadline.max_submitter.data_const import ALL_CAMERAS_STR, ALL_STATE_SETS_STR
+
+# Timeout value used by both this script and the pytest assertion
+TASK_RUN_TIMEOUT_SECONDS = 30
+
+
+def main(job_history_dir: str, output_dir: str):
+    """
+    Open the submitter, configure a task run timeout, and export a job bundle.
+    """
+    widget = show_job_bundle_submitter()
+
+    settings = widget.job_settings_type()
+    widget.shared_job_settings.update_settings(settings)
+    widget.job_settings.update_settings(settings)
+
+    settings.state_set = ALL_STATE_SETS_STR
+    settings.camera_selection = ALL_CAMERAS_STR
+    settings.include_adaptor_wheels = False
+    settings.override_frame_range = True
+    settings.frame_list = "1"
+    settings.output_filename_pattern = "<stateset>_test_###_<camera>"
+
+    # --- The feature under test ---
+    settings.task_run_timeout_seconds = TASK_RUN_TIMEOUT_SECONDS
+
+    widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+        {"name": "deadline:targetTaskRunStatus", "value": "READY"}
+    )
+    widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+        {"name": "deadline:maxFailedTasksCount", "value": 20}
+    )
+    widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+        {"name": "deadline:maxRetriesPerTask", "value": 5}
+    )
+    widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+        {"name": "deadline:priority", "value": 50}
+    )
+
+    on_create_job_bundle_callback(
+        widget,
+        job_history_dir,
+        settings,
+        widget.shared_job_settings.get_parameters(),
+        widget.job_attachments.get_asset_references(),
+        {output_dir},
+        widget.host_requirements.get_requirements(),
+        purpose=JobBundlePurpose.EXPORT,
+    )
+
+
+if __name__ == "__main__":
+    opts = rt.maxops.mxsCmdLineArgs
+    job_history_dir = repr(opts[rt.name("job_history_dir")])
+    output_dir = repr(opts[rt.name("output_dir")])
+    main(job_history_dir[1:-1], output_dir[1:-1])

--- a/test/integ/test_scripts/task_run_timeout_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/task_run_timeout_test/expected_job_bundle/template.yaml
@@ -1,0 +1,149 @@
+specificationVersion: jobtemplate-2023-09
+name: task_run_timeout_test
+description: null
+parameterDefinitions:
+- name: MaxSceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Max Scene File
+    groupLabel: 3dsMax Settings
+    fileFilters:
+    - label: Max Scene Files
+      patterns:
+      - '*.max'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Max scene file to render.
+- name: StrictErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Strict Error Checking
+    groupLabel: 3dsMax Settings
+  description: Fail when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: State01_Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: State01 Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: State01_ImageHeight
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Height
+    groupLabel: State01 Settings
+  minValue: 1
+  description: The image height of the output.
+- name: State01_ImageWidth
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Width
+    groupLabel: State01 Settings
+  minValue: 1
+  description: The image width of the output.
+- name: State01_OutputFileFormat
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Format
+    groupLabel: State01 Settings
+  description: The output file extension.
+- name: State01_OutputFileName
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Name
+    groupLabel: State01 Settings
+  description: The output file name.
+- name: State01_OutputFilePath
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output File Path
+    groupLabel: State01 Settings
+  description: The render output path.
+steps:
+- name: State01
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.State01_Frames}}'
+  stepEnvironments:
+  - name: 3ds Max
+    description: Runs 3ds Max in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          scene_file: {{Param.MaxSceneFile}}
+          renderer: Default_Scanline_Renderer
+          state_set: State01
+          output_file_path: '{{Param.State01_OutputFilePath}}'
+          output_file_name: '{{Param.State01_OutputFileName}}'
+          output_file_format: '{{Param.State01_OutputFileFormat}}'
+          image_width: '{{Param.State01_ImageWidth}}'
+          image_height: '{{Param.State01_ImageHeight}}'
+      - name: runStart
+        filename: start.bat
+        type: TEXT
+        data: |
+          3dsmax-openjd daemon start --connection-file {{Session.WorkingDirectory}}/connection.json --init-data file://{{Env.File.initData}} --path-mapping-rules file://{{Session.PathMappingRulesFile}}
+      - name: runStop
+        filename: stop.bat
+        type: TEXT
+        data: |
+          3dsmax-openjd daemon stop --connection-file {{Session.WorkingDirectory}}/connection.json
+      actions:
+        onEnter:
+          command: powershell
+          args:
+          - '{{Env.File.runStart}}'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
+        onExit:
+          command: powershell
+          args:
+          - '{{Env.File.runStop}}'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
+  script:
+    actions:
+      onRun:
+        command: powershell
+        args:
+        - '{{Task.File.runRender}}'
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 5
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |-
+        frame: {{Task.Param.Frame}}
+    - name: runRender
+      filename: render.bat
+      type: TEXT
+      runnable: true
+      data: |
+        powershell -Command "Start-Sleep -Seconds 30"
+        3dsmax-openjd daemon run --connection-file {{ Session.WorkingDirectory }}/connection.json --run-data file://{{Task.File.runData}}

--- a/test/unit/deadline_submitter_for_3ds_max/test_create_job_bundle.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_create_job_bundle.py
@@ -224,6 +224,7 @@ class TestCreateStepDefinitions:
         settings.batch_render.enabled_views = []
         settings.camera_selection = "Camera001"
         settings.renderer = "V_Ray_6"
+        settings.task_run_timeout_seconds = 0
         return settings
 
     @patch("deadline.max_submitter.create_job_bundle.get_batch_render_views")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Our adaptor listen to subprocess renderer (VRay, Arnold, etc) for exit signal, but when those are hanging, our adaptor thing it's running and thus, keep worker running for no use, wasting resource

### What was the solution? (How)
- Add a timeout UI box and read that box to alter the generated `template.yaml`
- No code change needed on the adaptor

### What is the impact of this change?
We now have a convenience way to set timeout for task run without having to:
- Manually export the bundle
- Go into the bundle and modify the `template.yaml`
- Submit that bundle through CLI

### How was this change tested?
- Add 2 integ tests and run it on my local CI
<img width="1432" height="1103" alt="Screenshot 2026-05-20 at 3 25 14 PM" src="https://github.com/user-attachments/assets/985b14aa-07db-4a2c-96b0-9a6570afcf68" />

- Manually install a test version of the submitter to 3dsMax 2025 and 2026
  - Confirm seeing the box for timeout, uncheck by default
<img width="540" height="732" alt="Screenshot 2026-05-20 at 3 05 34 PM" src="https://github.com/user-attachments/assets/83a7093f-f039-4e30-bbd9-c2752bf8b14a" />

  - Export and make sure `template.yaml` have the timeout block
```
script:
    actions:
      onRun:
        command: powershell
        args:
        - '{{Task.File.runRender}}'
        cancelation:
          mode: NOTIFY_THEN_TERMINATE
        timeout: 300
```
  - Run the bundle using `openjd-cli`, with a sleep > timeout time and make sure job exit due to timeout
```
0:00:39.906819  Running command ... render.bat
0:00:40.064830  C:\...>powershell -Command "Start-Sleep -Seconds 300"
0:05:39.928614  TIMEOUT - Runtime limit reached at 2026-05-20T21:01:25Z. Canceling action.
0:05:39.929622  Canceling subprocess 13504 via notify then terminate method
```

### Was this change documented?
Yes

### Did you modify schema files?
- [ ] Yes
- [x] No
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*