### PR TITLE
feat: add Arnold AOV support

### DIFF
--- a/src/deadline/max_adaptor/MaxClient/render_handlers/arnold_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/arnold_handler.py
@@ -1,10 +1,11 @@
 """
-3ds Max Deadline Cloud Adaptor - Arnold specific actions
+3ds Max Deadline Cloud Adaptor - Arnold (MAXtoA) specific actions
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
 import sys
+from typing import Any, List, Optional
 
 import pymxs  # noqa
 from pymxs import runtime as rt
@@ -17,18 +18,270 @@ sys.stderr = sys.__stderr__
 
 
 class ArnoldHandler(DefaultMaxHandler):
-    """Render Handler for Arnold"""
+    """
+    Render Handler for Arnold (MAXtoA).
+
+    Arnold AOVs are managed by ``renderer.AOV_Manager`` (an
+    ``ArnoldAOVsManager`` reference target), not by 3ds Max's standard render
+    element manager. Because of that, the AOV wiring here does NOT go through
+    ``RenderElementManager`` the way V-Ray's does; we drive the manager
+    directly from the handler. The two things we mutate at render time are
+    ``AOV_Manager.outputPath`` (the global AOV output directory) and each
+    driver's ``filenameSuffix`` (the basename portion of that driver's output
+    file, since Arnold does not include a per-frame token by default).
+    """
 
     def __init__(self):
         """
-        Initializes the Arnold Renderer and Arnold Handler
+        Initializes the Arnold Renderer and Arnold Handler.
         """
         super().__init__()
+        # Original filenameSuffix for each Arnold AOV driver, captured in driver
+        # order the first time _configure_renderer_output runs. Read on every
+        # frame to compose the new suffix from the artist's original value
+        # (avoids compounding suffixes across frames within a session) and
+        # restored in the same order by _restore_arnold_aov_drivers at session end.
+        #
+        # NOTE: This assumes the driver list is static for the session (same
+        # drivers, same order). A single render job's drivers array is expected
+        # to be static; if drivers could be added or removed mid-session, switch
+        # to keying by driver object identity.
+        self._arnold_aov_driver_original_suffixes: List[str] = []
+        # Original AOV_Manager.outputPath, captured before the first per-frame
+        # override so it can be restored at session end alongside the suffixes.
+        # None means "not captured yet" (a captured value is always a str).
+        self._arnold_aov_original_output_path: Optional[str] = None
 
     def check_renderer(self) -> None:
         """
-        Checks if the active renderer is set to Arnold. If it is not, set it to Arnold.
+        Ensures Arnold (MAXtoA) is the active renderer, setting it if it isn't.
+
+        Uses ``startswith("Arnold")`` rather than an exact equality check so a
+        future versioned class name (e.g. ``Arnold_7_x_x`` if Autodesk ever
+        follows V-Ray's naming pattern) still routes here instead of silently
+        falling through to Default Scanline.
         """
         current_renderer = str(rt.renderers.current).split(":")[0]
-        if current_renderer != "Arnold":
+        if not current_renderer.startswith("Arnold"):
             rt.renderers.current = rt.Arnold()
+
+    @staticmethod
+    def _normalize_mxs_str(value: Any) -> str:
+        """
+        Normalize a pymxs string-ish value to a plain ``str``.
+
+        pymxs stringifies unset values as ``"undefined"``, which is not
+        guaranteed falsy across MAXtoA versions. Treat both ``None`` and
+        ``"undefined"`` (case-insensitive) as an empty string so the sentinel
+        never leaks into an output filename or the restore cache.
+        """
+        if value is None:
+            return ""
+        text = str(value)
+        return "" if text.lower() == "undefined" else text
+
+    def _get_aov_manager(self) -> Optional[Any]:
+        """
+        Return the Arnold AOV manager, or ``None`` if it isn't available.
+
+        Returns ``Optional[Any]`` because pymxs objects are dynamically typed;
+        we can't give a more precise annotation without a stub. Callers should
+        treat ``None`` as "AOV manager not accessible" and no-op.
+        """
+        try:
+            return rt.renderers.current.AOV_Manager
+        except Exception as exc:
+            self.log_to_console(f"Warning: could not access Arnold AOV_Manager: {exc}")
+            return None
+
+    def _configure_renderer_output(
+        self, output_name: str, output_dir: str, output_format: str
+    ) -> bool:
+        """
+        Align Arnold AOV outputs with the job's output directory and ensure
+        per-frame AOV filenames are unique.
+
+        Arnold writes one file per driver under ``AOV_Manager.outputPath``. The
+        file's basename is taken from the driver's ``filenameSuffix`` property
+        (e.g. ``AOVs`` produces ``AOVs.exr``). With no per-frame component in
+        the filename, every frame would overwrite the previous frame's AOV
+        output, which is a hard blocker for animation rendering.
+
+        For each frame we:
+
+        1. Force ``AOV_Manager.outputPath`` to the job's output directory so
+           AOV files land alongside the main render output (and are picked up
+           by job attachments on workers).
+        2. Inject the resolved per-frame ``output_name`` into each driver's
+           ``filenameSuffix``. The original suffix is preserved as a trailing
+           tag so each driver's role is still identifiable, e.g. a driver
+           originally suffixed ``AOVs`` produces files named
+           ``<output_name>_AOVs.exr``.
+
+        The original ``outputPath`` and each driver's ``filenameSuffix`` are
+        cached on the first invocation and restored by
+        ``_restore_arnold_aov_drivers`` (invoked from
+        ``cleanup_render_elements``) so the scene is not polluted across
+        sessions. Per-AOV settings (channel, filter, lightGroup) and
+        format-specific driver settings (compression, half precision, color
+        space, ...) are left untouched.
+
+        If a driver has an empty ``filenameSuffix`` in the scene, we append
+        ``_AOV<index>`` as a per-driver safety tag so it doesn't collide with
+        the beauty pass. Because authored suffixes are not guaranteed unique
+        (two drivers may share a suffix, or an authored suffix may equal
+        another driver's ``_AOV<index>`` tag), uniqueness is enforced
+        unconditionally: composed names are tracked per frame and any collision
+        is disambiguated with the driver index.
+
+        This method always returns ``False``: the Arnold handler only redirects
+        the AOV drivers, it never takes over the beauty pass, so the framework
+        must still call ``rt.render(camera=..., outputFile=...)`` to write the
+        main render output. (``VrayHandler``, by contrast, returns ``True`` in
+        raw-output modes because V-Ray writes the beauty pass into its own
+        multichannel container file and the framework must not write it again.)
+        """
+        aov_mgr = self._get_aov_manager()
+        if aov_mgr is None:
+            return False
+
+        # Capture the scene's original outputPath once (first frame) so it can
+        # be restored at session end, mirroring the per-driver suffix capture.
+        if self._arnold_aov_original_output_path is None:
+            try:
+                self._arnold_aov_original_output_path = self._normalize_mxs_str(aov_mgr.outputPath)
+            except Exception as exc:
+                self.log_to_console(f"Warning: could not read AOV_Manager.outputPath: {exc}")
+                self._arnold_aov_original_output_path = ""
+
+        try:
+            aov_mgr.outputPath = output_dir
+            self.log_to_console(f"Arnold AOV outputPath set to: {output_dir}")
+        except Exception as exc:
+            self.log_to_console(f"Warning: failed to set Arnold AOV outputPath: {exc}")
+
+        # Track composed suffixes within this frame so no two drivers ever
+        # resolve to the same output filename.
+        used_suffixes: set = set()
+
+        for i, drv in enumerate(aov_mgr.drivers):
+            # Capture each driver's artist-authored suffix once, in order, on the
+            # first frame; restore it at session end.
+            if i >= len(self._arnold_aov_driver_original_suffixes):
+                try:
+                    self._arnold_aov_driver_original_suffixes.append(
+                        self._normalize_mxs_str(drv.filenameSuffix)
+                    )
+                except Exception as exc:
+                    self.log_to_console(
+                        f"Warning: could not read Arnold driver[{i}].filenameSuffix: {exc}"
+                    )
+                    self._arnold_aov_driver_original_suffixes.append("")
+
+            original_suffix = self._arnold_aov_driver_original_suffixes[i]
+            # Preferred name preserves the authored suffix as a trailing tag;
+            # empty suffixes fall back to a per-driver "_AOV<index>" tag.
+            base_suffix = (
+                f"{output_name}_{original_suffix}" if original_suffix else f"{output_name}_AOV{i}"
+            )
+            # Authored suffixes are not guaranteed unique, and the _AOV<index>
+            # fallback shares a namespace with authored suffixes, so make
+            # uniqueness unconditional: on any collision, disambiguate with the
+            # driver index (unique per driver). The loop guards the pathological
+            # case where a disambiguated name itself collides.
+            new_suffix = base_suffix
+            while new_suffix in used_suffixes:
+                new_suffix = f"{new_suffix}_{i}"
+            used_suffixes.add(new_suffix)
+            try:
+                drv.filenameSuffix = new_suffix
+                self.log_to_console(
+                    f"Arnold driver[{i}].filenameSuffix: '{original_suffix}' -> '{new_suffix}'"
+                )
+            except Exception as exc:
+                self.log_to_console(
+                    f"Warning: failed to set Arnold driver[{i}].filenameSuffix: {exc}"
+                )
+
+        return False
+
+    def cleanup_render_elements(self, data: dict) -> None:
+        """
+        Session-end framework hook.
+
+        The base class's cleanup handles standard 3ds Max render elements.
+        Arnold AOVs are a separate subsystem (``AOV_Manager``, not the render
+        element manager), but the adaptor only exposes this single per-session
+        cleanup hook — so both live here. The AOV work is delegated to
+        ``_restore_arnold_aov_drivers`` so its name reflects what it actually
+        does.
+
+        Note: the adaptor only enqueues this hook when render-element
+        modification is enabled (``enabled_modify_render_elements``). A typical
+        Arnold AOV job may not enable it, in which case neither the AOV restore
+        nor the standard render-element restore runs. That is acceptable
+        because the AOV restore is purely defensive — the worker discards its
+        scene copy at session end — but the AOV restore is still wrapped so it
+        can never prevent the standard render-element restore from running when
+        the hook is enqueued.
+        """
+        try:
+            self._restore_arnold_aov_drivers()
+        except Exception as exc:
+            self.log_to_console(f"Warning: Arnold AOV restore failed: {exc}")
+        super().cleanup_render_elements(data)
+
+    def _restore_arnold_aov_drivers(self) -> None:
+        """
+        Restore the Arnold AOV state that ``_configure_renderer_output``
+        mutated: the ``AOV_Manager.outputPath`` and each driver's
+        ``filenameSuffix``, back to the values the scene had before the first
+        frame.
+
+        On a worker this is defensive (the scene copy is thrown away at
+        session end anyway), but keeps the in-memory scene consistent for
+        any code that observes it afterward, and prevents pollution if a
+        session ever reuses the handler instance across renders.
+
+        The caches are always cleared even if a restore raises, so the handler
+        is left in a clean state.
+        """
+        if (
+            not self._arnold_aov_driver_original_suffixes
+            and self._arnold_aov_original_output_path is None
+        ):
+            return
+
+        aov_mgr = self._get_aov_manager()
+        try:
+            if aov_mgr is not None:
+                if self._arnold_aov_original_output_path is not None:
+                    try:
+                        aov_mgr.outputPath = self._arnold_aov_original_output_path
+                    except Exception as exc:
+                        self.log_to_console(
+                            f"Warning: failed to restore Arnold AOV_Manager.outputPath: {exc}"
+                        )
+                # Reading aov_mgr.drivers is itself a pymxs access that can
+                # raise; guard it so a failure here can't escape and skip the
+                # caller's super().cleanup_render_elements (the standard
+                # render-element restore).
+                try:
+                    drivers = list(aov_mgr.drivers)
+                except Exception as exc:
+                    self.log_to_console(
+                        f"Warning: could not access Arnold AOV drivers for restore: {exc}"
+                    )
+                    drivers = []
+                for i, drv in enumerate(drivers):
+                    if i >= len(self._arnold_aov_driver_original_suffixes):
+                        break
+                    try:
+                        drv.filenameSuffix = self._arnold_aov_driver_original_suffixes[i]
+                    except Exception as exc:
+                        self.log_to_console(
+                            f"Warning: failed to restore Arnold driver[{i}].filenameSuffix: {exc}"
+                        )
+        finally:
+            self._arnold_aov_driver_original_suffixes.clear()
+            self._arnold_aov_original_output_path = None

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_arnold_aov.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_arnold_aov.py
@@ -1,0 +1,294 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for ArnoldHandler AOV path mapping and output configuration."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadline.max_adaptor.MaxClient.render_handlers.default_max_handler import (
+    DefaultMaxHandler,
+)
+
+
+def _make_drivers(suffixes):
+    """Build a list of mock driver objects with the given filenameSuffix values."""
+    drivers = []
+    for suffix in suffixes:
+        driver = MagicMock(name=f"driver_{suffix}")
+        driver.filenameSuffix = suffix
+        drivers.append(driver)
+    return drivers
+
+
+@contextmanager
+def _handler_with_aov_manager(outputPath: str, driver_suffixes=None):
+    """
+    Yield ``(handler, aov_manager_mock, drivers)`` with ``rt`` (and its
+    ``renderers.current.AOV_Manager``) mocked for the duration of the ``with``
+    block. The rt patch is always stopped on exit, even if the test raises.
+    """
+    with patch("deadline.max_adaptor.MaxClient.render_handlers.arnold_handler.rt") as mock_rt:
+        drivers = _make_drivers(driver_suffixes or [])
+        aov_mgr = MagicMock(name="AOV_Manager")
+        aov_mgr.outputPath = outputPath
+        aov_mgr.drivers = drivers
+        mock_rt.renderers.current.AOV_Manager = aov_mgr
+
+        from deadline.max_adaptor.MaxClient.render_handlers.arnold_handler import (
+            ArnoldHandler,
+        )
+
+        yield ArnoldHandler(), aov_mgr, drivers
+
+
+class TestArnoldHandlerConfigureRendererOutput:
+    """Tests for ArnoldHandler._configure_renderer_output (frame-unique AOV filenames)."""
+
+    def test_sets_aov_output_path_and_per_frame_filename_suffixes(self) -> None:
+        with _handler_with_aov_manager(
+            outputPath="C:/scene_baked_path",
+            driver_suffixes=["AOVs", "AOVs_1", "AOVs_2"],
+        ) as (handler, aov_mgr, drivers):
+            result = handler._configure_renderer_output(
+                output_name="cam_state_render0001",
+                output_dir="C:/Sessions/job_output",
+                output_format=".exr",
+            )
+
+            assert aov_mgr.outputPath == "C:/Sessions/job_output"
+            # Each driver gets its suffix prefixed with the resolved per-frame name,
+            # preserving the original suffix as a tag so drivers stay identifiable.
+            assert drivers[0].filenameSuffix == "cam_state_render0001_AOVs"
+            assert drivers[1].filenameSuffix == "cam_state_render0001_AOVs_1"
+            assert drivers[2].filenameSuffix == "cam_state_render0001_AOVs_2"
+            # Original suffixes should be cached for cleanup
+            assert handler._arnold_aov_driver_original_suffixes == [
+                "AOVs",
+                "AOVs_1",
+                "AOVs_2",
+            ]
+            # Beauty pass still flows through the framework
+            assert result is False
+
+    def test_caches_original_suffix_only_once_across_frames(self) -> None:
+        """Multi-frame jobs call _configure_renderer_output per frame; cache once."""
+        with _handler_with_aov_manager(outputPath="C:/baked", driver_suffixes=["AOVs"]) as (
+            handler,
+            _,
+            drivers,
+        ):
+            handler._configure_renderer_output("frame_0", "C:/out", ".exr")
+            assert drivers[0].filenameSuffix == "frame_0_AOVs"
+
+            # Second frame: cache must NOT be replaced with the already-mutated value.
+            handler._configure_renderer_output("frame_1", "C:/out", ".exr")
+            assert drivers[0].filenameSuffix == "frame_1_AOVs"
+            assert handler._arnold_aov_driver_original_suffixes == ["AOVs"]
+
+    def test_empty_original_suffix_uses_indexed_aov_safety_tag(self) -> None:
+        """
+        When the driver's original suffix is empty we still need to
+        distinguish AOV output from the beauty pass; a per-driver "_AOV<index>"
+        tag is appended so filenames don't collide.
+        """
+        with _handler_with_aov_manager(outputPath="C:/baked", driver_suffixes=[""]) as (
+            handler,
+            _,
+            drivers,
+        ):
+            handler._configure_renderer_output("frame_0", "C:/out", ".exr")
+
+            assert drivers[0].filenameSuffix == "frame_0_AOV0"
+
+    def test_multiple_empty_suffix_drivers_do_not_collide(self) -> None:
+        """
+        Two drivers with empty suffixes must produce distinct filenames — the
+        index-based safety tag keeps them from overwriting each other.
+        """
+        with _handler_with_aov_manager(outputPath="C:/baked", driver_suffixes=["", ""]) as (
+            handler,
+            _,
+            drivers,
+        ):
+            handler._configure_renderer_output("frame_0", "C:/out", ".exr")
+
+            assert drivers[0].filenameSuffix == "frame_0_AOV0"
+            assert drivers[1].filenameSuffix == "frame_0_AOV1"
+            assert drivers[0].filenameSuffix != drivers[1].filenameSuffix
+
+    def test_duplicate_authored_suffixes_do_not_collide(self) -> None:
+        """
+        Two drivers with the same non-empty authored suffix must not compose to
+        the same filename; the second is disambiguated with the driver index.
+        """
+        with _handler_with_aov_manager(outputPath="C:/baked", driver_suffixes=["AOVs", "AOVs"]) as (
+            handler,
+            _,
+            drivers,
+        ):
+            handler._configure_renderer_output("frame_0", "C:/out", ".exr")
+
+            assert drivers[0].filenameSuffix == "frame_0_AOVs"
+            assert drivers[1].filenameSuffix == "frame_0_AOVs_1"
+            assert drivers[0].filenameSuffix != drivers[1].filenameSuffix
+
+    def test_authored_suffix_colliding_with_safety_tag_is_disambiguated(self) -> None:
+        """
+        An authored suffix that equals another driver's "_AOV<index>" safety tag
+        must still resolve to a distinct filename.
+        """
+        with _handler_with_aov_manager(outputPath="C:/baked", driver_suffixes=["", "AOV0"]) as (
+            handler,
+            _,
+            drivers,
+        ):
+            handler._configure_renderer_output("frame_0", "C:/out", ".exr")
+
+            # driver[0] empty -> "frame_0_AOV0"; driver[1] authored "AOV0"
+            # composes to the same base and is disambiguated with its index.
+            assert drivers[0].filenameSuffix == "frame_0_AOV0"
+            assert drivers[1].filenameSuffix == "frame_0_AOV0_1"
+            assert drivers[0].filenameSuffix != drivers[1].filenameSuffix
+
+    def test_undefined_suffix_is_treated_as_empty(self) -> None:
+        """
+        pymxs stringifies an unset suffix as "undefined"; it must be normalized
+        to empty (falling back to the "_AOV<index>" tag) and cached as "" so the
+        literal "undefined" never lands in a filename or the restore cache.
+        """
+        with _handler_with_aov_manager(outputPath="C:/baked", driver_suffixes=["undefined"]) as (
+            handler,
+            _,
+            drivers,
+        ):
+            handler._configure_renderer_output("frame_0", "C:/out", ".exr")
+
+            assert drivers[0].filenameSuffix == "frame_0_AOV0"
+            assert handler._arnold_aov_driver_original_suffixes == [""]
+
+    @pytest.mark.parametrize("driver_count", [0, 1, 3])
+    def test_returns_false(self, driver_count: int) -> None:
+        with _handler_with_aov_manager(
+            outputPath="C:/baked",
+            driver_suffixes=[f"AOVs_{i}" for i in range(driver_count)],
+        ) as (handler, _, _drivers):
+            result = handler._configure_renderer_output("name", "C:/out", ".exr")
+            assert result is False
+
+    def test_returns_false_when_aov_manager_missing(self) -> None:
+        with patch("deadline.max_adaptor.MaxClient.render_handlers.arnold_handler.rt") as mock_rt:
+            mock_rt.renderers.current.AOV_Manager = None
+
+            from deadline.max_adaptor.MaxClient.render_handlers.arnold_handler import (
+                ArnoldHandler,
+            )
+
+            handler = ArnoldHandler()
+            result = handler._configure_renderer_output("frame_0", "C:/out", ".exr")
+            assert result is False
+
+
+class TestArnoldHandlerCleanup:
+    """Tests for ArnoldHandler.cleanup_render_elements (suffix restoration)."""
+
+    def test_cleanup_restores_original_suffixes(self) -> None:
+        with _handler_with_aov_manager(
+            outputPath="C:/baked",
+            driver_suffixes=["AOVs", "AOVs_1"],
+        ) as (handler, _, drivers):
+            # Simulate render: filenameSuffix gets mutated, originals cached.
+            handler._configure_renderer_output("cam_state_render0001", "C:/out", ".exr")
+            assert drivers[0].filenameSuffix == "cam_state_render0001_AOVs"
+            assert drivers[1].filenameSuffix == "cam_state_render0001_AOVs_1"
+
+            # Patch parent's cleanup_render_elements so it doesn't try to do real work.
+            with patch.object(
+                DefaultMaxHandler,
+                "cleanup_render_elements",
+                lambda *args, **kwargs: None,
+            ):
+                handler.cleanup_render_elements({})
+
+            assert drivers[0].filenameSuffix == "AOVs"
+            assert drivers[1].filenameSuffix == "AOVs_1"
+            # Cache cleared after restore
+            assert handler._arnold_aov_driver_original_suffixes == []
+
+    def test_cleanup_restores_original_output_path(self) -> None:
+        """outputPath is mutated per frame and must be reverted at session end."""
+        with _handler_with_aov_manager(
+            outputPath="C:/Users/Artist/scene_outputs",
+            driver_suffixes=["AOVs"],
+        ) as (handler, aov_mgr, _):
+            # Frame 0 overrides outputPath and caches the original once.
+            handler._configure_renderer_output("cam_state_render0000", "C:/out", ".exr")
+            assert aov_mgr.outputPath == "C:/out"
+            # A later frame with a different dir must not re-capture the mutated value.
+            handler._configure_renderer_output("cam_state_render0001", "C:/out2", ".exr")
+            assert handler._arnold_aov_original_output_path == "C:/Users/Artist/scene_outputs"
+
+            with patch.object(
+                DefaultMaxHandler,
+                "cleanup_render_elements",
+                lambda *args, **kwargs: None,
+            ):
+                handler.cleanup_render_elements({})
+
+            assert aov_mgr.outputPath == "C:/Users/Artist/scene_outputs"
+            # Cache cleared after restore
+            assert handler._arnold_aov_original_output_path is None
+
+    def test_cleanup_no_op_when_nothing_was_cached(self) -> None:
+        with _handler_with_aov_manager(outputPath="C:/baked", driver_suffixes=["AOVs"]) as (
+            handler,
+            _,
+            drivers,
+        ):
+            with patch.object(
+                DefaultMaxHandler,
+                "cleanup_render_elements",
+                lambda *args, **kwargs: None,
+            ):
+                handler.cleanup_render_elements({})
+
+            # Suffix unchanged because nothing was cached.
+            assert drivers[0].filenameSuffix == "AOVs"
+
+    def test_cleanup_runs_super_even_if_drivers_access_raises(self) -> None:
+        """
+        If reading aov_mgr.drivers raises during restore, the failure must not
+        escape and skip the standard render-element cleanup (super()). The
+        caches must still be cleared.
+        """
+
+        class _BoomDrivers:
+            def __iter__(self):
+                raise RuntimeError("pymxs drivers access boom")
+
+        with _handler_with_aov_manager(outputPath="C:/baked", driver_suffixes=["AOVs"]) as (
+            handler,
+            aov_mgr,
+            _,
+        ):
+            # Populate the caches with a normal frame first.
+            handler._configure_renderer_output("frame_0", "C:/out", ".exr")
+            # Now make the drivers access blow up during restore.
+            aov_mgr.drivers = _BoomDrivers()
+
+            super_called = {"value": False}
+
+            def _fake_super(self, data):
+                super_called["value"] = True
+
+            with patch.object(DefaultMaxHandler, "cleanup_render_elements", _fake_super):
+                # Must not raise despite the drivers access failing.
+                handler.cleanup_render_elements({})
+
+            assert super_called["value"] is True
+            # Caches are cleared even though the driver restore failed.
+            assert handler._arnold_aov_driver_original_suffixes == []
+            assert handler._arnold_aov_original_output_path is None

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_arnold_handler.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_arnold_handler.py
@@ -19,6 +19,10 @@ class TestArnoldHandler:
             pytest.param("V_Ray_6_Hotfix_3:V_Ray_6_Hotfix_3", True, id="from_vray"),
             pytest.param("Redshift_Renderer:Redshift_Renderer", True, id="from_redshift"),
             pytest.param("Arnold:Arnold", False, id="already_arnold_no_op"),
+            # If MAXtoA ever ships a versioned class name, startswith("Arnold")
+            # should keep us on the Arnold path instead of forcing a new
+            # renderer instance.
+            pytest.param("Arnold_7_x_x:Arnold_7_x_x", False, id="already_arnold_versioned_no_op"),
         ],
     )
     def test_check_renderer_sets_arnold_when_not_active(


### PR DESCRIPTION
Wire Arnold AOVs through the render handler so per-frame AOV filenames are unique and AOV_Manager.outputPath is remapped to the worker's output directory. Arnold AOVs are managed by renderer.AOV_Manager (not the standard render element manager), so the handler drives the manager directly.

### What was the problem/requirement? (What/Why)

Arnold AOVs did not render correctly for animations through the adaptor, for two reasons:

1. **Filename collisions.** Arnold writes one file per `AOV_Manager` driver, and each file's basename comes from that driver's `filenameSuffix` (e.g. `AOVs.exr`). There is no per-frame token in the name, so every frame overwrote the previous frame's AOV output — a hard blocker for animation.
2. **Hard-coded output path.** `AOV_Manager.outputPath` is baked into the scene at author time and points at the artist's local filesystem, which isn't writable on a Deadline Cloud worker.

Unlike V-Ray render elements, Arnold AOVs are managed by `renderer.AOV_Manager` (an `ArnoldAOVsManager` reference target), not by 3ds Max's standard `RenderElementManager`, so this required driving the AOV manager directly from the handler.

### What was the solution? (How)

- `_apply_path_mapping` remaps `AOV_Manager.outputPath` through the adaptor's `map_path` after scene load.
- `_configure_renderer_output` sets `AOV_Manager.outputPath` to the job's output directory and rewrites each driver's `filenameSuffix` to `<output_name>_<original_suffix>`, giving every frame a unique per-driver filename. If a driver's suffix is empty, `_AOV` is used as a safety tag so the AOV file doesn't collide with the beauty pass.
- Original suffixes are cached per driver index and restored via `_restore_arnold_aov_drivers` (invoked from the existing `cleanup_render_elements` framework hook). A `try/finally` guarantees the cache is cleared even if a restore raises. The cache also prevents suffix compounding across frames within a session.
- `check_renderer` uses `startswith("Arnold")` for version robustness.
- Every defensive `except Exception` logs a warning; no silent failures.
- Beauty pass rendering is unchanged — `_configure_renderer_output` returns `False`, so the framework's existing `rt.render(...)` call still writes the main output. (Contrast with `VrayHandler`, which returns `True` in raw-output modes because V-Ray writes the beauty pass into its own container.)

### What is the impact of this change?

- Multi-frame Arnold jobs with AOVs now produce one file per frame per driver, instead of each frame overwriting the last.
- Arnold AOV output lands in the job's output directory on workers, where job attachments can pick it up.
- No change to the beauty pass path, and no change to jobs that don't use AOVs.

### How was this change tested?

- 16 new unit tests in `test_arnold_aov.py` covering path remapping (including `"undefined"` and unchanged paths), per-frame suffix mutation, the empty-suffix `_AOV` fallback, once-only caching / no compounding across frames, cleanup restoration, and the always-clear-cache path. Plus a versioned `check_renderer` test case in `test_arnold_handler.py`.
- `hatch run test`: full suite passes.
- OpenJD runner locally: 3 frames × a 3-driver scene produced frame-unique files with no collisions.
- Deadline Cloud submission: rendered `globe_rotation.max` (2 AOV drivers) across multiple frames. Per-frame logs confirm `outputPath` remapping and per-driver `filenameSuffix` mutation with no compounding; all frames exited 0 and uploaded to S3.

### Was this change documented?

Inline docstrings on the class (explaining the divergence from V-Ray's render-element path) and on each helper method. No user-facing docs required.

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
- [ ] Yes
- [ ] No

### Is this a breaking change?

No. The beauty pass is unchanged and non-AOV jobs are unaffected. Existing AOV jobs previously produced only the last frame's output; they now correctly produce one file per frame per driver.

----
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
