### PR TITLE
fix(vray): apply path mapping to bitmap textures

### DIFF
--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -111,11 +111,7 @@ class VrayHandler(DefaultMaxHandler):
 
         Currently handles:
         - VRayProxy objects (.vrmesh files)
-
-        TODO: Add support for VRayHDRI (HDR environment maps)
-        TODO: Add support for VRayMesh (V-Ray mesh export files)
-        TODO: Add support for VRayFur (fur/hair geometry files)
-        TODO: Add support for VRayScene (V-Ray scene files .vrscene)
+        - Bitmap textures (all Bitmaptexture instances in the scene)
         """
         self.log_to_console("VrayHandler._apply_path_mapping called")
         if self.map_path is None:
@@ -123,9 +119,10 @@ class VrayHandler(DefaultMaxHandler):
             return
 
         self.log_to_console(
-            "VrayHandler._apply_path_mapping: map_path is set, applying VRay proxy path mapping"
+            "VrayHandler._apply_path_mapping: map_path is set, applying VRay path mapping"
         )
         self._apply_vray_proxy_path_mapping()
+        self._apply_bitmap_path_mapping()
 
     def _apply_vray_proxy_path_mapping(self) -> None:
         """
@@ -168,6 +165,65 @@ class VrayHandler(DefaultMaxHandler):
                     self.log_to_console(f"Warning: Failed to remap VRayProxy '{proxy.name}': {e}")
 
         self.log_to_console(f"VRMesh path mapping complete: {mapped_count} proxies remapped")
+
+    def _apply_bitmap_path_mapping(self) -> None:
+        """
+        Applies path mapping to all bitmap texture file paths in the scene.
+
+        This covers standard 3ds Max Bitmaptexture nodes, which are used by
+        Chaos Cosmos assets, V-Ray materials, and any other material that
+        references an image file. Without this, textures uploaded via job
+        attachments remain pointing at the artist's local filesystem path
+        and silently fail to load on the worker (V-Ray renders without them
+        instead of erroring).
+        """
+        try:
+            bitmaps: list[Any] = list(rt.getClassInstances(rt.Bitmaptexture))
+        except Exception as e:
+            self.log_to_console(f"Warning: could not enumerate Bitmaptexture instances: {e}")
+            return
+
+        if not bitmaps:
+            self.log_to_console("No Bitmaptexture instances found in scene")
+            return
+
+        assert self.map_path is not None  # Guaranteed by caller
+        mapped_count: int = 0
+        for tex in bitmaps:
+            # Note: Bitmaptexture exposes its path as `.filename` (lowercase 'n'),
+            # whereas VRayProxy uses `.fileName` (capital 'N'). These spellings are
+            # defined by 3ds Max / MAXScript per class and are not interchangeable.
+            try:
+                raw_filename = tex.filename
+                # An unassigned .filename comes back as rt.undefined, which is truthy;
+                # str() on it yields the literal "undefined". Skip those explicitly so
+                # we don't make a bogus map_path call or log a misleading path.
+                if raw_filename is None or raw_filename is rt.undefined:
+                    continue
+                original_path: str = str(raw_filename)
+            except Exception as e:
+                self.log_to_console(
+                    f"Warning: could not read filename for a Bitmaptexture instance: {e}"
+                )
+                continue
+
+            if not original_path:
+                continue
+
+            self.log_to_console(f"Requesting Path Mapping for path '{original_path}'.")
+            mapped_path: str = self.map_path(original_path)
+            self.log_to_console(f"Mapped path '{original_path}' to '{mapped_path}'.")
+            if mapped_path != original_path:
+                try:
+                    tex.filename = mapped_path
+                    mapped_count += 1
+                    self.log_to_console(f"Remapped Bitmaptexture: {original_path} -> {mapped_path}")
+                except Exception as e:
+                    self.log_to_console(
+                        f"Warning: Failed to remap bitmap texture '{original_path}': {e}"
+                    )
+
+        self.log_to_console(f"Bitmap path mapping complete: {mapped_count} textures remapped")
 
     def _configure_renderer_output(
         self, output_name: str, output_dir: str, output_format: str

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_path_mapping.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_path_mapping.py
@@ -280,6 +280,310 @@ class TestVrayProxyPathMapping:
         assert "0 proxies remapped" in captured.out
 
 
+@patch(
+    "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.get_max_version_year",
+    new=lambda: 2025,
+)
+class TestVrayBitmapPathMapping:
+    """Tests for VrayHandler bitmap texture path mapping."""
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_textures_are_remapped(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test that Bitmaptexture filenames are path-mapped and logged."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+        mock_rt.objects = []
+        mock_rt.VRayProxy = MagicMock()
+        mock_rt.classOf.return_value = None
+
+        mock_tex1 = MagicMock()
+        mock_tex1.filename = "C:/Users/artist/textures/wood.jpg"
+        mock_tex2 = MagicMock()
+        mock_tex2.filename = "C:/Users/artist/textures/metal.png"
+        mock_rt.getClassInstances.return_value = [mock_tex1, mock_tex2]
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = lambda p: p.replace("C:/Users/artist", "C:/Sessions/assetroot")
+
+        handler._apply_bitmap_path_mapping()
+
+        assert mock_tex1.filename == "C:/Sessions/assetroot/textures/wood.jpg"
+        assert mock_tex2.filename == "C:/Sessions/assetroot/textures/metal.png"
+
+        captured = capsys.readouterr()
+        assert "Remapped Bitmaptexture" in captured.out
+        assert "2 textures remapped" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_unchanged_path_not_reassigned(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test that bitmaps whose path doesn't change aren't written back."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+        mock_rt.objects = []
+        mock_rt.VRayProxy = MagicMock()
+        mock_rt.classOf.return_value = None
+
+        mock_tex = MagicMock()
+        mock_tex.filename = "C:/already/mapped/texture.jpg"
+        mock_rt.getClassInstances.return_value = [mock_tex]
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = lambda p: p  # identity — no change
+
+        handler._apply_bitmap_path_mapping()
+
+        # Path unchanged, so filename should still be the original value
+        assert mock_tex.filename == "C:/already/mapped/texture.jpg"
+        captured = capsys.readouterr()
+        assert "0 textures remapped" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_empty_filename_skipped(self, mock_rt: MagicMock) -> None:
+        """Test that bitmaps with empty filenames are skipped gracefully."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+        mock_rt.objects = []
+        mock_rt.VRayProxy = MagicMock()
+        mock_rt.classOf.return_value = None
+
+        mock_tex = MagicMock()
+        mock_tex.filename = ""
+        mock_rt.getClassInstances.return_value = [mock_tex]
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="/should/not/be/called")
+
+        handler._apply_bitmap_path_mapping()
+
+        handler.map_path.assert_not_called()
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_no_instances_graceful(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test graceful handling when no Bitmaptexture instances exist."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+        mock_rt.objects = []
+        mock_rt.VRayProxy = MagicMock()
+        mock_rt.classOf.return_value = None
+        mock_rt.getClassInstances.return_value = []
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock()
+
+        handler._apply_bitmap_path_mapping()
+
+        handler.map_path.assert_not_called()
+        captured = capsys.readouterr()
+        assert "No Bitmaptexture instances found" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_remap_failure_logs_warning(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test that a failure while writing back the mapped path is logged and non-fatal."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        class FakeBitmap:
+            """Bitmap whose filename reads fine but raises on assignment."""
+
+            @property
+            def filename(self):
+                return "C:/Users/artist/textures/wood.jpg"
+
+            @filename.setter
+            def filename(self, value):
+                raise Exception("Access denied")
+
+        mock_rt.getClassInstances.return_value = [FakeBitmap()]
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="C:/Sessions/assetroot/textures/wood.jpg")
+
+        # Should not raise
+        handler._apply_bitmap_path_mapping()
+
+        captured = capsys.readouterr()
+        assert "Warning: Failed to remap bitmap texture" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_enumeration_failure_logs_warning(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test that a failure enumerating Bitmaptexture instances is logged and non-fatal."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+        mock_rt.getClassInstances.side_effect = Exception("runtime error")
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock()
+
+        # Should not raise
+        handler._apply_bitmap_path_mapping()
+
+        handler.map_path.assert_not_called()
+        captured = capsys.readouterr()
+        assert "could not enumerate Bitmaptexture instances" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_read_failure_logs_and_skips_node(
+        self, mock_rt: MagicMock, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Test that a node which raises when reading its filename is logged and skipped."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+        mock_rt.undefined = object()  # distinct sentinel, not equal to any real filename
+
+        class ReadRaisesBitmap:
+            """Bitmap that raises when its filename is read."""
+
+            @property
+            def filename(self):
+                raise Exception("cannot read filename")
+
+        good_tex = MagicMock()
+        good_tex.filename = "C:/Users/artist/textures/wood.jpg"
+        # A bad node followed by a good one: the good one must still be remapped.
+        mock_rt.getClassInstances.return_value = [ReadRaisesBitmap(), good_tex]
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = lambda p: p.replace("C:/Users/artist", "C:/Sessions/assetroot")
+
+        # Should not raise despite the first node failing to read
+        handler._apply_bitmap_path_mapping()
+
+        assert good_tex.filename == "C:/Sessions/assetroot/textures/wood.jpg"
+        captured = capsys.readouterr()
+        assert "could not read filename for a Bitmaptexture instance" in captured.out
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_undefined_filename_skipped(self, mock_rt: MagicMock) -> None:
+        """Test that a Bitmaptexture with an unassigned (rt.undefined) filename is skipped
+        without calling map_path (avoids the bogus 'undefined' path)."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+        sentinel_undefined = object()
+        mock_rt.undefined = sentinel_undefined
+
+        mock_tex = MagicMock()
+        mock_tex.filename = sentinel_undefined  # unassigned filename
+        mock_rt.getClassInstances.return_value = [mock_tex]
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = MagicMock(return_value="/should/not/be/called")
+
+        handler._apply_bitmap_path_mapping()
+
+        handler.map_path.assert_not_called()
+
+    @patch.dict(
+        "os.environ",
+        {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        },
+    )
+    @patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt")
+    def test_bitmap_mixed_only_changed_remapped(self, mock_rt: MagicMock) -> None:
+        """Test that only textures whose path changes are written back."""
+        mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+        mock_changed = MagicMock()
+        mock_changed.filename = "C:/Users/artist/textures/wood.jpg"
+        mock_unchanged = MagicMock()
+        mock_unchanged.filename = "C:/shared/local/metal.png"
+        mock_rt.getClassInstances.return_value = [mock_changed, mock_unchanged]
+
+        from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import VrayHandler
+
+        handler = VrayHandler(gpu=False)
+        handler.map_path = lambda p: p.replace("C:/Users/artist", "C:/Sessions/assetroot")
+
+        handler._apply_bitmap_path_mapping()
+
+        assert mock_changed.filename == "C:/Sessions/assetroot/textures/wood.jpg"
+        assert mock_unchanged.filename == "C:/shared/local/metal.png"
+
+
 class TestDefaultMaxHandlerPathMapping:
     """Tests for DefaultMaxHandler path mapping base functionality."""
 


### PR DESCRIPTION
## What was the problem?
The V-Ray render handler only remapped VRayProxy `.vrmesh` file paths during path mapping. Standard bitmap texture nodes were never remapped, so textures uploaded via job attachments kept pointing at the artist's local filesystem path. On the worker those paths don't exist, and V-Ray silently renders without the textures instead of erroring. This affected Chaos Cosmos assets (and any material using standard bitmaps).

## What was the solution?
Added `_apply_bitmap_path_mapping()` to `VrayHandler`, called from `_apply_path_mapping()` after the existing proxy mapping. It enumerates every `Bitmaptexture` instance via `rt.getClassInstances()` and runs each `filename` through `map_path`, writing back only when the path changes. Enumeration and per-node writes are wrapped defensively so a single bad node cannot abort the pass.

## What is the impact of this change?
Bitmap textures now resolve correctly on the worker for 3dsmaxbatch V-Ray renders. Validated on a Chaos Cosmos scene: 28 textures remapped, render completed with a correctly textured output and no missing-texture warnings.

## How was this change tested?
- Added unit tests covering all branches of the new method (happy path, no-op, empty filename, no instances, read failure, write-back failure, mixed batch, and the logged summary).
- `hatch run fmt` / `hatch run lint` clean; full unit suite passes.
- End-to-end farm render on a Service-Managed Fleet.

## Was this change documented?
Method docstring updated.

## Is this a breaking change?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.