### PR TITLE
ci: add Security Scan stub (zizmor via reusable org workflow)

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -7,11 +7,12 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # canonical dependabot auto-approve pattern; the job only has pull-requests: write and runs Dependabot's own metadata action
+    if: ${{ github.actor == 'dependabot[bot]' }} # zizmor: ignore[bot-conditions]
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -11,7 +11,7 @@
 # workflow_run identifiers and the role-ARN secret.
 name: Claude PR Review
 
-on:
+on: # zizmor: ignore[dangerous-triggers] -- workflow_run is intentional and safe here; see the header comment above (runs from default branch, fork PRs cannot alter behavior/secrets)
   workflow_run:
     workflows: ["Claude PR Review (collect)"]
     types:

--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate semantic versioning
+        env:
+          # Pass context via env, not inline ${{ }}, to avoid template injection.
+          TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
           if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Tag '$TAG' does not follow semantic versioning format (X.Y.Z)"
             exit 1
@@ -33,18 +35,21 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
       - name: Validate semantic versioning
+        env:
+          # Pass context via env, not inline ${{ }}, to avoid template injection.
+          TAG: ${{ inputs.tag }}
         run: |
-          if ! [[ ${{ inputs.tag }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
-            echo "Error: Tag '${{ inputs.tag }}' does not follow semantic versioning format (X.Y.Z)"
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
+            echo "Error: Tag '$TAG' does not follow semantic versioning format (X.Y.Z)"
             exit 1
           fi
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.9'
       - name: Install dependencies
@@ -54,4 +59,4 @@ jobs:
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,6 +1,9 @@
 name: On Opened PR
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
+  # workflow_run is intentional: it runs from the default branch with this
+  # repo's context (never a fork's copy), and only consumes the PR artifact via
+  # the reusable extract-PR-details workflow. A fork PR cannot alter behavior.
   workflow_run:
     workflows: ["Record PR"]
     types:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -98,12 +98,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ needs.TagRelease.outputs.build-python-version }}
       - name: Install dependencies
@@ -113,4 +113,4 @@ jobs:
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,21 @@
+name: "Security Scan"
+
+on:
+  push:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  pull_request:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  schedule:
+    - cron: '0 8 * * MON'
+
+jobs:
+  Scan:
+    name: Scan
+    # Central, extensible security-scan workflow (currently zizmor). New checks
+    # added there apply here automatically — no change needed to this stub.
+    uses: aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline
+    permissions:
+      # The reusable workflow checks out this repo and fetches the central
+      # zizmor config, and reports findings to the run log / PR annotations
+      # (not the Security tab), so it only needs read access.
+      contents: read


### PR DESCRIPTION
## What

Adds a thin `Security Scan` stub (`.github/workflows/security_scan.yml`) that calls the central reusable workflow `aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline`. The stub runs zizmor against this repo's workflows and gates PRs on **high**-severity findings. New checks added centrally apply automatically with no per-repo change.

Replicates what was done in aws-deadline/deadline-cloud (PR #1256).

## Zizmor fixes (required first so the gate is green)

Fixed all **13 high-severity** findings:

- **unpinned-uses (6)** — pinned `actions/checkout@v7`, `actions/setup-python@v6`, `pypa/gh-action-pypi-publish@release/v1`, `dependabot/fetch-metadata@v3` to full commit SHAs with `# vX.Y.Z` comments (manual_pypi_release.yml, release_publish.yml, auto_approve.yml).
- **template-injection (3)** — moved `${{ inputs.tag }}` out of `run:` blocks into `env:` vars referenced as `"$TAG"` (manual_pypi_release.yml).
- **dangerous-triggers (2)** — suppressed with `# zizmor: ignore[dangerous-triggers]` on the `workflow_run` triggers in claude_pr_review.yml and on_opened_pr.yml. Intentional: these run from the default branch with this repo's context (never a fork's copy), so a fork PR cannot alter behavior/secrets.
- **bot-conditions (1)** — suppressed with `# zizmor: ignore[bot-conditions]` on the Dependabot actor check in auto_approve.yml. Canonical Dependabot auto-approve pattern; the job only has `pull-requests: write`.

After fixes, `zizmor --min-severity high` reports **0 findings**.

Commits are DCO signed-off.