### PR TITLE
test: add integration tests for V-Ray Standalone GPU support

### DIFF
--- a/test/integ/test_3dsmax_vray_standalone.py
+++ b/test/integ/test_3dsmax_vray_standalone.py
@@ -1,0 +1,228 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Integration tests for the V-Ray Standalone submitter (PR #244)."""
+
+import json
+import os
+import sys
+import yaml
+
+from pathlib import Path
+
+import pytest
+
+from deadline.max_adaptor.executable_handler import MaxExecutableHandler
+
+from .helpers.test_runners import is_valid_template, run_submitter_test
+from .test_const import (
+    JOB_HISTORY_FOLDER,
+    PARAMETER_VALUES,
+    TEMPLATE,
+    TEST_SCENE_FOLDER,
+)
+
+
+# fog.max from the render-elements suite already has V-Ray as the active
+# renderer. Sticky-settings filenames don't collide between the two suites.
+VRAY_SCENE_DIR = "vray_re_test"
+VRAY_SCENE_FILE = "fog.max"
+VRAY_STICKY_SETTINGS = "fog.deadline_vrscene_settings.json"
+
+DRIVER_SCRIPT = "_test_driver.py"
+CONFIG_FILE = "test_config.json"
+
+
+def _expected_param(parameter_values, name):
+    for entry in parameter_values["parameterValues"]:
+        if entry["name"] == name:
+            return entry["value"]
+    return None
+
+
+def _config(
+    *,
+    render_engine: int,
+    rt_timeout: float = 0.0,
+    rt_noise: float = 0.001,
+    rt_sample_level: int = 0,
+    region_columns: int = 1,
+    region_rows: int = 1,
+    expect_failure: bool = False,
+) -> dict:
+    return {
+        "render_engine": render_engine,
+        "rt_timeout": rt_timeout,
+        "rt_noise": rt_noise,
+        "rt_sample_level": rt_sample_level,
+        "region_columns": region_columns,
+        "region_rows": region_rows,
+        "expect_failure": expect_failure,
+    }
+
+
+@pytest.mark.submitter
+class TestVRayStandaloneSubmitter:
+
+    @pytest.fixture(autouse=True)
+    def _add_submitter_to_pythonpath(self):
+        # Per DEVELOPMENT.md, both <repo>/src and <repo>/src/deadline/max_submitter
+        # need to be on PYTHONPATH. Prepend so local source wins over any
+        # stale copy in 3ds Max's site-packages.
+        src_path = Path(__file__).resolve().parents[2] / "src"
+        submitter_path = src_path / "deadline" / "max_submitter"
+
+        for path in (submitter_path, src_path):
+            path_str = str(path)
+
+            current_pythonpath = os.environ.get("PYTHONPATH", "")
+            entries = current_pythonpath.split(os.pathsep) if current_pythonpath else []
+            if path_str in entries:
+                entries.remove(path_str)
+            entries.insert(0, path_str)
+            os.environ["PYTHONPATH"] = os.pathsep.join(entries)
+
+            if path_str in sys.path:
+                sys.path.remove(path_str)
+            sys.path.insert(0, path_str)
+
+    def _cleanup_sticky_settings(self, scene_file: Path):
+        Path(scene_file.parent / VRAY_STICKY_SETTINGS).unlink(missing_ok=True)
+
+    def _run_driver(self, script_location: Path, config: dict, tmp_path: Path) -> Path:
+        job_history_dir = tmp_path / JOB_HISTORY_FOLDER
+        scene_dir = script_location / VRAY_SCENE_DIR / TEST_SCENE_FOLDER
+        scene_location = scene_dir / VRAY_SCENE_FILE
+        output_path = scene_dir
+
+        self._cleanup_sticky_settings(scene_location)
+
+        os.makedirs(job_history_dir, exist_ok=True)
+        os.makedirs(output_path, exist_ok=True)
+
+        with open(job_history_dir / CONFIG_FILE, "w", encoding="utf8") as f:
+            json.dump(config, f)
+
+        run_submitter_test(
+            MaxExecutableHandler().max_executable.full_path,
+            str(script_location / "vray_standalone_test" / DRIVER_SCRIPT),
+            str(scene_location),
+            str(job_history_dir),
+            str(output_path),
+        )
+
+        return job_history_dir
+
+    def _load_bundle(self, job_history_dir: Path) -> tuple[dict, dict]:
+        assert is_valid_template(job_history_dir / TEMPLATE)
+        with open(job_history_dir / TEMPLATE) as f:
+            template = yaml.safe_load(f)
+        with open(job_history_dir / PARAMETER_VALUES) as f:
+            parameter_values = yaml.safe_load(f)
+        return template, parameter_values
+
+    def test_vray_standalone_cuda_no_tile_submitter(
+        self, script_location: Path, tmp_path: Path
+    ) -> None:
+        job_history_dir = self._run_driver(
+            script_location,
+            _config(
+                render_engine=5,
+                rt_timeout=30.0,
+                rt_noise=0.005,
+                rt_sample_level=1024,
+            ),
+            tmp_path,
+        )
+        template, parameter_values = self._load_bundle(job_history_dir)
+
+        step_names = [step["name"] for step in template["steps"]]
+        assert "ExportVRScene" in step_names
+        assert any("Render" in name and "Region" not in name for name in step_names)
+
+        param_defs = {p["name"]: p for p in template.get("parameterDefinitions", [])}
+        assert param_defs["RenderEngine"]["type"] == "INT"
+        assert param_defs["RenderEngine"]["allowedValues"] == [0, 5, 7]
+        for rt_param, rt_type in (
+            ("RTTimeout", "FLOAT"),
+            ("RTNoise", "FLOAT"),
+            ("RTSampleLevel", "INT"),
+        ):
+            assert param_defs[rt_param]["type"] == rt_type
+
+        assert _expected_param(parameter_values, "RenderEngine") == "5"
+        assert _expected_param(parameter_values, "RTTimeout") == "30.0"
+        assert _expected_param(parameter_values, "RTNoise") == "0.005"
+        assert _expected_param(parameter_values, "RTSampleLevel") == "1024"
+        assert _expected_param(parameter_values, "RegionColumns") == "1"
+        assert _expected_param(parameter_values, "RegionRows") == "1"
+
+    def test_vray_standalone_cpu_default_submitter(
+        self, script_location: Path, tmp_path: Path
+    ) -> None:
+        job_history_dir = self._run_driver(
+            script_location,
+            _config(render_engine=0),
+            tmp_path,
+        )
+        template, parameter_values = self._load_bundle(job_history_dir)
+
+        param_defs = {p["name"]: p for p in template.get("parameterDefinitions", [])}
+        for required in ("RenderEngine", "RTTimeout", "RTNoise", "RTSampleLevel"):
+            assert required in param_defs
+        assert param_defs["RenderEngine"]["allowedValues"] == [0, 5, 7]
+
+        assert _expected_param(parameter_values, "RenderEngine") == "0"
+        assert _expected_param(parameter_values, "RTTimeout") == "0.0"
+        assert _expected_param(parameter_values, "RTNoise") == "0.001"
+        assert _expected_param(parameter_values, "RTSampleLevel") == "0"
+
+    def test_vray_standalone_invalid_engine_rejected(
+        self, script_location: Path, tmp_path: Path
+    ) -> None:
+        job_history_dir = self._run_driver(
+            script_location,
+            _config(render_engine=99, expect_failure=True),
+            tmp_path,
+        )
+
+        assert not (job_history_dir / TEMPLATE).exists()
+
+        outcome_file = job_history_dir / "validation_outcome.txt"
+        assert outcome_file.exists()
+
+        outcome = outcome_file.read_text(encoding="utf8")
+        assert outcome.startswith("VALIDATION_FAILED")
+        assert "Invalid render engine" in outcome
+
+    def test_vray_standalone_rtx_tile_submitter(
+        self, script_location: Path, tmp_path: Path
+    ) -> None:
+        job_history_dir = self._run_driver(
+            script_location,
+            _config(
+                render_engine=7,
+                rt_timeout=60.0,
+                rt_noise=0.002,
+                rt_sample_level=2048,
+                region_columns=2,
+                region_rows=2,
+            ),
+            tmp_path,
+        )
+        template, parameter_values = self._load_bundle(job_history_dir)
+
+        step_names = [step["name"] for step in template["steps"]]
+        assert "ExportVRScene" in step_names
+        assert any("Region" in name for name in step_names)
+
+        param_defs = {p["name"]: p for p in template.get("parameterDefinitions", [])}
+        assert param_defs["RenderEngine"]["allowedValues"] == [0, 5, 7]
+        for rt_param in ("RTTimeout", "RTNoise", "RTSampleLevel"):
+            assert rt_param in param_defs
+
+        assert _expected_param(parameter_values, "RenderEngine") == "7"
+        assert _expected_param(parameter_values, "RTTimeout") == "60.0"
+        assert _expected_param(parameter_values, "RTNoise") == "0.002"
+        assert _expected_param(parameter_values, "RTSampleLevel") == "2048"
+        assert _expected_param(parameter_values, "RegionColumns") == "2"
+        assert _expected_param(parameter_values, "RegionRows") == "2"

--- a/test/integ/test_scripts/vray_standalone_test/_test_driver.py
+++ b/test/integ/test_scripts/vray_standalone_test/_test_driver.py
@@ -1,0 +1,90 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Generic V-Ray Standalone integ test driver.
+
+The host test writes a `test_config.json` into `job_history_dir` describing
+the engine + RT settings to apply, then invokes this driver inside
+3dsmaxbatch. The driver applies the config and either submits the bundle or,
+when `expect_failure` is true, captures the resulting ValueError to
+`validation_outcome.txt` for the host to assert on.
+"""
+
+import json
+import os
+
+from pymxs import runtime as rt
+
+from deadline.client.ui.dialogs._types import JobBundlePurpose
+
+from deadline.max_submitter.vray_standalone_submitter import (
+    show_vray_standalone_submitter,
+    on_create_vrscene_job_bundle_callback,
+)
+
+
+CONFIG_FILE = "test_config.json"
+VALIDATION_OUTCOME_FILE = "validation_outcome.txt"
+
+
+def main(job_history_dir: str, output_dir: str):
+    with open(os.path.join(job_history_dir, CONFIG_FILE), encoding="utf8") as f:
+        config = json.load(f)
+
+    widget = show_vray_standalone_submitter()
+
+    settings = widget.job_settings_type()
+    widget.shared_job_settings.update_settings(settings)
+    widget.job_settings.update_settings(settings)
+
+    settings.export_mode = 2
+    settings.export_animation_mode = 1
+    settings.frame_list = "1-2"
+    settings.output_path = output_dir
+    settings.vrscene_render_region_columns = config["region_columns"]
+    settings.vrscene_render_region_rows = config["region_rows"]
+    settings.vrscene_render_engine = config["render_engine"]
+    settings.vrscene_rt_timeout = config["rt_timeout"]
+    settings.vrscene_rt_noise = config["rt_noise"]
+    settings.vrscene_rt_sample_level = config["rt_sample_level"]
+    settings.include_adaptor_wheels = False
+
+    widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+        {"name": "deadline:targetTaskRunStatus", "value": "READY"}
+    )
+    widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+        {"name": "deadline:priority", "value": 50}
+    )
+
+    if config.get("expect_failure"):
+        outcome_path = os.path.join(job_history_dir, VALIDATION_OUTCOME_FILE)
+        try:
+            on_create_vrscene_job_bundle_callback(
+                widget,
+                job_history_dir,
+                settings,
+                widget.shared_job_settings.get_parameters(),
+                widget.job_attachments.get_asset_references(),
+                purpose=JobBundlePurpose.EXPORT,
+            )
+            with open(outcome_path, "w", encoding="utf8") as f:
+                f.write("UNEXPECTED_SUCCESS")
+        except ValueError as e:
+            with open(outcome_path, "w", encoding="utf8") as f:
+                f.write(f"VALIDATION_FAILED\n{e}")
+    else:
+        on_create_vrscene_job_bundle_callback(
+            widget,
+            job_history_dir,
+            settings,
+            widget.shared_job_settings.get_parameters(),
+            widget.job_attachments.get_asset_references(),
+            purpose=JobBundlePurpose.EXPORT,
+        )
+
+
+if __name__ == "__main__":
+    opts = rt.maxops.mxsCmdLineArgs
+    job_history_dir = repr(opts[rt.name("job_history_dir")])
+    output_dir = repr(opts[rt.name("output_dir")])
+    main(job_history_dir[1:-1], output_dir[1:-1])


### PR DESCRIPTION
Adds integration tests covering the new RenderEngine / RT engine parameters added in PR #244 (V-Ray GPU support). Drives the V-Ray Standalone submitter end-to-end inside 3dsmaxbatch and asserts the new params flow into both the standard render and tile rendering bundle paths, plus verifies the validator rejects an out-of-range engine value before any template is written.

### What was the problem/requirement? (What/Why)

PR #244 added V-Ray GPU support (CUDA / RTX render engines plus RT-engine stopping conditions: timeout, noise threshold, max samples) to the V-Ray Standalone submitter. The PR shipped with unit tests for the bundle parameter builder and the validator, but no integration coverage for the V-Ray Standalone submitter. Per the request to gate the next release on integ-test coverage of new features, we need integ tests verifying the new params flow correctly through the full submitter UI into the produced job bundle for both bundle code paths (single-render and tile-render).

### What was the solution? (How)

Added a new integ test class `TestVRayStandaloneSubmitter` in `test/integ/test_3dsmax_vray_standalone.py` driven by a single config-driven driver script (`test/integ/test_scripts/vray_standalone_test/_test_driver.py`). The host test writes a `test_config.json` into `job_history_dir`, the driver reads it, applies the engine + RT settings to the V-Ray Standalone submitter, and either submits the bundle or captures the validation failure to a sentinel file.

Four scenarios:
- CUDA engine + non-tile farm export — exercises `vray_render_job_template.yaml` bundle path
- CPU engine (default) + non-tile — verifies default RT values still flow through
- RTX engine + 2x2 tile farm export — exercises `vray_tile_render_job_template.yaml` bundle path
- Invalid engine (99) — asserts `validate_vrscene_export_settings` rejects before any template is written

Tests reuse `vray_re_test/scene/fog.max` since it already has V-Ray as the active renderer (a precondition for the V-Ray Standalone submitter). The two suites use disjoint sticky-settings filenames so they don't collide.

Test class fixture prepends both `<repo>/src` and `<repo>/src/deadline/max_submitter` to PYTHONPATH per DEVELOPMENT.md's submitter dev workflow, so local source wins over any stale copy in 3ds Max's site-packages.

### What is the impact of this change?

Test-only. No production code paths change. Adds ~2.5 minutes of integ-test wall time (4 × 3dsmaxbatch cold starts) when running `pytest -m submitter`.

### How was this change tested?

Ran locally against 3ds Max 2025 + V-Ray for 3ds Max 2025:

```
$ python -m pytest test/integ/test_3dsmax_vray_standalone.py -m submitter -v -o addopts=""
test_vray_standalone_cuda_no_tile_submitter   PASSED
test_vray_standalone_cpu_default_submitter    PASSED
test_vray_standalone_invalid_engine_rejected  PASSED
test_vray_standalone_rtx_tile_submitter       PASSED
4 passed in 150.55s
```

Lint + format clean (`black`, `ruff`, `mypy`).

### Was this change documented?

No documentation changes required. The tests are self-documenting via test names and the driver's docstring; preconditions (3ds Max + V-Ray + DEVELOPMENT.md PYTHONPATH setup) are already covered in DEVELOPMENT.md's "Integration Test Workflow" section.

### Did you modify schema files?

- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants? See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [x] No

### Is this a breaking change?

No. Test-only addition; existing tests and behavior are unchanged.

----
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
