### PR TITLE
feat: add 3ds Max 2027 to supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AWS Deadline Cloud for 3ds Max is a python package that allows users to create [
 
 This library requires:
 
-1. 3ds Max 2024, 2025, 2026.
+1. 3ds Max 2024, 2025, 2026, 2027.
 1. Python 3.10 or higher.
 1. Windows operating system.
 

--- a/installer/deadline-cloud-for-3ds-max.xml
+++ b/installer/deadline-cloud-for-3ds-max.xml
@@ -1,8 +1,8 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. --><!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <component>
     <name>deadline_cloud_for_3ds_max</name>
-    <description>Deadline Cloud for 3ds Max 2024 - 2026</description>
-	<detailedDescription>3ds Max plugin for submitting jobs to AWS Deadline Cloud. Compatible with 3ds Max 2024 - 2026.</detailedDescription>
+    <description>Deadline Cloud for 3ds Max 2024 - 2027</description>
+	<detailedDescription>3ds Max plugin for submitting jobs to AWS Deadline Cloud. Compatible with 3ds Max 2024 - 2027.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -81,8 +81,8 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_max_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for 3ds Max 2024 - 2026
-- Compatible with 3ds Max 2024 - 2026.
+			<value>Deadline Cloud for 3ds Max 2024 - 2027
+- Compatible with 3ds Max 2024 - 2027.
 - Install the integrated 3ds Max submitter files to the installation directory.
 - Register the plug-in with 3ds Max by creating or updating 3ds-Max-specific environment variables (ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR, ADSK_3DSMAX_MACROS_ADDON_DIR, ADSK_3DSMAX_SCRIPTS_ADDON_DIR, MAX_SUBMITTER).</value>
 		</stringParameter>


### PR DESCRIPTION
Bump the compatible 3ds Max version range from 2024-2026 to 2024-2027 in the installer descriptions and the README requirements.

### What was the problem/requirement? (What/Why)

3ds Max 2027 has been released, but the installer descriptions and the README still advertised support only for 3ds Max 2024–2026. Users on 2027 had no indication the plugin supports their version, and the installer's summary/description text was out of date.

### What was the solution? (How)

Updated the advertised version range from `2024 - 2026` to `2024 - 2027` in:
- `installer/deadline-cloud-for-3ds-max.xml` — the component `description`, `detailedDescription`, and the installer summary parameter.
- `README.md` — the requirements line listing supported 3ds Max versions.

Version detection in the code is already dynamic (`2000 + ceil(maxVersion / 1000) - 2`) with no hard-coded upper bound, so no code paths needed to change — this is a documentation/metadata update.

### What is the impact of this change?

3ds Max 2027 is now listed as supported in the installer and README. No behavioral change to the submitter or adaptor; existing 2024–2026 support is unaffected.

### How was this change tested?

Text/metadata change only. Verified the installer XML remains well-formed after the edit and the strings render as intended, and built the submitter installer locally to confirm the "2024 - 2027" text appears in the installer screens. 3dsmaxcmd rendering was separately exercised against a 3ds Max 2027 installation during related work.

### Was this change documented?

Yes — this change is itself the documentation update (README + installer descriptions).

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
- [ ] Yes
- [ ] No

### Is this a breaking change?

No. This only widens the advertised supported-version range; existing behavior and 2024–2026 support are unchanged.

----
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
