### PR TITLE
feat: Run pre-GUI hooks in the 3ds Max render submitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ The 3ds Max submitter plugin is packaged as part of the Deadline Cloud submitter
 
 To manually build the installer, please follow the instructions [here](https://github.com/aws-deadline/deadline-cloud-for-3ds-max/blob/mainline/DEVELOPMENT.md#manual-installation).
 
+### Submission Hooks
+
+The 3ds Max submitter supports Deadline Cloud *submission hooks* — pre-GUI, pre-submission, and
+post-submission — sourced from a directory named by the `DEADLINE_HOOKS_DIR` environment variable.
+A pre-GUI hook can pre-populate the submitter dialog (job name/description, parameters such as
+priority or Conda packages) before it opens. Enable environment hooks with:
+
+```sh
+deadline config set settings.allow_environment_hooks true
+```
+
+Hooks run when you open the submitter from the 3ds Max shelf button. The submitter shows a
+confirmation dialog listing the hooks it found before running them, skipped when the
+general-purpose `settings.auto_accept` setting is enabled.
+
+For the hook types, the `hooks.yaml` format, the stdin/stdout contract, and examples, see
+[Submission Hooks](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md)
+in the AWS Deadline Cloud client library.
+
 ## Adaptor
 
 The 3ds Max Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch 3ds Max and feed it commands. This gives the following benefits:

--- a/src/deadline/max_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/max_submitter/job_bundle_output_test_runner.py
@@ -142,6 +142,12 @@ def _run_job_bundle_output_test(test_dir: str, dcc_scene_file: str, report_fh, m
 
         # Open the AWS Deadline Cloud submitter
         submitter = _show_deadline_cloud_submitter()
+        if submitter is None:
+            # show_job_bundle_submitter returns None if a pre-GUI hook confirmation is declined;
+            # there is nothing to export in that case, so fail loudly rather than dereference None.
+            raise RuntimeError(
+                "Submitter did not open (pre-GUI hook confirmation declined?); cannot export bundle."
+            )
         QApplication.processEvents()
 
         # Save the Job Bundle

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -24,10 +24,18 @@ from data_const import (
     TEMP_BACKUP_FILENAME,
     UI_GROUP_LABEL,
 )
+from deadline.client.config import get_setting, str2bool
 from deadline.client.dataclasses import SubmitterInfo
+from deadline.client.exceptions import DeadlineOperationCanceled, DeadlineOperationError
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.ui.dialogs._types import JobBundlePurpose
+from deadline.client.ui.pre_gui_hooks import (
+    PreGuiHookContext,
+    apply_pre_gui_output,
+    qt_hook_confirmation,
+    run_pre_gui_hooks,
+)
 from pymxs import runtime as rt
 from qtpy.QtCore import Qt  # type: ignore
 from qtpy.QtWidgets import QMessageBox  # type: ignore
@@ -280,6 +288,18 @@ def on_create_job_bundle_callback(
     settings.save_sticky_settings()
 
 
+def _pre_gui_hook_confirm_callback(parent):
+    """Choose the confirmation callback for pre-GUI hooks based on the auto_accept setting.
+
+    Returns ``None`` (run hooks without prompting) when ``settings.auto_accept`` is enabled,
+    otherwise the standard Qt confirmation dialog from ``qt_hook_confirmation``. Kept as a small
+    helper so the auto_accept branch can be unit-tested headlessly.
+    """
+    if str2bool(get_setting("settings.auto_accept")):
+        return None
+    return qt_hook_confirmation(parent)
+
+
 def show_job_bundle_submitter():
     """
     Main function that shows the UI.
@@ -290,8 +310,13 @@ def show_job_bundle_submitter():
 
     render_settings = RenderSubmitterUISettings()
 
-    # Set settings dependent on scene
-    render_settings.name = max_utils.get_scene_name()
+    # Set settings dependent on scene. Capture the scene name in a local before
+    # load_sticky_settings() (below) can overwrite render_settings.name with a previously persisted
+    # value: pre-GUI hooks receive this pre-sticky scene name as job_name (see the hook block), so a
+    # read-modify-write hook (e.g. a "STUDIO_" + jobName prefix) stays idempotent across runs instead
+    # of compounding through the sticky settings file.
+    scene_name = max_utils.get_scene_name()
+    render_settings.name = scene_name
     render_settings.frame_list = max_utils.get_frames()
     render_settings.project_path = max_utils.get_scene_path()
 
@@ -309,9 +334,92 @@ def show_job_bundle_submitter():
 
     render_settings.load_sticky_settings()
 
+    # Compute the shared parameter values the dialog is seeded with. These are also handed to the
+    # pre-GUI hooks below (as the PreGuiHookContext parameters), so build them before the hook runs.
+    max_version = get_max_version_year()
+    adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
+    conda_packages = f"3dsmax={max_version}.* 3dsmax-openjd={adaptor_version}.*"
+
+    shared_parameter_values = {
+        "CondaPackages": conda_packages,
+    }
+
+    # Run pre-GUI hooks so studios can pre-populate dialog fields before it opens. 3ds Max has no
+    # on-disk job bundle at this point, so hooks are sourced from DEADLINE_HOOKS_DIR only
+    # (bundle_dir=None), gated by settings.allow_environment_hooks. The confirmation prompt is
+    # skipped when auto_accept is set; otherwise the standard dialog is shown.
+    #
+    # This runs BEFORE the state-set discovery loop and asset scanning below. That loop sets the
+    # scene's active state set (masterState.CurrentState) as it walks each state set, mutating the
+    # scene; running the hooks first means declining the confirmation prompt or a hook failure
+    # aborts (return None) without having touched the scene, and the prompt also appears promptly
+    # instead of after all the scanning work.
+    hook_deadline_params_applied = False
+    try:
+        # Build the confirmation callback (reads settings.auto_accept), run the hooks, and apply
+        # their output, all inside this try so hook failures are handled by the except clauses below
+        # instead of escaping as a raw traceback (3ds Max opens the submitter without a surrounding
+        # gui_error_handler).
+        confirm_callback = _pre_gui_hook_confirm_callback(main_window)
+        pre_gui_output = run_pre_gui_hooks(
+            PreGuiHookContext(
+                bundle_dir=None,
+                # Pre-sticky scene name (not render_settings.name, which load_sticky_settings may
+                # have replaced with a prior hook's output) so read-modify-write hooks stay
+                # idempotent and don't compound through the sticky settings file.
+                job_name=scene_name,
+                submitter_name=render_settings.submitter_name,
+                priority=render_settings.priority,
+                parameters=dict(shared_parameter_values),
+            ),
+            confirm_callback=confirm_callback,
+        )
+        # deadline-cloud's generic helper maps the merged output onto our settings + shared values.
+        # RenderSubmitterUISettings has no .parameters list, so every hook parameter (CondaPackages,
+        # deadline: job properties, etc.) flows into shared_parameter_values, which seeds the dialog.
+        # Guard with `or {}` defensively: run_pre_gui_hooks returns {} when no hooks run, but this
+        # keeps the call safe if a future release returns None instead.
+        apply_pre_gui_output(pre_gui_output or {}, render_settings, shared_parameter_values)
+        # Track only whether hook deadline: parameters were applied. The dialog's shared-settings
+        # widget replays only deadline: keys synchronously during construction (via
+        # set_parameter_value in SharedJobSettingsWidget.__init__), so those are the sole hook output
+        # that can make SubmitMaxJobToDeadlineDialog(...) raise below, and thus the only thing the
+        # construction guard should arm on. name/description land on the type-validated
+        # RenderSubmitterUISettings dataclass, and non-deadline: queue parameters are applied
+        # asynchronously (see the construction-guard comment) — neither can fail construction here.
+        hook_deadline_params_applied = any(
+            name.startswith("deadline:")
+            for name in ((pre_gui_output or {}).get("parameters") or {})
+        )
+    except DeadlineOperationCanceled:
+        # The user declined the hook confirmation prompt — a normal cancellation, not a failure — so
+        # abort opening the submitter silently. Mirrors the check_and_show_update_dialog() early
+        # return. (DeadlineOperationCanceled subclasses DeadlineOperationError, so this handler must
+        # come first.)
+        return None
+    except DeadlineOperationError:
+        # A pre-GUI hook failed: non-zero exit, timeout, invalid JSON, or disallowed output —
+        # deadline-cloud raises DeadlineOperationError for all of these. Its documented contract is
+        # that a failing pre-GUI hook *blocks* the dialog, so surface a clear error and abort rather
+        # than opening with un-applied values (which would silently bypass any pipeline policy the
+        # hook enforces). Only DeadlineOperationError is caught, so genuine local bugs still surface
+        # as tracebacks instead of being mistaken for hook failures.
+        _logger.exception("A pre-GUI submission hook failed; the submitter will not open.")
+        QMessageBox.critical(
+            main_window,
+            "AWS Deadline Cloud",
+            "A pre-GUI submission hook failed, so the submitter was not opened. "
+            "See the 3ds Max scripting listener/log for details.",
+        )
+        return None
+
     output_directories: set[str] = set()
 
-    # Add output dir from state set settings if one is set
+    # Add output dir from state set settings if one is set. NOTE: this loop sets
+    # masterState.CurrentState for each state set to read its output path, changing the scene's
+    # active state set; the submitter dialog re-applies a state set when it opens, so the visible
+    # end state is dialog-driven. The pre-GUI hook block above deliberately runs before this so its
+    # abort paths don't leave the scene mutated with no dialog open.
     state_sets = max_utils.get_state_set_names()
     for state_set in state_sets:
         rt.execute(
@@ -356,10 +464,6 @@ def show_job_bundle_submitter():
         output_directories=set(render_settings.output_directories),
     )
 
-    max_version = get_max_version_year()
-    adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
-    conda_packages = f"3dsmax={max_version}.* 3dsmax-openjd={adaptor_version}.*"
-
     submitter_info = SubmitterInfo(
         submitter_name="3dsMax",
         submitter_package_name="deadline-cloud-for-3ds-max",
@@ -368,21 +472,47 @@ def show_job_bundle_submitter():
         host_application_version=str(max_version),
     )
 
-    # Instantiate and show the Submitter UI
-    window = SubmitMaxJobToDeadlineDialog(
-        job_setup_widget_type=SceneSettingsWidget,
-        initial_job_settings=render_settings,
-        initial_shared_parameter_values={
-            "CondaPackages": conda_packages,
-        },
-        auto_detected_attachments=auto_detected_attachments,
-        attachments=attachments,
-        on_create_job_bundle_callback=on_create_job_bundle_callback,
-        parent=main_window,
-        f=Qt.Tool,
-        show_host_requirements_tab=True,
-        submitter_info=submitter_info,
-    )
+    # Instantiate and show the Submitter UI. A pre-GUI hook can inject a deadline: parameter the
+    # shared-settings widget doesn't accept (an unknown key, or a value of the wrong type). Only
+    # deadline: keys are replayed synchronously here, during construction (SharedJobSettingsWidget
+    # replays them via set_parameter_value in __init__), so that is the failure this guard catches:
+    # per the block-on-failure contract, treat it as a hook failure and abort with a clear error
+    # rather than a raw traceback, but only when the hook actually supplied a deadline: parameter. A
+    # construction failure with no hook deadline: parameter applied is a genuine submitter bug and
+    # is left to propagate as a traceback.
+    #
+    # Non-deadline: (queue) parameters such as CondaPackages are NOT replayed here — the widget
+    # applies them asynchronously once the queue's parameter definitions have loaded, after this
+    # try/except has returned. So this guard cannot catch them: a bad queue-parameter *value*
+    # surfaces later in the Qt event loop, and a queue-parameter *name* the target queue doesn't
+    # define is silently dropped. Validating those against the loaded queue parameters belongs in
+    # deadline-cloud's shared widget, not here.
+    try:
+        window = SubmitMaxJobToDeadlineDialog(
+            job_setup_widget_type=SceneSettingsWidget,
+            initial_job_settings=render_settings,
+            initial_shared_parameter_values=shared_parameter_values,
+            auto_detected_attachments=auto_detected_attachments,
+            attachments=attachments,
+            on_create_job_bundle_callback=on_create_job_bundle_callback,
+            parent=main_window,
+            f=Qt.Tool,
+            show_host_requirements_tab=True,
+            submitter_info=submitter_info,
+        )
+    except Exception:
+        if not hook_deadline_params_applied:
+            raise
+        _logger.exception(
+            "A pre-GUI hook supplied a value the submitter could not use; the submitter will not open."
+        )
+        QMessageBox.critical(
+            main_window,
+            "AWS Deadline Cloud",
+            "A pre-GUI submission hook supplied a value the submitter could not use, so the "
+            "submitter was not opened. See the 3ds Max scripting listener/log for details.",
+        )
+        return None
     window.show()
     return window
 

--- a/test/integ/test_scripts/batch_render_test/_test_max.py
+++ b/test/integ/test_scripts/batch_render_test/_test_max.py
@@ -18,6 +18,11 @@ def main(job_history_dir: str, output_dir: str):
     """
 
     widget = show_job_bundle_submitter()
+    # show_job_bundle_submitter returns None when a pre-GUI hook aborts the open (declined
+    # confirmation, hook failure, or a bad hook value). This test configures no environment hooks,
+    # so that path is not expected here; assert to fail clearly instead of raising an opaque
+    # AttributeError on widget.job_settings_type() below if it ever does.
+    assert widget is not None, "submitter did not open (pre-GUI hook aborted?)"
 
     settings = widget.job_settings_type()
     widget.shared_job_settings.update_settings(settings)

--- a/test/integ/test_scripts/batch_render_test/_test_max_override_frames.py
+++ b/test/integ/test_scripts/batch_render_test/_test_max_override_frames.py
@@ -18,6 +18,11 @@ def main(job_history_dir: str, output_dir: str):
     """
 
     widget = show_job_bundle_submitter()
+    # show_job_bundle_submitter returns None when a pre-GUI hook aborts the open (declined
+    # confirmation, hook failure, or a bad hook value). This test configures no environment hooks,
+    # so that path is not expected here; assert to fail clearly instead of raising an opaque
+    # AttributeError on widget.job_settings_type() below if it ever does.
+    assert widget is not None, "submitter did not open (pre-GUI hook aborted?)"
 
     settings = widget.job_settings_type()
     widget.shared_job_settings.update_settings(settings)

--- a/test/integ/test_scripts/minimal_test/_test_max.py
+++ b/test/integ/test_scripts/minimal_test/_test_max.py
@@ -17,6 +17,11 @@ def main(job_history_dir: str, output_dir: str):
     """
 
     widget = show_job_bundle_submitter()
+    # show_job_bundle_submitter returns None when a pre-GUI hook aborts the open (declined
+    # confirmation, hook failure, or a bad hook value). This test configures no environment hooks,
+    # so that path is not expected here; assert to fail clearly instead of raising an opaque
+    # AttributeError on widget.job_settings_type() below if it ever does.
+    assert widget is not None, "submitter did not open (pre-GUI hook aborted?)"
 
     settings = widget.job_settings_type()
     widget.shared_job_settings.update_settings(settings)

--- a/test/integ/test_scripts/task_run_timeout_test/_test_max.py
+++ b/test/integ/test_scripts/task_run_timeout_test/_test_max.py
@@ -27,6 +27,11 @@ def main(job_history_dir: str, output_dir: str):
     Open the submitter, configure a task run timeout, and export a job bundle.
     """
     widget = show_job_bundle_submitter()
+    # show_job_bundle_submitter returns None when a pre-GUI hook aborts the open (declined
+    # confirmation, hook failure, or a bad hook value). This test configures no environment hooks,
+    # so that path is not expected here; assert to fail clearly instead of raising an opaque
+    # AttributeError on widget.job_settings_type() below if it ever does.
+    assert widget is not None, "submitter did not open (pre-GUI hook aborted?)"
 
     settings = widget.job_settings_type()
     widget.shared_job_settings.update_settings(settings)

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -37,10 +37,20 @@ def pytest_configure(config):
     if "qtmax" not in sys.modules:
         sys.modules["qtmax"] = MagicMock()
 
-    # Mock qtpy for max_submitter modules
-    if "qtpy" not in sys.modules:
-        sys.modules["qtpy"] = MagicMock()
-        sys.modules["qtpy.QtCore"] = MagicMock()
+    # Mock qtpy for max_submitter modules. QtWidgets/QtGui are stubbed as their own sys.modules
+    # entries (not just left to auto-vivify off the qtpy mock) so a test can patch QMessageBox on
+    # the exact module object that deadline-cloud's qt_hook_confirmation reads via a lazy
+    # `from qtpy.QtWidgets import QMessageBox` — see test_pre_gui_hooks, which patches
+    # sys.modules["qtpy.QtWidgets"] directly. Mirrors the Maya submitter's test module stubbing.
+    #
+    # Each submodule is registered independently with setdefault rather than under a single
+    # `if "qtpy" not in sys.modules` guard: if a real qtpy is imported first (by a dev/CI install or
+    # another plugin) but its QtWidgets submodule is not, that guard would skip the stub and
+    # test_pre_gui_hooks' collection-time `sys.modules["qtpy.QtWidgets"]` lookup would KeyError.
+    # setdefault fills any missing entry without clobbering an already-imported real module.
+    sys.modules.setdefault("qtpy", MagicMock())
+    for _qtpy_submodule in ("QtCore", "QtWidgets", "QtGui"):
+        sys.modules.setdefault(f"qtpy.{_qtpy_submodule}", MagicMock())
 
     # Mock UI modules (these have complex Qt dependencies)
     if "ui" not in sys.modules:

--- a/test/unit/deadline_submitter_for_3ds_max/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_3ds_max/test_pre_gui_hooks.py
@@ -1,0 +1,483 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for the 3ds Max submitter's pre-GUI hook integration.
+
+``show_job_bundle_submitter`` calls deadline-cloud's ``run_pre_gui_hooks`` (env-only, since
+3ds Max has no on-disk bundle) and then delegates the mapping to deadline-cloud's generic
+``apply_pre_gui_output``. The full submitter needs a running 3ds Max, so it is exercised in the
+integration suite; here we verify the DCC-owned pieces headless:
+
+* ``apply_pre_gui_output`` routes hook output correctly against 3ds Max's own
+  ``RenderSubmitterUISettings`` — which has no ``.parameters`` list, so every hook parameter must
+  land in the shared parameter values. This guards against a regression where
+  ``RenderSubmitterUISettings`` gains a ``parameters`` attribute that would misroute hook params.
+* ``_pre_gui_hook_confirm_callback`` honours the ``settings.auto_accept`` setting.
+* Declining the hook confirmation (``DeadlineOperationCanceled``) aborts the open silently
+  rather than surfacing an uncaught traceback.
+* A failing pre-GUI hook (``DeadlineOperationError``) blocks the submitter with a clear error
+  dialog rather than opening with un-applied values; hook-supplied values that only fail when the
+  dialog is built block the same way; and genuine local bugs (other exceptions) still propagate.
+
+The pymxs / Qt modules are stubbed by ``test/unit/conftest.py`` so imports resolve.
+"""
+
+import sys
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from deadline.client.exceptions import DeadlineOperationCanceled, DeadlineOperationError
+from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
+from deadline.max_submitter import max_render_submitter
+from deadline.max_submitter.data_classes import RenderSubmitterUISettings
+
+
+def _settings() -> RenderSubmitterUISettings:
+    s = RenderSubmitterUISettings()
+    s.name = "Original"
+    s.description = ""
+    return s
+
+
+def test_settings_has_no_parameters_list():
+    """The DCC contract apply_pre_gui_output depends on: RenderSubmitterUISettings exposes no
+    ``.parameters`` list, so hook parameters are treated as shared values, not template params."""
+    assert getattr(RenderSubmitterUISettings(), "parameters", None) is None
+
+
+def test_name_and_description_applied_to_settings():
+    """A hook's name/description overwrite the settings fields (3ds Max has no .parameters list,
+    so these land directly on the dataclass)."""
+    settings = _settings()
+    shared = {"CondaPackages": "3dsmax=2026.* 3dsmax-openjd=0.1.*"}
+
+    apply_pre_gui_output({"name": "PREGUI RAN", "description": "from pipeline"}, settings, shared)
+
+    assert settings.name == "PREGUI RAN"
+    assert settings.description == "from pipeline"
+
+
+def test_hook_parameters_merged_into_shared_values():
+    """With no template-parameter list, every hook parameter (queue params, deadline: properties)
+    is merged into the shared values the dialog is seeded with, overriding defaults on collision."""
+    settings = _settings()
+    shared = {"CondaPackages": "3dsmax=2026.* 3dsmax-openjd=0.1.*"}
+
+    apply_pre_gui_output(
+        {
+            "parameters": {
+                "deadline:priority": 88,
+                "CondaPackages": "3dsmax=2026.* custom_pkg",  # overrides the default
+            }
+        },
+        settings,
+        shared,
+    )
+
+    assert shared["deadline:priority"] == 88
+    assert shared["CondaPackages"] == "3dsmax=2026.* custom_pkg"
+
+
+def test_empty_output_is_a_noop():
+    """No pre-GUI hook output leaves the settings and shared values unchanged."""
+    settings = _settings()
+    shared = {"CondaPackages": "pkg"}
+
+    apply_pre_gui_output({}, settings, shared)
+
+    assert settings.name == "Original"
+    assert settings.description == ""
+    assert shared == {"CondaPackages": "pkg"}
+
+
+def test_partial_output_only_touches_present_keys():
+    """Only the keys present in the output are applied; others keep their prior values."""
+    settings = _settings()
+    settings.description = "keep me"
+    shared: dict = {}
+
+    apply_pre_gui_output({"name": "NewName"}, settings, shared)
+
+    assert settings.name == "NewName"
+    assert settings.description == "keep me"  # not overwritten
+    assert shared == {}  # no parameters in output
+
+
+@patch.object(max_render_submitter, "get_setting", return_value="true")
+def test_confirm_callback_none_when_auto_accept_enabled(mock_get_setting):
+    """With settings.auto_accept enabled, hooks run without a confirmation prompt."""
+    assert max_render_submitter._pre_gui_hook_confirm_callback(parent=None) is None
+    mock_get_setting.assert_called_once_with("settings.auto_accept")
+
+
+@patch.object(sys.modules["qtpy.QtWidgets"], "QMessageBox")
+@patch.object(max_render_submitter, "get_setting", return_value="false")
+def test_confirmation_dialog_fires_when_auto_accept_disabled(mock_get_setting, mock_msgbox):
+    """With settings.auto_accept disabled, invoking the returned callback actually shows the
+    confirmation dialog (QMessageBox.question), parented to the passed-in window.
+
+    This exercises the real ``qt_hook_confirmation`` callback rather than mocking it out, so it
+    verifies the prompt fires — not merely that a non-None callback was selected. ``run_pre_gui_hooks``
+    invokes ``confirm_callback(sources)`` with the hook sources; an empty list is enough to reach
+    the dialog. The user's answer is mapped from the QMessageBox reply.
+    """
+    mock_msgbox.question.return_value = mock_msgbox.Yes
+
+    callback = max_render_submitter._pre_gui_hook_confirm_callback(parent="mainwin")
+    assert callback is not None
+
+    result = callback([])  # no hook sources needed to reach the dialog
+
+    assert mock_msgbox.question.call_count == 1
+    # The dialog is parented to the window passed into the submitter.
+    assert mock_msgbox.question.call_args[0][0] == "mainwin"
+    # "Yes" reply → proceed.
+    assert result is True
+
+
+def test_falsy_output_is_a_noop():
+    """The submitter passes ``pre_gui_output or {}`` into apply_pre_gui_output, so the values
+    run_pre_gui_hooks can actually produce for the no-hooks path — ``{}`` today, or ``None`` if
+    the contract ever changed — must both be safe no-ops that leave settings/shared untouched."""
+    falsy_values: list[Optional[dict]] = [{}, None]
+    for falsy in falsy_values:
+        settings = _settings()
+        shared = {"CondaPackages": "3dsmax=2026.* 3dsmax-openjd=0.1.*"}
+
+        # Mirror the submitter call site: `pre_gui_output or {}`.
+        apply_pre_gui_output(falsy or {}, settings, shared)
+
+        assert settings.name == "Original"
+        assert settings.description == ""
+        assert shared == {"CondaPackages": "3dsmax=2026.* 3dsmax-openjd=0.1.*"}
+
+
+@patch.object(max_render_submitter, "SubmitMaxJobToDeadlineDialog")
+@patch.object(max_render_submitter, "run_pre_gui_hooks")
+@patch.object(max_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(max_render_submitter, "get_render_elements_output_directories", return_value=set())
+@patch.object(max_render_submitter, "rt")
+@patch.object(max_render_submitter, "qtmax")
+@patch.object(max_render_submitter, "max_utils")
+def test_declining_hook_confirmation_aborts_without_error(
+    mock_max_utils,
+    mock_qtmax,
+    mock_rt,
+    mock_render_elements,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+):
+    """Declining the hook prompt (DeadlineOperationCanceled) returns None and never builds the
+    dialog. 3ds Max opens the submitter without a surrounding gui_error_handler, so an uncaught
+    cancellation would otherwise propagate as a raw traceback."""
+    # Scene-setup helpers must return plausible/unpackable values so execution reaches the hook.
+    mock_max_utils.get_render_output_info.return_value = ("/out", "name", ".jpg")
+    mock_max_utils.get_scene_name.return_value = "scene"
+    mock_max_utils.get_frames.return_value = "1-10"
+    mock_max_utils.get_scene_path.return_value = "/scene.max"
+    mock_max_utils.get_state_set_names.return_value = []
+    mock_max_utils.get_referenced_files.return_value = []
+    mock_rt.execute.return_value = "C:/tmp"
+    mock_rt.maxVersion.return_value = [26000]
+    mock_rt.renderers.current = "Arnold:Arnold"
+    mock_rt.maxFilePath = "/scene/"
+    # The user clicks "No" on the confirmation prompt.
+    mock_run_hooks.side_effect = DeadlineOperationCanceled("user declined")
+
+    result = max_render_submitter.show_job_bundle_submitter()
+
+    assert result is None
+    mock_run_hooks.assert_called_once()
+    mock_dialog.assert_not_called()  # dialog must not be built on cancellation
+    # Hooks run before the state-set discovery loop, which mutates the scene's active state set. On
+    # cancellation we must abort before that loop so a declined submission never touches the scene.
+    mock_max_utils.get_state_set_names.assert_not_called()
+
+
+def _scene_mocks(mock_max_utils, mock_rt):
+    """Make the scene-setup helpers return plausible/unpackable values so execution reaches the
+    pre-GUI hook block."""
+    mock_max_utils.get_render_output_info.return_value = ("/out", "name", ".jpg")
+    mock_max_utils.get_scene_name.return_value = "scene"
+    mock_max_utils.get_frames.return_value = "1-10"
+    mock_max_utils.get_scene_path.return_value = "/scene.max"
+    mock_max_utils.get_state_set_names.return_value = []
+    mock_max_utils.get_referenced_files.return_value = []
+    mock_rt.execute.return_value = "C:/tmp"
+    mock_rt.maxVersion.return_value = [26000]
+    mock_rt.renderers.current = "Arnold:Arnold"
+    mock_rt.maxFilePath = "/scene/"
+
+
+@patch.object(max_render_submitter, "QMessageBox")
+@patch.object(max_render_submitter, "apply_pre_gui_output")
+@patch.object(max_render_submitter, "SubmitMaxJobToDeadlineDialog")
+@patch.object(max_render_submitter, "run_pre_gui_hooks")
+@patch.object(max_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(max_render_submitter, "get_render_elements_output_directories", return_value=set())
+@patch.object(max_render_submitter, "rt")
+@patch.object(max_render_submitter, "qtmax")
+@patch.object(max_render_submitter, "max_utils")
+def test_hook_failure_blocks_submitter(
+    mock_max_utils,
+    mock_qtmax,
+    mock_rt,
+    mock_render_elements,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+    mock_apply,
+    mock_msgbox,
+):
+    """A failing pre-GUI hook (``DeadlineOperationError`` — non-zero exit, timeout, invalid JSON,
+    disallowed output) blocks the submitter: a clear error dialog is shown, the function returns
+    ``None``, and the submitter dialog is never built (matching deadline-cloud's block-on-failure
+    contract), rather than opening with un-applied values."""
+    _scene_mocks(mock_max_utils, mock_rt)
+    mock_run_hooks.side_effect = DeadlineOperationError("pre-GUI hook exited with code 1")
+
+    result = max_render_submitter.show_job_bundle_submitter()
+
+    assert result is None
+    mock_run_hooks.assert_called_once()
+    mock_apply.assert_not_called()  # output never applied when the hook failed
+    mock_dialog.assert_not_called()  # submitter is not opened
+    mock_msgbox.critical.assert_called_once()  # user is told, not just the log
+    # Hooks run before the state-set discovery loop that mutates the scene's active state set, so a
+    # hook failure blocks before that loop and never touches the scene.
+    mock_max_utils.get_state_set_names.assert_not_called()
+
+
+@patch.object(max_render_submitter, "QMessageBox")
+@patch.object(max_render_submitter, "apply_pre_gui_output")
+@patch.object(max_render_submitter, "SubmitMaxJobToDeadlineDialog")
+@patch.object(max_render_submitter, "run_pre_gui_hooks")
+@patch.object(max_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(max_render_submitter, "get_render_elements_output_directories", return_value=set())
+@patch.object(max_render_submitter, "rt")
+@patch.object(max_render_submitter, "qtmax")
+@patch.object(max_render_submitter, "max_utils")
+def test_unexpected_hook_error_propagates(
+    mock_max_utils,
+    mock_qtmax,
+    mock_rt,
+    mock_render_elements,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+    mock_apply,
+    mock_msgbox,
+):
+    """Only ``DeadlineOperationError`` is treated as a hook failure. A different exception is a
+    genuine local bug and must propagate (surface as a traceback) rather than be silently converted
+    into a "hook failed" dialog — so real defects stay visible."""
+    _scene_mocks(mock_max_utils, mock_rt)
+    mock_run_hooks.side_effect = RuntimeError("genuine bug, not a hook failure")
+
+    with pytest.raises(RuntimeError):
+        max_render_submitter.show_job_bundle_submitter()
+
+    mock_dialog.assert_not_called()
+    mock_msgbox.critical.assert_not_called()
+
+
+@patch.object(max_render_submitter, "QMessageBox")
+@patch.object(max_render_submitter, "apply_pre_gui_output")
+@patch.object(
+    max_render_submitter, "SubmitMaxJobToDeadlineDialog", side_effect=KeyError("deadline:prioriy")
+)
+@patch.object(
+    max_render_submitter,
+    "run_pre_gui_hooks",
+    return_value={"parameters": {"deadline:priority": "not-an-int"}},
+)
+@patch.object(max_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(max_render_submitter, "get_render_elements_output_directories", return_value=set())
+@patch.object(max_render_submitter, "rt")
+@patch.object(max_render_submitter, "qtmax")
+@patch.object(max_render_submitter, "max_utils")
+def test_bad_hook_params_block_at_dialog_construction(
+    mock_max_utils,
+    mock_qtmax,
+    mock_rt,
+    mock_render_elements,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+    mock_apply,
+    mock_msgbox,
+):
+    """A hook can inject a deadline: *parameter* (unknown key, or wrong value type) that only fails
+    when the shared-settings widget replays it during dialog construction — after the hook
+    try/except. When hook parameters were applied, that construction failure blocks cleanly (error
+    dialog + ``None``) instead of escaping as a raw traceback. The hook output here carries a
+    ``parameters`` map (not just name/description), because only parameters are replayed through the
+    widget and can arm the construction guard."""
+    _scene_mocks(mock_max_utils, mock_rt)
+
+    result = max_render_submitter.show_job_bundle_submitter()
+
+    assert result is None
+    mock_dialog.assert_called_once()  # construction was attempted...
+    mock_msgbox.critical.assert_called_once()  # ...failed, and the user was told
+
+
+@patch.object(max_render_submitter, "QMessageBox")
+@patch.object(max_render_submitter, "apply_pre_gui_output")
+@patch.object(
+    max_render_submitter, "SubmitMaxJobToDeadlineDialog", side_effect=AttributeError("widget bug")
+)
+@patch.object(max_render_submitter, "run_pre_gui_hooks", return_value={"name": "SHOT_010"})
+@patch.object(max_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(max_render_submitter, "get_render_elements_output_directories", return_value=set())
+@patch.object(max_render_submitter, "rt")
+@patch.object(max_render_submitter, "qtmax")
+@patch.object(max_render_submitter, "max_utils")
+def test_name_only_hook_output_does_not_mask_construction_bug(
+    mock_max_utils,
+    mock_qtmax,
+    mock_rt,
+    mock_render_elements,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+    mock_apply,
+    mock_msgbox,
+):
+    """The construction guard arms only when hook *deadline:* parameters were applied. A hook that
+    returns only ``{"name": "SHOT_010"}`` (the canonical job-name-prefix hook, no parameters) must
+    NOT arm it: name/description land on the settings dataclass and are already type-validated, so
+    they cannot break dialog construction. An unrelated construction failure (e.g. an
+    ``AttributeError`` regression in the widget) must therefore still propagate as a traceback
+    rather than be masked as "a pre-GUI hook supplied a bad value" — otherwise submitter bugs would
+    be misattributed to the studio's hook in every studio whose hook always returns a name."""
+    _scene_mocks(mock_max_utils, mock_rt)
+
+    with pytest.raises(AttributeError):
+        max_render_submitter.show_job_bundle_submitter()
+
+    mock_dialog.assert_called_once()
+    mock_msgbox.critical.assert_not_called()  # not masked as a hook failure
+
+
+@patch.object(max_render_submitter, "QMessageBox")
+@patch.object(max_render_submitter, "apply_pre_gui_output")
+@patch.object(
+    max_render_submitter, "SubmitMaxJobToDeadlineDialog", side_effect=RuntimeError("widget bug")
+)
+@patch.object(
+    max_render_submitter,
+    "run_pre_gui_hooks",
+    return_value={"parameters": {"CondaPackages": "3dsmax=2026.* custom_pkg"}},
+)
+@patch.object(max_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(max_render_submitter, "get_render_elements_output_directories", return_value=set())
+@patch.object(max_render_submitter, "rt")
+@patch.object(max_render_submitter, "qtmax")
+@patch.object(max_render_submitter, "max_utils")
+def test_queue_only_hook_params_do_not_mask_construction_bug(
+    mock_max_utils,
+    mock_qtmax,
+    mock_rt,
+    mock_render_elements,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+    mock_apply,
+    mock_msgbox,
+):
+    """Only ``deadline:`` parameters arm the construction guard, because only they are replayed
+    synchronously during ``SubmitMaxJobToDeadlineDialog`` construction. A hook that supplies only a
+    non-``deadline:`` queue parameter (e.g. ``CondaPackages``) cannot break construction: those are
+    applied asynchronously by the shared-settings widget after the queue's parameter definitions
+    load, well after construction returns. So a construction failure here is a genuine submitter bug
+    and must propagate as a traceback, not be masked as a hook failure."""
+    _scene_mocks(mock_max_utils, mock_rt)
+
+    with pytest.raises(RuntimeError):
+        max_render_submitter.show_job_bundle_submitter()
+
+    mock_dialog.assert_called_once()
+    mock_msgbox.critical.assert_not_called()  # queue-only params don't arm the guard
+
+
+@patch.object(max_render_submitter, "QMessageBox")
+@patch.object(max_render_submitter, "apply_pre_gui_output")
+@patch.object(
+    max_render_submitter, "SubmitMaxJobToDeadlineDialog", side_effect=RuntimeError("dialog bug")
+)
+@patch.object(max_render_submitter, "run_pre_gui_hooks", return_value={})
+@patch.object(max_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(max_render_submitter, "get_render_elements_output_directories", return_value=set())
+@patch.object(max_render_submitter, "rt")
+@patch.object(max_render_submitter, "qtmax")
+@patch.object(max_render_submitter, "max_utils")
+def test_dialog_construction_bug_propagates_without_hook_output(
+    mock_max_utils,
+    mock_qtmax,
+    mock_rt,
+    mock_render_elements,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+    mock_apply,
+    mock_msgbox,
+):
+    """When no hook output was applied, a dialog-construction failure is a genuine bug and must
+    propagate — the hook-attribution guard must not mask it as a "hook supplied a bad value" block.
+    """
+    _scene_mocks(mock_max_utils, mock_rt)
+
+    with pytest.raises(RuntimeError):
+        max_render_submitter.show_job_bundle_submitter()
+
+    mock_msgbox.critical.assert_not_called()
+
+
+@patch.object(max_render_submitter, "SubmitMaxJobToDeadlineDialog")
+@patch.object(max_render_submitter, "run_pre_gui_hooks", return_value={})
+@patch.object(max_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(max_render_submitter, "get_render_elements_output_directories", return_value=set())
+@patch.object(max_render_submitter, "rt")
+@patch.object(max_render_submitter, "qtmax")
+@patch.object(max_render_submitter, "max_utils")
+def test_hook_receives_pre_sticky_scene_name(
+    mock_max_utils,
+    mock_qtmax,
+    mock_rt,
+    mock_render_elements,
+    mock_confirm_cb,
+    mock_run_hooks,
+    mock_dialog,
+):
+    """Pre-GUI hooks receive the pre-sticky *scene* name as ``job_name``, not the sticky
+    ``render_settings.name`` that ``load_sticky_settings`` may have replaced with a prior hook's
+    output. Guards the sticky-settings feedback loop: a read-modify-write hook (e.g. a
+    ``"STUDIO_" + jobName`` prefix) must stay idempotent across runs instead of compounding
+    (``STUDIO_myscene`` -> ``STUDIO_STUDIO_myscene`` -> ...) through the persisted sticky file."""
+    mock_max_utils.get_render_output_info.return_value = ("/out", "name", ".jpg")
+    mock_max_utils.get_scene_name.return_value = "myscene"
+    mock_max_utils.get_frames.return_value = "1-10"
+    mock_max_utils.get_scene_path.return_value = "/scene.max"
+    mock_max_utils.get_state_set_names.return_value = []
+    mock_max_utils.get_referenced_files.return_value = []
+    mock_rt.execute.return_value = "C:/tmp"
+    mock_rt.maxVersion.return_value = [26000]
+    mock_rt.renderers.current = "Arnold:Arnold"
+    mock_rt.maxFilePath = "/scene/"
+
+    # Simulate a prior run's hook output persisted to the sticky file: load_sticky_settings
+    # overwrites render_settings.name with the previously prefixed value.
+    def _sticky(self):
+        self.name = "STUDIO_myscene"
+
+    with patch.object(
+        RenderSubmitterUISettings, "load_sticky_settings", autospec=True, side_effect=_sticky
+    ):
+        max_render_submitter.show_job_bundle_submitter()
+
+    ctx = mock_run_hooks.call_args.args[0]
+    # Pre-sticky scene name, not the persisted "STUDIO_myscene".
+    assert ctx.job_name == "myscene"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The 3ds Max submitter had no way for studios to pre-populate the submission dialog before it
opens. deadline-cloud exposes pre-GUI hooks (`run_pre_gui_hooks`) that Maya and Nuke already
integrate; 3ds Max should offer the same extension point.

### What was the solution? (How)

`show_job_bundle_submitter` now calls `run_pre_gui_hooks` before building the dialog:

- Hooks come from `DEADLINE_HOOKS_DIR` only (`bundle_dir=None`), gated by
  `settings.allow_environment_hooks`; the confirmation prompt is shown unless
  `settings.auto_accept` is set. Output is applied via deadline-cloud's generic
  `apply_pre_gui_output` — `RenderSubmitterUISettings` has no `.parameters` list, so hook
  parameters flow into the dialog's shared parameter values and `name`/`description` onto settings.
- The callback, hook call, and apply all run in one `try`: declining the prompt
  (`DeadlineOperationCanceled`) aborts silently (`return None`); any other failure is logged and
  the dialog opens with defaults, so a faulty hook can't block submission.
- Hooks receive the pre-sticky scene name as `job_name` (and the current `priority`), so a
  read-modify-write hook stays idempotent instead of compounding through the sticky settings file.

![Submitter fields populated by the pre-GUI hook](https://raw.githubusercontent.com/leon-li-inspire/deadline-cloud-for-3ds-max/pregui-assets/pregui_hook_submitter.png)

### What is the impact of this change?

Opt-in and a no-op when no hooks are configured — the dialog is seeded exactly as before. Requires
`deadline >= 0.60.3` (already the floor on `mainline`), which is where the `pre_gui_hooks` module
first shipped.

### How was this change tested?

- Headless unit tests covering the `apply_pre_gui_output` contract, `auto_accept` confirmation
  gating, the cancel-guard, graceful degradation (a hook — or applying its output — raising), and
  the pre-sticky `job_name`. Run against the released deadline-cloud; `black`/`ruff`/`mypy` and the
  Windows CI legs (3.9/3.10/3.11) pass.
- End-to-end on 3ds Max 2026: the pre-GUI confirmation and field population shown above, plus
  pre- and post-submission hooks firing on a real submission (verified by their marker files and
  the pre-GUI < pre-submission < post-submission ordering).

### Was this change documented?

Yes — a **Pre-GUI hooks** section in the README (under *Submitter*) with the setup steps and the
hook stdin/stdout contract.

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
   - [ ] Yes
   - [ ] No

### Is this a breaking change?

No — opt-in behavior gated by existing settings, with no change when no hooks are configured.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
