### PR TITLE
feat: add version information to submitter dialog

### DIFF
--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -4,7 +4,6 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 
-import math
 import os
 import sys
 from typing import Any
@@ -13,6 +12,7 @@ from pymxs import runtime as rt
 
 from deadline.max_shared.utilities.max_utils import (
     configure_vray_raw_output,
+    get_max_version_year,
     is_vray_raw_output_format,
 )
 
@@ -39,11 +39,8 @@ class VrayHandler(DefaultMaxHandler):
         Validates that required VRay environment variables are set.
         Raises RuntimeError with actionable message if variables are missing.
         """
-        # Get 3ds Max year using the same formula as max_render_submitter.py
-        max_version: Any = rt.maxVersion()
-        # Convert to int to handle both real values and mock objects
-        version_major: int = int(max_version[0])
-        year: int = 2000 + math.ceil(version_major / 1000.0) - 2
+        # Get 3ds Max release year (e.g. 2025)
+        year: int = get_max_version_year()
 
         # Define required environment variables
         required_vars: list[str] = [

--- a/src/deadline/max_shared/utilities/max_utils.py
+++ b/src/deadline/max_shared/utilities/max_utils.py
@@ -9,6 +9,7 @@ and management.
 """
 
 import logging
+import math
 import os
 import re
 from dataclasses import dataclass, field
@@ -19,6 +20,21 @@ import pymxs  # separate import to initialize  # noqa: F401
 from pymxs import runtime as rt
 
 _logger = logging.getLogger(__name__)
+
+
+def get_max_version_year() -> int:
+    """
+    Get the 3ds Max release year (e.g. 2025) from the running application.
+
+    3ds Max's internal major version number (``rt.maxVersion()[0]``) encodes the
+    release as ``(year - 1998) * 1000`` (e.g. 27000 for 2025). This converts it
+    back to the human-readable release year.
+
+    :returns: the 3ds Max release year, e.g. 2025
+    """
+    # int() handles both real values and mocked values used in tests
+    version_major: int = int(rt.maxVersion()[0])
+    return 2000 + math.ceil(version_major / 1000.0) - 2
 
 
 @dataclass

--- a/src/deadline/max_submitter/max_render_submitter.py
+++ b/src/deadline/max_submitter/max_render_submitter.py
@@ -5,7 +5,6 @@
 """
 
 import logging
-import math
 import os
 from os.path import abspath, join, normpath
 from pathlib import Path
@@ -25,6 +24,7 @@ from data_const import (
     TEMP_BACKUP_FILENAME,
     UI_GROUP_LABEL,
 )
+from deadline.client.dataclasses import SubmitterInfo
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.ui.dialogs._types import JobBundlePurpose
@@ -37,9 +37,11 @@ from ui.submit_dialog import SubmitMaxJobToDeadlineDialog
 from utilities import max_utils, submission_utils
 from deadline.max_shared.utilities.max_utils import (
     get_batch_render_views,
+    get_max_version_year,
     get_render_elements_output_directories,
 )
 
+from _version import version
 from _version import version_tuple as adaptor_version_tuple
 
 _logger = logging.getLogger(__name__)
@@ -354,9 +356,17 @@ def show_job_bundle_submitter():
         output_directories=set(render_settings.output_directories),
     )
 
-    max_version = 2000 + (math.ceil(rt.maxVersion()[0] / 1000.0) - 2)
+    max_version = get_max_version_year()
     adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
     conda_packages = f"3dsmax={max_version}.* 3dsmax-openjd={adaptor_version}.*"
+
+    submitter_info = SubmitterInfo(
+        submitter_name="3dsMax",
+        submitter_package_name="deadline-cloud-for-3ds-max",
+        submitter_package_version=version,
+        host_application_name="3ds Max",
+        host_application_version=str(max_version),
+    )
 
     # Instantiate and show the Submitter UI
     window = SubmitMaxJobToDeadlineDialog(
@@ -371,6 +381,7 @@ def show_job_bundle_submitter():
         parent=main_window,
         f=Qt.Tool,
         show_host_requirements_tab=True,
+        submitter_info=submitter_info,
     )
     window.show()
     return window

--- a/src/deadline/max_submitter/utilities/vray_executable_utils.py
+++ b/src/deadline/max_submitter/utilities/vray_executable_utils.py
@@ -7,6 +7,8 @@ import os
 
 from pymxs import runtime as rt
 
+from deadline.max_shared.utilities.max_utils import get_max_version_year
+
 _logger = logging.getLogger(__name__)
 
 
@@ -24,7 +26,7 @@ def get_vray_executable_path() -> str:
 
     # Fallback: derive from V-Ray's own env vars (set by V-Ray installer)
     try:
-        max_version = 2000 + (int(rt.maxVersion()[0] / 1000.0) - 2)
+        max_version = get_max_version_year()
         vray_main = os.environ.get(f"VRAY_FOR_3DSMAX{max_version}_MAIN", "")
         if vray_main:
             candidate = os.path.join(vray_main, "vray.exe")

--- a/src/deadline/max_submitter/vray_standalone_submitter.py
+++ b/src/deadline/max_submitter/vray_standalone_submitter.py
@@ -11,9 +11,11 @@ from typing import Any, Optional
 
 import pymxs  # noqa
 import qtmax
+from deadline.client.dataclasses import SubmitterInfo
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.ui.dialogs._types import JobBundlePurpose
+from deadline.max_shared.utilities.max_utils import get_max_version_year
 from pymxs import runtime as rt
 from qtpy.QtCore import Qt  # type: ignore
 from ui.submit_dialog import SubmitMaxJobToDeadlineDialog
@@ -38,6 +40,8 @@ from utilities.vray_executable_utils import (
     get_3dsmax_executable_path,
 )
 from vrscene_settings import VRSceneRenderSubmitterUISettings
+
+from _version import version
 
 _logger = logging.getLogger(__name__)
 
@@ -532,6 +536,15 @@ def show_vray_standalone_submitter():
     # For V-Ray Standalone, we need vray package instead of 3dsmax
     conda_packages = "vray imagemagick ffmpeg"
 
+    max_version = get_max_version_year()
+    submitter_info = SubmitterInfo(
+        submitter_name="VRayStandalone",
+        submitter_package_name="deadline-cloud-for-3ds-max",
+        submitter_package_version=version,
+        host_application_name="3ds Max",
+        host_application_version=str(max_version),
+    )
+
     # Instantiate and show the Submitter UI
     window = SubmitMaxJobToDeadlineDialog(
         job_setup_widget_type=VRayStandaloneSettingsWidget,
@@ -545,6 +558,7 @@ def show_vray_standalone_submitter():
         parent=main_window,
         f=Qt.Tool,
         show_host_requirements_tab=False,  # Not needed for vrscene rendering
+        submitter_info=submitter_info,
     )
     window.show()
     return window

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
@@ -5,6 +5,10 @@ from unittest.mock import patch
 import pytest
 
 
+@patch(
+    "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.get_max_version_year",
+    new=lambda: 2025,
+)
 class TestVrayHandler:
     """Tests for VrayHandler environment variable validation"""
 
@@ -51,7 +55,13 @@ class TestVrayHandler:
     ) -> None:
         """Test VRay handler initializes successfully with all required env vars"""
         with patch.dict("os.environ", env_vars, clear=True):
-            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+            with (
+                patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt,
+                patch(
+                    "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.get_max_version_year",
+                    return_value=year,
+                ),
+            ):
                 mock_rt.maxVersion.return_value = max_version
 
                 from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_path_mapping.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_path_mapping.py
@@ -5,6 +5,10 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 
 
+@patch(
+    "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.get_max_version_year",
+    new=lambda: 2025,
+)
 class TestVrayProxyPathMapping:
     """Tests for VrayHandler path mapping functionality."""
 


### PR DESCRIPTION
fixes: #222 

### What was the problem/requirement? (What/Why)

3ds Max submitter isn't displaying version information for users, which is a super handy feature to have

### What was the solution? (How)

deadline cloud client implements the help dialog + setting window title and a mechanism to pass information into it. Here's Blender's PR to support it: https://github.com/aws-deadline/deadline-cloud-for-blender/pull/316

### What is the impact of this change?

Users can see what version of the submitter they're using, as well as information about the runtime environment!

### How was this change tested?

<img width="540" height="734" alt="image" src="https://github.com/user-attachments/assets/b1a55c47-8ce0-449f-a8fe-a43d7f09fd60" />

### Was this change documented?

N/a

### Did you modify schema files?
N/A

### Is this a breaking change?
N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*