### PR TITLE
feat: add Arnold renderer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ AWS Deadline Cloud officially supports rendering 3ds Max jobs using the followin
 * Chaos V-Ray 6 (CPU & GPU)
 * Chaos V-Ray 7 (CPU & GPU)
 * Maxon Redshift
+* Autodesk Arnold
 
 ## Deadline Cloud Getting Started
 

--- a/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/max_adaptor/MaxAdaptor/schemas/init_data.schema.json
@@ -56,7 +56,8 @@
                         "Default_Scanline_Renderer",
                         "ART_Renderer",
                         "Corona",
-                        "Redshift_Renderer"
+                        "Redshift_Renderer",
+                        "Arnold"
                     ]
                 }
             ]

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/__init__.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from .arnold_handler import ArnoldHandler
 from .art_handler import ArtHandler
 from .corona_handler import CoronaHandler
 from .default_max_handler import DefaultMaxHandler
@@ -29,5 +30,7 @@ def get_render_handler(renderer: str = "Default_Scanline_Renderer") -> DefaultMa
         return VrayHandler(gpu=False)
     elif renderer == "Redshift_Renderer":
         return RedshiftHandler()
+    elif renderer == "Arnold":
+        return ArnoldHandler()
     else:
         return DefaultMaxHandler()

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/arnold_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/arnold_handler.py
@@ -1,0 +1,34 @@
+"""
+3ds Max Deadline Cloud Adaptor - Arnold specific actions
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+
+import sys
+
+import pymxs  # noqa
+from pymxs import runtime as rt
+
+from .default_max_handler import DefaultMaxHandler
+
+# Re-assign sys stdout and stderr to print in the console instead of the Max Listener
+sys.stdout = sys.__stdout__
+sys.stderr = sys.__stderr__
+
+
+class ArnoldHandler(DefaultMaxHandler):
+    """Render Handler for Arnold"""
+
+    def __init__(self):
+        """
+        Initializes the Arnold Renderer and Arnold Handler
+        """
+        super().__init__()
+
+    def check_renderer(self) -> None:
+        """
+        Checks if the active renderer is set to Arnold. If it is not, set it to Arnold.
+        """
+        current_renderer = str(rt.renderers.current).split(":")[0]
+        if current_renderer != "Arnold":
+            rt.renderers.current = rt.Arnold()

--- a/src/deadline/max_submitter/data_const.py
+++ b/src/deadline/max_submitter/data_const.py
@@ -31,6 +31,7 @@ ALLOWED_RENDERERS = [
     "V_Ray_7",
     "V_Ray_GPU_7",
     "Redshift_Renderer",
+    "Arnold",
 ]
 
 # Possible output extensions


### PR DESCRIPTION
Add ArnoldHandler so the adaptor sets rt.Arnold() as the active renderer. Register Arnold in the renderer-to-handler lookup, in the submitter's allowed-renderers list, and in the init-data schema enum. Update README's compatible renderers list.

Verified: rendered an Arnold scene end-to-end via the OpenJD runner locally and via a Deadline Cloud SMF submission.

### What was the problem/requirement? (What/Why)

Autodesk Arnold (MAXtoA) ships natively with 3ds Max but was not a supported renderer in the Deadline Cloud integration. Selecting Arnold in 3ds Max blocked the submitter at the sanity check ("State01 has an unsupported renderer set. Renderer: Arnold"), and even with that bypassed the adaptor schema would reject `"renderer": "Arnold"`, with the dispatch falling through to `DefaultMaxHandler` and quietly switching the scene to Default Scanline.

### What was the solution? (How)

- New `ArnoldHandler(DefaultMaxHandler)` whose only override is `check_renderer()` to set `rt.Arnold()` as the active renderer (mirrors the simple Corona/Redshift pattern, since MAXtoA needs no version selection or extra env vars).
- Wire the new handler into `get_render_handler()` with an `elif renderer == "Arnold"` branch.
- Add `"Arnold"` to `ALLOWED_RENDERERS` so the submitter's renderer dropdown lists it and `check_sanity_specific_state_set` accepts it.
- Add `"Arnold"` to the `renderer` enum in `init_data.schema.json` (alongside the existing V-Ray regex branch).
- README compatible-renderers list updated.

### What is the impact of this change?

Users can submit Arnold render jobs from the 3ds Max submitter to Deadline Cloud. No behavior change for existing renderers. The schema change is purely additive — older init-data payloads still validate. Workers with the older adaptor will reject `"renderer": "Arnold"` until they have this version installed.

### How was this change tested?

- Local: rendered an Arnold scene via `scripts/test-3dsmax-openjd-run.ps1` against 3ds Max 2025. Frame 0 finished cleanly (exit code 0, MaxClient: `Finished Rendering Frame 0`).
- Cloud: submitted the same scene to a Deadline Cloud SMF fleet using the "Override Adaptor Wheels" developer option to ship the modified wheel along with the job. Adaptor accepted `"renderer": "Arnold"`, MAXtoA initialized on the worker, and Arnold rendered the scene to the configured output.
- `ruff check` and `black --check` pass on the changed files.

### Was this change documented?

Yes — README's "Compatible Renderers" list now includes Autodesk Arnold.

### Did you modify schema files?

- [x] Yes
- [ ] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [x] No

The change is purely additive — a new value in the `renderer` enum — and does not alter the contract for any existing renderer or field. Old payloads still validate without modification. Happy to bump the version if reviewers consider any client-visible schema addition to require it.

### Is this a breaking change?

No. Existing renderer submissions are unaffected. The only client-visible compatibility consideration is that workers running an older adaptor (without this PR) will reject jobs that specify `"renderer": "Arnold"`, but those jobs would have been impossible to construct with an older submitter anyway.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
