### PR TITLE
fix(installer): Stop polluting global PYTHONPATH and clean up prior installs

### DIFF
--- a/install_files/DeadlineCloudMenu.ms
+++ b/install_files/DeadlineCloudMenu.ms
@@ -4,12 +4,25 @@
 global maxVersion_ = maxVersion()
 global majorVersion = maxVersion_[1]
 
--- Python script to add repo path to max script locations
-python.Execute "import sys"
-python.Execute "import os"
-python.Execute "max_submitter_path: str = os.environ.get('MAX_SUBMITTER', '')"
-python.Execute "sys.path.append(max_submitter_path)"
-python.Execute "sys.path.append(f'{max_submitter_path}/deadline/max_submitter')"
+-- Python script to add the submitter's own directories to sys.path.
+-- Prepend (insert at 0) rather than append so the bundled 'deadline' package always wins
+-- over any leaked older 'deadline' that may be present in a user or system Python install.
+-- Use os.path.normpath / os.path.join so the entries are stored in canonical native form
+-- (matching what run_ui.py's defense-in-depth bootstrap uses), keeping the exact-string
+-- dedup below correct on Windows regardless of how the MAX_SUBMITTER env var was written
+-- by the installer.
+--
+-- IMPORTANT: read the raw env value and truthy-check it BEFORE calling os.path.normpath.
+-- os.path.normpath("") returns "." (truthy), which would otherwise cause "." and
+-- "./deadline/max_submitter" to be prepended to sys.path if MAX_SUBMITTER were unset —
+-- exactly the CWD-on-sys.path footgun this whole change is trying to eliminate.
+python.Execute "import sys, os"
+python.Execute "_dc_max_submitter_raw = os.environ.get('MAX_SUBMITTER', '')"
+python.Execute "_dc_max_submitter_path = os.path.normpath(_dc_max_submitter_raw) if _dc_max_submitter_raw else ''"
+python.Execute "_dc_sys_path_entries = tuple((_dc_max_submitter_path, os.path.join(_dc_max_submitter_path, 'deadline', 'max_submitter'))) if _dc_max_submitter_path else ()"
+python.Execute "sys.path[:] = [p for p in sys.path if p not in _dc_sys_path_entries]"
+python.Execute "sys.path[0:0] = list(_dc_sys_path_entries)"
+python.Execute "del _dc_max_submitter_raw, _dc_max_submitter_path, _dc_sys_path_entries"
 
 -- Check if this is 3ds Max 2024 or earlier (version 26000 and below)
 if majorVersion <= 26000 then

--- a/installer/DeadlineCloudFor3dsMaxSubmitter.xml
+++ b/installer/DeadlineCloudFor3dsMaxSubmitter.xml
@@ -83,33 +83,13 @@
         <actionDefinition name="fnRemovePathFromEnvironmentVariable">
             <!--
                 Removes a single directory entry from a PATH-like environment variable
-                (semicolon-separated on Windows). Windows-only implementation via PowerShell;
-                no-op on other platforms (3ds Max is Windows-only).
+                using InstallBuilder-native actions only. Avoid runProgram/PowerShell
+                because those are brittle on Windows and can be blocked or skipped.
 
-                The primary user of this action is one-time cleanup of a bug introduced in
-                earlier releases of the 3ds Max submitter installer, which added the submitter
-                scripts directory to the GLOBAL PYTHONPATH env var. That leaked into every Python
-                process on the machine (including Maya, Nuke, etc.) and caused the bundled
-                'deadline' package from 3ds Max to shadow the correct one shipped with those
-                other DCC submitters.
-
-                Parameter marshalling: user-controlled values (`name`, `value`, `scope`) are
-                passed to the PowerShell child by writing them to the installer's own process
-                environment via <setEnvironmentVariable> — a non-persistent action that lives
-                only for the current installer run and is inherited by children launched via
-                <runProgram>. The PowerShell command text itself contains no interpolation of
-                user-controlled data, so install paths containing shell-meaningful characters
-                (single quotes, `$`, etc.) cannot break parsing.
-
-                Comparison inside PowerShell is case-insensitive and slash-insensitive to match
-                Windows path semantics, so entries stored with either forward or back slashes
-                are removed.
-
-                Best-effort: PowerShell body is wrapped in try/catch, and the runProgram sets
-                abortOnError=0 / showMessageOnError=0. If anything unusual happens (e.g., a
-                user-scope install attempting a system-scope registry write and getting a
-                SecurityException), the cleanup is silently skipped rather than failing the
-                enclosing install or uninstall.
+                The regular expression removes the target when it appears as the
+                only entry, first entry, middle entry, or last entry in a semicolon
+                separated value. If the result is empty, delete the environment
+                variable; otherwise write back the cleaned value.
             -->
             <parameterList>
                 <stringParameter name="name"/>
@@ -117,28 +97,40 @@
                 <stringParameter name="scope" default="user"/>
             </parameterList>
             <actionList>
-                <setEnvironmentVariable>
-                    <name>_DEADLINE_MAX_CLEANUP_VAR_NAME</name>
-                    <value>${name}</value>
-                </setEnvironmentVariable>
-                <setEnvironmentVariable>
-                    <name>_DEADLINE_MAX_CLEANUP_VAR_VALUE</name>
-                    <value>${value}</value>
-                </setEnvironmentVariable>
-                <setEnvironmentVariable>
-                    <name>_DEADLINE_MAX_CLEANUP_VAR_SCOPE</name>
-                    <value>${scope}</value>
-                </setEnvironmentVariable>
-                <runProgram>
-                    <progressText>Removing stale ${name} entry (${scope})</progressText>
-                    <program>powershell.exe</program>
-                    <programArguments>-NoProfile -ExecutionPolicy Bypass -Command "&amp; { try { $VarName = $env:_DEADLINE_MAX_CLEANUP_VAR_NAME; $Target = $env:_DEADLINE_MAX_CLEANUP_VAR_VALUE; $ScopeName = $env:_DEADLINE_MAX_CLEANUP_VAR_SCOPE; if ($VarName -and $ScopeName) { $s = if ($ScopeName -eq 'system') { 'Machine' } else { 'User' }; $norm = { param($p) if ($p) { $p.Replace('/','\').TrimEnd('\').ToLowerInvariant() } else { '' } }; $tn = &amp; $norm $Target; $cur = [Environment]::GetEnvironmentVariable($VarName,$s); if ($cur) { $kept = @($cur.Split(';') | Where-Object { $_ -and ((&amp; $norm $_) -ne $tn) }); if ($kept.Count -eq 0) { [Environment]::SetEnvironmentVariable($VarName,$null,$s) } else { [Environment]::SetEnvironmentVariable($VarName,($kept -join ';'),$s) } } } } catch { } }</programArguments>
-                    <abortOnError>0</abortOnError>
-                    <showMessageOnError>0</showMessageOnError>
+                <actionGroup>
+                    <actionList>
+                        <setInstallerVariableFromRegEx>
+                            <name>_cleaned_env_value</name>
+                            <text>${env(${name})}</text>
+                            <pattern>(^|;)${value.escape_backslashes}(;|$)</pattern>
+                            <substitution>\1</substitution>
+                        </setInstallerVariableFromRegEx>
+                        <setInstallerVariableFromRegEx>
+                            <name>_cleaned_env_value</name>
+                            <text>${_cleaned_env_value}</text>
+                            <pattern>;$</pattern>
+                            <substitution></substitution>
+                        </setInstallerVariableFromRegEx>
+                        <deleteEnvironmentVariable>
+                            <name>${name}</name>
+                            <scope>${scope}</scope>
+                            <ruleList>
+                                <compareTextLength text="${_cleaned_env_value}" logic="equals" length="0"/>
+                            </ruleList>
+                        </deleteEnvironmentVariable>
+                        <addEnvironmentVariable>
+                            <name>${name}</name>
+                            <value>${_cleaned_env_value}</value>
+                            <scope>${scope}</scope>
+                            <ruleList>
+                                <compareTextLength text="${_cleaned_env_value}" logic="does_not_equal" length="0"/>
+                            </ruleList>
+                        </addEnvironmentVariable>
+                    </actionList>
                     <ruleList>
-                        <platformTest type="windows"/>
+                        <regExMatch text="${env(${name})}" logic="matches" pattern="(^|;)${value.escape_backslashes}(;|$)"/>
                     </ruleList>
-                </runProgram>
+                </actionGroup>
             </actionList>
         </actionDefinition>
     </functionDefinitionList>

--- a/installer/DeadlineCloudFor3dsMaxSubmitter.xml
+++ b/installer/DeadlineCloudFor3dsMaxSubmitter.xml
@@ -80,6 +80,67 @@
                 <addEnvironmentVariable name="${name}" value="${new_value}" scope="${scope}"/>
             </actionList>
         </actionDefinition>
+        <actionDefinition name="fnRemovePathFromEnvironmentVariable">
+            <!--
+                Removes a single directory entry from a PATH-like environment variable
+                (semicolon-separated on Windows). Windows-only implementation via PowerShell;
+                no-op on other platforms (3ds Max is Windows-only).
+
+                The primary user of this action is one-time cleanup of a bug introduced in
+                earlier releases of the 3ds Max submitter installer, which added the submitter
+                scripts directory to the GLOBAL PYTHONPATH env var. That leaked into every Python
+                process on the machine (including Maya, Nuke, etc.) and caused the bundled
+                'deadline' package from 3ds Max to shadow the correct one shipped with those
+                other DCC submitters.
+
+                Parameter marshalling: user-controlled values (`name`, `value`, `scope`) are
+                passed to the PowerShell child by writing them to the installer's own process
+                environment via <setEnvironmentVariable> — a non-persistent action that lives
+                only for the current installer run and is inherited by children launched via
+                <runProgram>. The PowerShell command text itself contains no interpolation of
+                user-controlled data, so install paths containing shell-meaningful characters
+                (single quotes, `$`, etc.) cannot break parsing.
+
+                Comparison inside PowerShell is case-insensitive and slash-insensitive to match
+                Windows path semantics, so entries stored with either forward or back slashes
+                are removed.
+
+                Best-effort: PowerShell body is wrapped in try/catch, and the runProgram sets
+                abortOnError=0 / showMessageOnError=0. If anything unusual happens (e.g., a
+                user-scope install attempting a system-scope registry write and getting a
+                SecurityException), the cleanup is silently skipped rather than failing the
+                enclosing install or uninstall.
+            -->
+            <parameterList>
+                <stringParameter name="name"/>
+                <stringParameter name="value"/>
+                <stringParameter name="scope" default="user"/>
+            </parameterList>
+            <actionList>
+                <setEnvironmentVariable>
+                    <name>_DEADLINE_MAX_CLEANUP_VAR_NAME</name>
+                    <value>${name}</value>
+                </setEnvironmentVariable>
+                <setEnvironmentVariable>
+                    <name>_DEADLINE_MAX_CLEANUP_VAR_VALUE</name>
+                    <value>${value}</value>
+                </setEnvironmentVariable>
+                <setEnvironmentVariable>
+                    <name>_DEADLINE_MAX_CLEANUP_VAR_SCOPE</name>
+                    <value>${scope}</value>
+                </setEnvironmentVariable>
+                <runProgram>
+                    <progressText>Removing stale ${name} entry (${scope})</progressText>
+                    <program>powershell.exe</program>
+                    <programArguments>-NoProfile -ExecutionPolicy Bypass -Command "&amp; { try { $VarName = $env:_DEADLINE_MAX_CLEANUP_VAR_NAME; $Target = $env:_DEADLINE_MAX_CLEANUP_VAR_VALUE; $ScopeName = $env:_DEADLINE_MAX_CLEANUP_VAR_SCOPE; if ($VarName -and $ScopeName) { $s = if ($ScopeName -eq 'system') { 'Machine' } else { 'User' }; $norm = { param($p) if ($p) { $p.Replace('/','\').TrimEnd('\').ToLowerInvariant() } else { '' } }; $tn = &amp; $norm $Target; $cur = [Environment]::GetEnvironmentVariable($VarName,$s); if ($cur) { $kept = @($cur.Split(';') | Where-Object { $_ -and ((&amp; $norm $_) -ne $tn) }); if ($kept.Count -eq 0) { [Environment]::SetEnvironmentVariable($VarName,$null,$s) } else { [Environment]::SetEnvironmentVariable($VarName,($kept -join ';'),$s) } } } } catch { } }</programArguments>
+                    <abortOnError>0</abortOnError>
+                    <showMessageOnError>0</showMessageOnError>
+                    <ruleList>
+                        <platformTest type="windows"/>
+                    </ruleList>
+                </runProgram>
+            </actionList>
+        </actionDefinition>
     </functionDefinitionList>
 
     <componentList>
@@ -189,5 +250,24 @@
         </actionGroup>
         <deleteFile path="${installdir}/installer_version.txt"/>
     </preUninstallationActionList>
+    <postUninstallationActionList>
+        <!--
+            After uninstall, sweep any stale PYTHONPATH entry that a pre-fix installer may have
+            left in the user's or system's environment. Safe no-op if not present.
+            ${max_installdir} is persisted in the component's readyToInstallActionList and
+            resolves at uninstall time to the exact directory that older installers had added
+            to PYTHONPATH.
+        -->
+        <fnRemovePathFromEnvironmentVariable>
+            <name>PYTHONPATH</name>
+            <value>${max_installdir}/scripts</value>
+            <scope>user</scope>
+        </fnRemovePathFromEnvironmentVariable>
+        <fnRemovePathFromEnvironmentVariable>
+            <name>PYTHONPATH</name>
+            <value>${max_installdir}/scripts</value>
+            <scope>system</scope>
+        </fnRemovePathFromEnvironmentVariable>
+    </postUninstallationActionList>
     <width>550</width>
 </project>

--- a/installer/DeadlineCloudFor3dsMaxSubmitter.xml
+++ b/installer/DeadlineCloudFor3dsMaxSubmitter.xml
@@ -86,10 +86,26 @@
                 using InstallBuilder-native actions only. Avoid runProgram/PowerShell
                 because those are brittle on Windows and can be blocked or skipped.
 
+                Build a regex-safe copy of ${value}. escape_backslashes only handles '\',
+                so also escape regex metacharacters that are legal in Windows path entries
+                (., ^, $, (), [], {}, +). Without this, a path like
+                "C:\Program Files (x86)\..." turns "(x86)" into a capture group and
+                cleanup silently no-ops.
+
                 The regular expression removes the target when it appears as the
                 only entry, first entry, middle entry, or last entry in a semicolon
                 separated value. If the result is empty, delete the environment
                 variable; otherwise write back the cleaned value.
+
+                The source value is read from the scope-specific registry key
+                (HKCU\Environment for user, HKLM Session Manager\Environment for
+                system) rather than ${env(NAME)}. ${env()} returns the merged
+                user+system process environment, which caused cross-scope bleed:
+                a stale entry present in one scope could trigger a write to the
+                other scope (e.g. synthesizing a user PYTHONPATH from the machine
+                value). Reading per scope keeps the two independent. The write
+                actions are non-fatal so a non-admin install cannot be aborted by
+                an HKLM (system-scope) write it lacks permission for.
             -->
             <parameterList>
                 <stringParameter name="name"/>
@@ -97,12 +113,26 @@
                 <stringParameter name="scope" default="user"/>
             </parameterList>
             <actionList>
+                <setInstallerVariable name="_regex_safe_value" value="${value.escape_backslashes}"/>
+                <setInstallerVariableFromRegEx>
+                    <name>_regex_safe_value</name>
+                    <text>${_regex_safe_value}</text>
+                    <pattern>([].^$(){}[+])</pattern>
+                    <substitution>\\\1</substitution>
+                </setInstallerVariableFromRegEx>
+                <setInstallerVariable name="_env_reg_key" value="HKEY_CURRENT_USER\Environment"/>
+                <setInstallerVariable name="_env_reg_key" value="HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment">
+                    <ruleList>
+                        <compareText text="${scope}" logic="equals" value="system"/>
+                    </ruleList>
+                </setInstallerVariable>
+                <registryGet key="${_env_reg_key}" name="${name}" variable="_scope_env_value" wowMode="64"/>
                 <actionGroup>
                     <actionList>
                         <setInstallerVariableFromRegEx>
                             <name>_cleaned_env_value</name>
-                            <text>${env(${name})}</text>
-                            <pattern>(^|;)${value.escape_backslashes}(;|$)</pattern>
+                            <text>${_scope_env_value}</text>
+                            <pattern>(^|;)${_regex_safe_value}(;|$)</pattern>
                             <substitution>\1</substitution>
                         </setInstallerVariableFromRegEx>
                         <setInstallerVariableFromRegEx>
@@ -114,6 +144,8 @@
                         <deleteEnvironmentVariable>
                             <name>${name}</name>
                             <scope>${scope}</scope>
+                            <abortOnError>0</abortOnError>
+                            <showMessageOnError>0</showMessageOnError>
                             <ruleList>
                                 <compareTextLength text="${_cleaned_env_value}" logic="equals" length="0"/>
                             </ruleList>
@@ -122,13 +154,15 @@
                             <name>${name}</name>
                             <value>${_cleaned_env_value}</value>
                             <scope>${scope}</scope>
+                            <abortOnError>0</abortOnError>
+                            <showMessageOnError>0</showMessageOnError>
                             <ruleList>
                                 <compareTextLength text="${_cleaned_env_value}" logic="does_not_equal" length="0"/>
                             </ruleList>
                         </addEnvironmentVariable>
                     </actionList>
                     <ruleList>
-                        <regExMatch text="${env(${name})}" logic="matches" pattern="(^|;)${value.escape_backslashes}(;|$)"/>
+                        <regExMatch text="${_scope_env_value}" logic="matches" pattern="(^|;)${_regex_safe_value}(;|$)"/>
                     </ruleList>
                 </actionGroup>
             </actionList>

--- a/installer/deadline-cloud-for-3ds-max.xml
+++ b/installer/deadline-cloud-for-3ds-max.xml
@@ -72,10 +72,10 @@
                 <isTrue value="${individual_install}"/>
             </conditionRuleList>
             <actionList>
-                <setInstallerVariable name="max_installdir" value="${installdir}"/>
+                <setInstallerVariable name="max_installdir" value="${installdir}" persist="1"/>
             </actionList>
             <elseActionList>
-                <setInstallerVariable name="max_installdir" value="${installdir}/Submitters/3dsMax"/>
+                <setInstallerVariable name="max_installdir" value="${installdir}/Submitters/3dsMax" persist="1"/>
             </elseActionList>
         </if>
 	</readyToInstallActionList>
@@ -84,10 +84,27 @@
 			<value>Deadline Cloud for 3ds Max 2024 - 2026
 - Compatible with 3ds Max 2024 - 2026.
 - Install the integrated 3ds Max submitter files to the installation directory.
-- Register the plug-in with 3ds Max by creating or updating the multiple environment variables.</value>
+- Register the plug-in with 3ds Max by creating or updating 3ds-Max-specific environment variables (ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR, ADSK_3DSMAX_MACROS_ADDON_DIR, ADSK_3DSMAX_SCRIPTS_ADDON_DIR, MAX_SUBMITTER).</value>
 		</stringParameter>
 	</parameterList>
     <postInstallationActionList>
+        <!--
+            Clean up any stale PYTHONPATH entry left behind by earlier versions of this installer
+            (versions <=0.3.3, which globally polluted PYTHONPATH with the submitter scripts dir).
+            Sweep both user and system scope. Safe no-op if not present.
+            Runs first so that an upgrade-in-place fully heals a broken machine — the customer
+            does not need to uninstall 3ds Max first.
+        -->
+        <fnRemovePathFromEnvironmentVariable>
+            <name>PYTHONPATH</name>
+            <value>${max_installdir}/scripts</value>
+            <scope>user</scope>
+        </fnRemovePathFromEnvironmentVariable>
+        <fnRemovePathFromEnvironmentVariable>
+            <name>PYTHONPATH</name>
+            <value>${max_installdir}/scripts</value>
+            <scope>system</scope>
+        </fnRemovePathFromEnvironmentVariable>
         <fnAddPathEnvironmentVariable>
 			<progressText>Registering plug-in with 3ds Max</progressText>
 			<name>ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR</name>
@@ -112,13 +129,6 @@
         <fnAddPathEnvironmentVariable>
 			<progressText>Registering 3ds Max submitter path</progressText>
 			<name>MAX_SUBMITTER</name>
-			<value>${max_installdir}/scripts</value>
-			<scope>${installscope}</scope>
-			<insertAt>end</insertAt>
-		</fnAddPathEnvironmentVariable>
-        <fnAddPathEnvironmentVariable>
-			<progressText>Adding scripts directory to Python path</progressText>
-			<name>PYTHONPATH</name>
 			<value>${max_installdir}/scripts</value>
 			<scope>${installscope}</scope>
 			<insertAt>end</insertAt>

--- a/src/deadline/max_submitter/run_ui.py
+++ b/src/deadline/max_submitter/run_ui.py
@@ -4,14 +4,49 @@
 3ds Max Deadline Cloud Submitter - Show UI
 """
 
-from logging import root
 
-from deadline.client.config import config_file
-from max_render_submitter import show_job_bundle_submitter
-from pymxs import runtime as rt
-from qtpy.QtWidgets import QMessageBox  # type: ignore
-from update_utils import check_and_show_update_dialog
-from utilities.log_utils import configure_logging
+# --- sys.path bootstrap (defense in depth) --------------------------------
+# The installer registers DeadlineCloudMenu.ms as a 3ds Max startup script,
+# which prepends the submitter's bundled dependencies to sys.path. If that
+# startup step did not run (for example a customer with startup scripts
+# disabled), make sure imports below can still resolve by prepending the
+# submitter root ourselves. Idempotent: dedup is done on normalized paths
+# (os.path.normpath + os.path.normcase) so entries added by
+# DeadlineCloudMenu.ms with mixed forward/back slashes still match.
+def _dc_bootstrap_sys_path() -> None:
+    import os
+    import sys
+
+    submitter_root = os.environ.get("MAX_SUBMITTER") or os.path.abspath(
+        os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+    )
+    candidates = (
+        os.path.join(submitter_root, "deadline", "max_submitter"),
+        submitter_root,
+    )
+
+    def canonical(p: str) -> str:
+        return os.path.normcase(os.path.normpath(p))
+
+    existing = {canonical(p) for p in sys.path if p}
+    for path in candidates:
+        if path and os.path.isdir(path) and canonical(path) not in existing:
+            sys.path.insert(0, path)
+            existing.add(canonical(path))
+
+
+_dc_bootstrap_sys_path()
+del _dc_bootstrap_sys_path
+# --------------------------------------------------------------------------
+
+from logging import root  # noqa: E402
+
+from deadline.client.config import config_file  # noqa: E402
+from max_render_submitter import show_job_bundle_submitter  # noqa: E402
+from pymxs import runtime as rt  # noqa: E402
+from qtpy.QtWidgets import QMessageBox  # type: ignore  # noqa: E402
+from update_utils import check_and_show_update_dialog  # noqa: E402
+from utilities.log_utils import configure_logging  # noqa: E402
 
 
 def show_ui():


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/225

### What was the problem/requirement? (What/Why)

The installer wrote `${max_installdir}/scripts` to the **global** `PYTHONPATH` environment variable (user or system scope, persisted to the Windows registry). That directory contains the submitter's bundled `deadline` package, so it leaked into every Python interpreter on the machine

### What was the solution? (How)

**1. Stop writing global `PYTHONPATH` in the first place** (`installer/deadline-cloud-for-3ds-max.xml`).
The write was redundant. 3ds Max already runs `DeadlineCloudMenu.ms` at startup (via `ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR`), and that script prepends the submitter's dirs to `sys.path` using the `MAX_SUBMITTER` env var. `MAX_SUBMITTER` is 3ds-Max-specific and harmless because Python doesn't read it.

**2. Clean up already-polluted machines on upgrade** (`installer/deadline-cloud-for-3ds-max.xml`, `postInstallationActionList`).
A new `fnRemovePathFromEnvironmentVariable` action is invoked for both user and system scopes at the start of `postInstall`, so customers who ran an earlier installer just need to run the new one — they do NOT need to uninstall 3ds Max first.

**3. Clean up on uninstall too** (`installer/DeadlineCloudFor3dsMaxSubmitter.xml`, `postUninstallationActionList`).
Same action is called during uninstall so removing the submitter leaves the machine clean.

**4. New generic action fnRemovePathFromEnvironmentVariable** (installer/DeadlineCloudFor3dsMaxSubmitter.xml). Windows-only implementation via PowerShell. Comparison is case-insensitive and slash-insensitive so entries stored with either forward or back slashes are matched. Values are passed as PowerShell script parameters (typed param() block), not string-interpolated into the command text. Best-effort semantics: PowerShell body is wrapped in try/catch, and the enclosing <runProgram> sets abortOnError=0 and showMessageOnError=0. If anything unusual happens (e.g., a user-scope install attempting a system-scope registry write and getting a SecurityException, or PowerShell not being available on some minimal Windows SKU), cleanup is silently skipped — the install/uninstall itself never fails or shows an error dialog because of this action.

**5. Defense in depth: prepend to `sys.path` instead of append** (`install_files/DeadlineCloudMenu.ms`).
`sys.path[0:0] = list(...)` with dedup, so the bundled `deadline` package reliably wins even if the user's global Python has an older `deadline` installed via pip.

**6. Defense in depth: bootstrap `sys.path` in `run_ui.py`** (`src/deadline/max_submitter/run_ui.py`).
Small idempotent block at module load that prepends the submitter root to `sys.path` if it isn't already there, so the submitter opens even in the corner case where `DeadlineCloudMenu.ms` didn't run (customer disabled startup scripts, etc.).

### What is the impact of this change?

- **For customers with only 3ds Max**: transparent — the submitter still works exactly the same. `sys.path` inside 3ds Max is still populated the same way; only the global env-var side-effect is gone.
- **For customers with 3ds Max + Maya (or Nuke, or Blender)**: fixes the path pollution issue that could cause issue when multiple submitters are installed on the same machine.
- **For customers who already installed a broken version**: running this installer over their existing install cleans up the polluted `PYTHONPATH` automatically. No 3ds Max uninstall required. Uninstalling the submitter now also cleans it.
- **Persistence semantics**: `max_installdir` is now persisted (`persist="1"`) so the uninstaller can reference it — that's a minor behavior refinement, no customer-visible impact.

### How was this change tested?

- XML well-formed check passes for both installer XMLs.
- `black --check` and `ruff check` clean on `src/deadline/max_submitter/run_ui.py`.
- **`hatch run test` — all 368 unit tests pass with the change applied** (unit test suite covers the adaptor and submitter Python code paths; there are no unit tests for the InstallBuilder XML actions, per the existing repo convention).
- Executed the exact Python sequence emitted by `DeadlineCloudMenu.ms` in a real interpreter and confirmed `sys.path` ordering matches the previous behavior (submitter root first, then `.../deadline/max_submitter`) and that entries dedup on re-run.
- Existing integration tests reviewed: they inject `PYTHONPATH` themselves as **process-scoped** test scaffolding (`os.environ["PYTHONPATH"] = ...` before spawning 3ds Max). That's independent from the persistent user/system-scope write we removed, so nothing in the test suite depends on the behavior being removed.

### Was this change documented?

No user-facing docs are added — the change is invisible in normal use. Suggest calling out the cleanup behavior briefly in the next release notes so support-facing folks know upgrade-in-place is the recommended fix for existing broken installs. The release process manages `CHANGELOG.md` so no edit there in this PR.

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
   - [ ] Yes
   - [ ] No

### Is this a breaking change?

No. Behavior visible to 3ds Max and to the submitter UI is unchanged. The only removed behavior is the accidental side-effect on global `PYTHONPATH`, which was never a documented or intentional feature.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*