### PR TITLE
chore(deps): update deadline requirement to >=0.60.3,<0.61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 # 2026 - 3.11: https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=MAXDEV_Python_what_s_new_in_3ds_max_python_api_html
 
 dependencies = [
-    "deadline >= 0.55.1,< 0.56",
+    "deadline >= 0.60.3,< 0.61",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `deadline` pin was stuck at `>= 0.55.1, < 0.56` — five minor versions behind — because Dependabot stopped proposing `deadline` bumps after #156 was closed without merging. We need 0.60.3 for the next release.

### What was the solution? (How)

Bumped the pin to `>= 0.60.3, < 0.61`. A manual bump was needed because Dependabot only proposes upgrades within the existing constraint, so it could never cross the `< 0.56` ceiling.

### What is the impact of this change?

Picks up bug and security fixes from 0.56 through 0.60.3. Reviewed every breaking change in that range against this package's actual imports — none apply, and all symbols we consume still resolve at the same paths.

### How was this change tested?

`hatch run test` (368 passed) and `hatch run lint` (ruff, black, mypy all clean).

### Was this change documented?

No — dependency bump only.

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?
See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.
   - [ ] Yes
   - [x] No

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
